### PR TITLE
cleaning up remaining csp, solarpilot, and tcs warnings

### DIFF
--- a/build_vc2013/solarpilot_vc2013.vcxproj
+++ b/build_vc2013/solarpilot_vc2013.vcxproj
@@ -31,7 +31,6 @@
     <ClCompile Include="..\solarpilot\interop.cpp" />
     <ClCompile Include="..\solarpilot\IOUtil.cpp" />
     <ClCompile Include="..\solarpilot\Land.cpp" />
-    <ClCompile Include="..\solarpilot\LayoutSimulateThread.cpp" />
     <ClCompile Include="..\solarpilot\mod_base.cpp" />
     <ClCompile Include="..\solarpilot\OpticalMesh.cpp" />
     <ClCompile Include="..\solarpilot\optimize.cpp" />
@@ -41,7 +40,6 @@
     <ClCompile Include="..\solarpilot\solpos.cpp" />
     <ClCompile Include="..\solarpilot\STObject.cpp" />
     <ClCompile Include="..\solarpilot\string_util.cpp" />
-    <ClCompile Include="..\solarpilot\STSimulateThread.cpp" />
     <ClCompile Include="..\solarpilot\Toolbox.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -58,7 +56,6 @@
     <ClInclude Include="..\solarpilot\interop.h" />
     <ClInclude Include="..\solarpilot\IOUtil.h" />
     <ClInclude Include="..\solarpilot\Land.h" />
-    <ClInclude Include="..\solarpilot\LayoutSimulateThread.h" />
     <ClInclude Include="..\solarpilot\mod_base.h" />
     <ClInclude Include="..\solarpilot\OpticalMesh.h" />
     <ClInclude Include="..\solarpilot\optimize.h" />
@@ -73,7 +70,6 @@
     <ClInclude Include="..\solarpilot\sort_method.h" />
     <ClInclude Include="..\solarpilot\STObject.h" />
     <ClInclude Include="..\solarpilot\string_util.h" />
-    <ClInclude Include="..\solarpilot\STSimulateThread.h" />
     <ClInclude Include="..\solarpilot\Toolbox.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/lpsolve/lp_lib.h
+++ b/lpsolve/lp_lib.h
@@ -913,7 +913,7 @@ typedef int (__WINAPI get_solutioncount_func)(lprec *lp);
 typedef int (__WINAPI get_solutionlimit_func)(lprec *lp);
 typedef int (__WINAPI get_status_func)(lprec *lp);
 typedef char * (__WINAPI get_statustext_func)(lprec *lp, int statuscode);
-typedef long (__WINAPI get_timeout_func)(lprec *lp);
+typedef double (__WINAPI get_timeout_func)(lprec *lp);      //mjw/nrel - changed long->double
 typedef COUNTER (__WINAPI get_total_iter_func)(lprec *lp);
 typedef COUNTER (__WINAPI get_total_nodes_func)(lprec *lp);
 typedef REAL (__WINAPI get_upbo_func)(lprec *lp, int colnr);

--- a/nlopt/sobolseq.c
+++ b/nlopt/sobolseq.c
@@ -46,6 +46,11 @@
    the critical numbers).  Please cite them.  Just that I needed
    a free/open-source implementation. */
 
+//disable unary operator warning - mjw/nrel
+#ifdef _MSC_VER
+#pragma warning(disable : 4146 )
+#endif
+
 #include <stdlib.h>
 #include <math.h>
 

--- a/solarpilot/AutoPilot_API.cpp
+++ b/solarpilot/AutoPilot_API.cpp
@@ -495,6 +495,7 @@ AutoPilot::AutoPilot()
 	_detail_callback_data = 0;
 	_summary_siminfo = 0;
 	_detail_siminfo = 0;
+    _opt = new sp_optimize();
 }
 
 AutoPilot::~AutoPilot()
@@ -515,6 +516,10 @@ AutoPilot::~AutoPilot()
 		}
 		catch(...){}
 	}
+
+    if( _opt != 0 )
+        delete _opt;
+
 	return;
 }
 
@@ -1526,7 +1531,7 @@ bool AutoPilot::OptimizeRSGS(vector<double*> &optvars, vector<double> &upper_ran
         }
         dimsimpt.push_back(tmp);
     }
