### PR TITLE
Fixes warning: left  operand of comma operator has no effect [-Wunused-value].

### DIFF
--- a/tcs/direct_steam_receivers.cpp
+++ b/tcs/direct_steam_receivers.cpp
@@ -143,7 +143,7 @@ bool C_DSG_Boiler::Initialize_Boiler( C_DSG_macro_receiver dsg_rec, double h_rec
 			{
 				for( int j = 0; j < m_nodes; j++ )
 				{
-					flow_pattern[i, j] = flow_pattern_temp[i, (m_dsg_rec.Get_n_panels_rec() - m_n_panels)/2 + j];
+					flow_pattern.at(i, j) = flow_pattern_temp.at(i, (m_dsg_rec.Get_n_panels_rec() - m_n_panels)/2 + j);
 				}
 			}
 			m_h_rec.resize_fill(m_n_panels, h_rec_full*m_dsg_rec.Get_sh_h_frac());


### PR DESCRIPTION
Another potentially nasty bug. Use matrix_t at() method for element accesses. Fixes warning: left operand of comma operator has no effect [-Wunused-value].

This is the first in a series of patches to fix warnings in the tcs directory.