### PR TITLE
Fix a bug flagged by the warning: left operand of comma operator has no effect

### DIFF
--- a/solarpilot/Heliostat.cpp
+++ b/solarpilot/Heliostat.cpp
@@ -745,15 +745,14 @@ Reflector *Heliostat::getPanelById(int id){
 
 	for (int j=0; j<(int)ncantx; j++) {
 		for (int i=0; i<(int)ncanty; i++) {
-			if (_panels[j,i].getId() == id){
-				return &_panels[j,i];
+		  	if (_panels.at(j,i).getId() == id) {
+			  	return &_panels.at(j,i);
 			}
 		}
 	}
 
 	//#####call an error here
-
-	return &_panels[0,0];
+	return &_panels.at(0, 0);
 }
 
 Reflector *Heliostat::getPanel(int row, int col){
@@ -761,7 +760,7 @@ Reflector *Heliostat::getPanel(int row, int col){
 	nr = _panels.nrows();
 	nc = _panels.ncols();
 	if(row < nr && col < nc) {
-		return &_panels[row,col];
+	  	return &_panels.at(row, col);
 	}
 	else{
 		//FLAG -- this should be an error


### PR DESCRIPTION
Fixes #35. 

* solarpilot/Heliostat.cpp (getPanelById): matrix_t::operator[] only
  takes a single int and returns the address of the row. Instead, use
  the public at() method to properly access matrix elements by row
  and column number.