-	_opt.setOptimizationSimulationHistory(dimsimpt, objective, max_flux);
+	_opt->setOptimizationSimulationHistory(dimsimpt, objective, max_flux);
 
 	return true;
 
@@ -1659,7 +1664,7 @@ bool AutoPilot::OptimizeAuto(vector<double*> &optvars, vector<double> &upper_ran
         }
         dimsimpt.push_back(tmp);
     }
-    _opt.setOptimizationSimulationHistory( dimsimpt, AO.m_objective, AO.m_flux );
+    _opt->setOptimizationSimulationHistory( dimsimpt, AO.m_objective, AO.m_flux );
 
     V->opt.flux_penalty.val = flux_penalty_save; //reset
     return true;
@@ -1942,7 +1947,7 @@ bool AutoPilot::OptimizeSemiAuto(vector<double*> &optvars, vector<double> &upper
             }
             dimsimpt.push_back(tmp);
         }
-        _opt.setOptimizationSimulationHistory( dimsimpt, AO.m_objective, AO.m_flux );
+        _opt->setOptimizationSimulationHistory( dimsimpt, AO.m_objective, AO.m_flux );
     }
     //reset
     V->opt.max_iter.val = tot_max_iter;   
@@ -1959,7 +1964,7 @@ bool AutoPilot::IsSimulationCancelled()
 
 sp_optimize *AutoPilot::GetOptimizationObject()
 {
-    return &_opt;
+    return _opt;
 }
 
 void AutoPilot::PostEvaluationUpdate(int iter, vector<double> &pos, /*vector<double> &normalizers, */double &obj, double &flux, double &cost, std::string *note)

--- a/solarpilot/AutoPilot_API.h
+++ b/solarpilot/AutoPilot_API.h
@@ -94,7 +94,7 @@ protected:
 		_setup_ok,	//The variable structure has been created
 		_simflag;	//add bool flags here to indicate simulation/setup status
 
-    sp_optimize _opt;
+    sp_optimize *_opt;
 
 	vector<double> interpolate_vectors( vector<double> &A, vector<double> &B, double alpha);
 

--- a/solarpilot/sort_method.h
+++ b/solarpilot/sort_method.h
@@ -243,7 +243,7 @@ void quicksort( vector<Comparable> & a, int left, int right )
 template <typename Comparable, typename Tag>
 void quicksort( vector<Comparable> & a, vector<Tag> & b)
 {
-    quicksort( a, b, 0, a.size( ) - 1 );
+    quicksort( a, b, 0, (int)a.size( ) - 1 );
 }
 
 /*------------------ Quicksort for one vector -------------------- */

--- a/tcs/csp_dispatch.cpp
+++ b/tcs/csp_dispatch.cpp
@@ -346,7 +346,7 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
             double fhfi = 0.;
             double fhfi_2 = 0.;
             vector<double> fiv;
-            int m = optinst->params.eff_table_load.get_size();
+            int m = (int)optinst->params.eff_table_load.get_size();
             for(int i=0; i<m; i++)
             {
                 if( i==0 ) continue; // first data point is zero, so skip

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -4794,7 +4794,7 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 		mc_reported_outputs.value(C_solver_outputs::HOUR_DAY, (int)(m_report_time_end/3600) % 24);	//[hr]
 
 
-		int n_sub_ts = mv_time_local.size();
+		int n_sub_ts = (int)mv_time_local.size();
 		mc_reported_outputs.overwrite_vector_to_constant(C_solver_outputs::N_OP_MODES, n_sub_ts);	//[-]
 		if( n_sub_ts == 1 )
 		{
@@ -4822,7 +4822,7 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 		}
 		
 
-		mc_reported_outputs.value(C_solver_outputs::TOU_PERIOD, tou_period);        //[-]       
+		mc_reported_outputs.value(C_solver_outputs::TOU_PERIOD, (double)tou_period);        //[-]       
 		mc_reported_outputs.value(C_solver_outputs::PRICING_MULT, pricing_mult);	//[-] 
 		mc_reported_outputs.value(C_solver_outputs::PC_Q_DOT_SB, q_pc_sb);          //[MW]     
 		mc_reported_outputs.value(C_solver_outputs::PC_Q_DOT_MIN, q_pc_min);        //[MW]    
@@ -4899,7 +4899,7 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 
 		// Report series of operating modes attempted during the timestep as a 'double' using 0s to separate the enumerations 
 		// ... (10 is set as a dummy enumeration so it won't show up as a potential operating mode)
-		int n_op_modes = m_op_mode_tracking.size();
+		int n_op_modes = (int)m_op_mode_tracking.size();
 		double op_mode_key = 0.0;
 		for( int i = 0; i < fmin(3,n_op_modes); i++ )
 		{
@@ -4975,7 +4975,7 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 				bool delete_last_step = false;
 				int pop_back_start = 1;
 
-				int n_time_local = mv_time_local.size();
+				int n_time_local = (int)mv_time_local.size();
 				if( mv_time_local[n_time_local - 1] == m_report_time_end )
 				{
 					delete_last_step = true;
@@ -4996,7 +4996,7 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 					}
 				}
 
-				int n_time_local_refresh = mv_time_local.size();
+				int n_time_local_refresh = (int)mv_time_local.size();
 				if(n_time_local_refresh > 0)
 				{
 					mc_reported_outputs.value(C_solver_outputs::N_OP_MODES, 1);	//[-]

--- a/tcs/csp_solver_gen_collector_receiver.cpp
+++ b/tcs/csp_solver_gen_collector_receiver.cpp
@@ -234,8 +234,8 @@ void C_csp_gen_collector_receiver::init(const C_csp_collector_receiver::S_csp_cr
 			}
 		}
 
-		mc_optical_table.AddXAxis(xax, ms_params.m_optical_table.ncols() - 1);
-		mc_optical_table.AddYAxis(yax, ms_params.m_optical_table.nrows() - 1);
+		mc_optical_table.AddXAxis(xax, (int)ms_params.m_optical_table.ncols() - 1);
+		mc_optical_table.AddYAxis(yax, (int)ms_params.m_optical_table.nrows() - 1);
 		mc_optical_table.AddData(data);
 		delete[] xax, yax, data;	
 	}
@@ -261,7 +261,7 @@ void C_csp_gen_collector_receiver::init(const C_csp_collector_receiver::S_csp_cr
 		MatDoub sunpos;
 		vector<double> effs;
 
-		int nrows = ms_params.m_optical_table.nrows();
+		int nrows = (int)ms_params.m_optical_table.nrows();
 
 		//read the data from the array into the local storage arrays
 		sunpos.resize(nrows, VectDoub(2));

--- a/tcs/csp_solver_lf_dsg_collector_receiver.cpp
+++ b/tcs/csp_solver_lf_dsg_collector_receiver.cpp
@@ -321,8 +321,8 @@ void C_csp_lf_dsg_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	m_EPSILON_5 = m_EPSILON_4;	
 
 	//m_AbsorberMaterial
-	int n_rows_abs = m_AbsorberMaterial_in.nrows();
-	int n_cols_abs = m_AbsorberMaterial_in.ncols();
+	int n_rows_abs = (int)m_AbsorberMaterial_in.nrows();
+	int n_cols_abs = (int)m_AbsorberMaterial_in.ncols();
 
 	int n_rows_matrix_lk_in = 2;
 	if( !(n_rows_abs == n_rows_matrix_lk_in && n_cols_abs == 1) )
@@ -345,8 +345,8 @@ void C_csp_lf_dsg_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	}
 
 	//m_AnnulusGas [-] Annulus gas type (1 = air; 26 = Ar; 27 = H2 )
-	n_rows_abs = m_AnnulusGas_in.nrows();
-	n_cols_abs = m_AnnulusGas_in.ncols();
+	n_rows_abs = (int)m_AnnulusGas_in.nrows();
+	n_cols_abs = (int)m_AnnulusGas_in.ncols();
 	if( !(n_rows_abs == n_rows_matrix_lk_in && n_cols_abs == 4) )
 	{
 		std::string err_msg = util::format("HCE annulus gas type matrix should have %d rows (b,SH) and 4 columns (HCE options) - the input matrix has %d rows and %d columns", 
@@ -406,8 +406,8 @@ void C_csp_lf_dsg_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	}
 
 	//[-] Boiler Optical Table
-	n_rows_abs = m_b_OpticalTable.nrows();
-	n_cols_abs = m_b_OpticalTable.ncols();
+	n_rows_abs = (int)m_b_OpticalTable.nrows();
+	n_cols_abs = (int)m_b_OpticalTable.ncols();
 
 	// Set up the optical table object..
 
@@ -450,8 +450,8 @@ void C_csp_lf_dsg_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	//0608
 	if (m_is_multgeom)
 	{
-		int n_rows = m_sh_OpticalTable.nrows();
-		int n_cols = m_sh_OpticalTable.ncols();
+		int n_rows = (int)m_sh_OpticalTable.nrows();
+		int n_cols = (int)m_sh_OpticalTable.ncols();
 
 		// Set up the optical table object..
 

--- a/tcs/csp_solver_mspt_receiver_222.cpp
+++ b/tcs/csp_solver_mspt_receiver_222.cpp
@@ -147,8 +147,8 @@ void C_mspt_receiver_222::init()
 	else if( m_field_fl == HTFProperties::User_defined )
 	{
 		// Check that 'm_field_fl_props' is allocated and correct dimensions
-		int n_rows = m_field_fl_props.nrows();
-		int n_cols = m_field_fl_props.ncols();
+		int n_rows = (int)m_field_fl_props.nrows();
+		int n_cols = (int)m_field_fl_props.ncols();
 		if( n_rows > 2 && n_cols == 7 )
 		{
 			if( !field_htfProps.SetUserDefinedFluid(m_field_fl_props) )
@@ -350,14 +350,14 @@ void C_mspt_receiver_222::call(const C_csp_weatherreader::S_outputs &weather,
 	double I_bn = weather.m_beam;
 
 
-	int n_flux_y = flux_map_input->nrows();
+	int n_flux_y = (int)flux_map_input->nrows();
 	if(n_flux_y > 1)
 	{
 		error_msg = util::format("The Molten Salt External Receiver (Type222) model does not currently support 2-dimensional "
 			"flux maps. The flux profile in the vertical dimension will be averaged. NY=%d", n_flux_y);
 		csp_messages.add_message(C_csp_messages::WARNING, error_msg);
 	}
-	int n_flux_x = flux_map_input->ncols();
+	int n_flux_x = (int)flux_map_input->ncols();
 	m_flux_in.resize(n_flux_x);
 
 	double T_sky = CSP::skytemp(T_amb, T_dp, hour);

--- a/tcs/csp_solver_pc_Rankine_indirect_224.cpp
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.cpp
@@ -99,8 +99,8 @@ void C_pc_Rankine_indirect_224::init(C_csp_power_cycle::S_solved_params &solved_
 	else if( ms_params.m_pc_fl == HTFProperties::User_defined )
 	{
 		// Check that 'm_field_fl_props' is allocated and correct dimensions
-		int n_rows = ms_params.m_pc_fl_props.nrows();
-		int n_cols = ms_params.m_pc_fl_props.ncols();
+		int n_rows = (int)ms_params.m_pc_fl_props.nrows();
+		int n_cols = (int)ms_params.m_pc_fl_props.ncols();
 		if( n_rows > 2 && n_cols == 7 )
 		{
 			if( !mc_pc_htfProps.SetUserDefinedFluid(ms_params.m_pc_fl_props) )
@@ -1364,7 +1364,7 @@ double C_pc_Rankine_indirect_224::Interpolate(int YT, int XT, double X)
 
 	//Use brute force interpolation.. it is faster in this case than bisection or hunting methods used in the user-specified HTF case
 
-	int iLastIndex = m_db.ncols() - 1;
+	int iLastIndex = (int)m_db.ncols() - 1;
 	for( size_t i = 0; i < m_db.ncols(); i++ )
 	{
 		// if we got to the last one, then set bounds and end loop
@@ -1405,8 +1405,8 @@ double C_pc_Rankine_indirect_224::Interpolate(int YT, int XT, double X)
 		// so the reference [i+1], where i = iLastIndex, will never happen
 		if( ((X >= m_db.at(XI, i)) && (X < m_db.at(XI, i + 1))) || ((X <= m_db.at(XI, i)) && (X > m_db.at(XI, i + 1))) )
 		{
-			lbi = i;
-			ubi = i + 1;
+			lbi = (int)i;
+			ubi = (int)i + 1;
 			break;
 		}
 	}

--- a/tcs/csp_solver_pc_heat_sink.cpp
+++ b/tcs/csp_solver_pc_heat_sink.cpp
@@ -107,8 +107,8 @@ void C_pc_heat_sink::init(C_csp_power_cycle::S_solved_params &solved_params)
 	else if( ms_params.m_pc_fl == HTFProperties::User_defined )
 	{
 		// Check that 'm_field_fl_props' is allocated and correct dimensions
-		int n_rows = ms_params.m_pc_fl_props.nrows();
-		int n_cols = ms_params.m_pc_fl_props.ncols();
+		int n_rows = (int)ms_params.m_pc_fl_props.nrows();
+		int n_cols = (int)ms_params.m_pc_fl_props.ncols();
 		if( n_rows > 2 && n_cols == 7 )
 		{
 			if( !mc_pc_htfProps.SetUserDefinedFluid(ms_params.m_pc_fl_props) )

--- a/tcs/csp_solver_pc_sco2.cpp
+++ b/tcs/csp_solver_pc_sco2.cpp
@@ -103,8 +103,8 @@ void C_pc_sco2::init(C_csp_power_cycle::S_solved_params &solved_params)
 	else if( ms_params.ms_mc_sco2_recomp_params.m_hot_fl_code == HTFProperties::User_defined )
 	{
 		// Check that 'm_field_fl_props' is allocated and correct dimensions
-		int n_rows = ms_params.ms_mc_sco2_recomp_params.mc_hot_fl_props.nrows();
-		int n_cols = ms_params.ms_mc_sco2_recomp_params.mc_hot_fl_props.ncols();
+		int n_rows = (int)ms_params.ms_mc_sco2_recomp_params.mc_hot_fl_props.nrows();
+		int n_cols = (int)ms_params.ms_mc_sco2_recomp_params.mc_hot_fl_props.ncols();
 		if( n_rows > 2 && n_cols == 7 )
 		{
 			if( !mc_pc_htfProps.SetUserDefinedFluid(ms_params.ms_mc_sco2_recomp_params.mc_hot_fl_props) )

--- a/tcs/csp_solver_trough_collector_receiver.cpp
+++ b/tcs/csp_solver_trough_collector_receiver.cpp
@@ -275,8 +275,8 @@ void C_csp_trough_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	}
 	else if (m_Fluid == HTFProperties::User_defined)
 	{
-		int n_rows = m_field_fl_props.nrows();
-		int n_cols = m_field_fl_props.ncols();
+		int n_rows = (int)m_field_fl_props.nrows();
+		int n_cols = (int)m_field_fl_props.ncols();
 		if (n_rows > 2 && n_cols == 7)
 		{
 			if (!m_htfProps.SetUserDefinedFluid(m_field_fl_props))
@@ -301,8 +301,8 @@ void C_csp_trough_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	m_ColAz = m_ColAz*m_d2r;		//[rad] Collector azimuth angle, convert from [deg]
 
 	// Check m_IAM matrix against number of collectors: m_nColt
-	m_n_r_iam_matrix = m_IAM_matrix.nrows();
-	m_n_c_iam_matrix = m_IAM_matrix.ncols();
+	m_n_r_iam_matrix = (int)m_IAM_matrix.nrows();
+	m_n_c_iam_matrix = (int)m_IAM_matrix.ncols();
 
 	if (m_n_c_iam_matrix < 3)
 	{

--- a/tcs/tcskernel.cpp
+++ b/tcs/tcskernel.cpp
@@ -171,7 +171,7 @@ int tcstypeprovider::load_library( const std::string &name )
 			std::ostringstream ss;
 			ss << "loaded " << idx << " dynamic type(s) from " << path;
 			m_messages.push_back( ss.str() );
-			return idx;
+			return (int)idx;
 		}
 
 		if (pdl) dll_close( pdl );
@@ -281,7 +281,7 @@ static bool tcsvalue_parse_array( tcsvalue *v, const char *s )
 	tcsvalue_free( v );		
 	v->type = TCS_ARRAY;
 	v->data.array.values = new double[ vals.size() ];
-	v->data.array.length = vals.size();
+	v->data.array.length = (unsigned int)vals.size();
 	for (int i=0;i<(int)vals.size();i++)
 		v->data.array.values[i] = vals[i];	
 
@@ -317,13 +317,13 @@ static bool tcsvalue_parse_matrix( tcsvalue *v, const char *s )
 	
 	if ( mat.size() == 0 || maxcol == 0 ) return false;
 	
-	int len = mat.size() * maxcol;
+	int len = (int)(mat.size() * maxcol);
 
 	tcsvalue_free( v );
 	v->type = TCS_MATRIX;
 	v->data.matrix.values = new double[ len ];
-	v->data.matrix.nrows = mat.size();
-	v->data.matrix.ncols = maxcol;
+	v->data.matrix.nrows = (int)mat.size();
+	v->data.matrix.ncols = (int)maxcol;
 	
 	for (int i=0;i<len;i++) v->data.matrix.values[i] = 0;
 	
@@ -733,7 +733,7 @@ int tcskernel::copy( tcskernel &tk )
 			std::vector<connection> &cc = u.conn[j];
 			for ( size_t k=0;k<cc.size();k++)
 			{
-				connect( id, j, cc[k].target_unit, cc[k].target_index, 
+				connect( (int)id, (int)j, cc[k].target_unit, cc[k].target_index, 
 					cc[k].ftol, cc[k].arridx );
 			}
 		}
@@ -756,7 +756,7 @@ int tcskernel::add_unit( const std::string &type, const std::string &name )
 	
 	// push an empty unit, obtain a reference to it
 	m_units.push_back( unit() );
-	int id = m_units.size() - 1;
+	int id = (int)m_units.size() - 1;
 	unit &u = m_units[ id ];
 	u.id = id;
 	u.name = name;
@@ -964,7 +964,7 @@ int tcskernel::solve( double time, double step )
 			}*/
 
 			if ( m_units[i].type->invoke( &m_units[i].context, m_units[i].instance, TCS_INVOKE,
-					&m_units[i].values[0], m_units[i].values.size(),
+					&m_units[i].values[0], (unsigned int)m_units[i].values.size(),
 					time, step, m_units[i].ncall ) < 0 )
 			{
 				message( TCS_ERROR,"unit %d (%s) type '%s' failed at time %.2lf", i, m_units[i].name.c_str(),
@@ -1108,7 +1108,7 @@ int tcskernel::simulate( double start, double end, double step )
 	for (size_t i=0;i<m_units.size();i++)
 	{
 		if( m_units[i].type->invoke( &m_units[i].context, m_units[i].instance, TCS_INIT,
-				&m_units[i].values[0], m_units[i].values.size(),
+				&m_units[i].values[0], (unsigned int)m_units[i].values.size(),
 				-1, step, -1 )  < 0 )
 		{
 			message( TCS_ERROR, "unit %d (%s) type '%s' failed at initialization", i, 
@@ -1140,7 +1140,7 @@ int tcskernel::simulate( double start, double end, double step )
 			if ( m_units[i].type->call_after_convergence > 0 )
 			{
 				if ( m_units[i].type->invoke( &m_units[i].context, m_units[i].instance, TCS_CONVERGED,
-					&m_units[i].values[0], m_units[i].values.size(),
+					&m_units[i].values[0], (unsigned int)m_units[i].values.size(),
 					m_currentTime, m_timeStep, -2 ) < 0 )
 				{
 					free_instances();

--- a/tcs/tou_translator_csp_solver.cpp
+++ b/tcs/tou_translator_csp_solver.cpp
@@ -186,7 +186,7 @@ public:
 				message(TCS_WARNING, out_msg.c_str());
 		}
 
-		value(O_TOU_VALUE, ms_outputs.m_csp_op_tou);
+		value(O_TOU_VALUE, (double)ms_outputs.m_csp_op_tou);
 
 		return 0;
 	}


### PR DESCRIPTION
This cleans up all compiler warnings in SSC when building on win32 and x64. I tested the MSPT model and get the same results for the default case.