### PR TITLE
Several bug fixes to solarpilot

### DIFF
--- a/solarpilot/Ambient.cpp
+++ b/solarpilot/Ambient.cpp
@@ -117,9 +117,10 @@ Vect Ambient::calcSunVectorFromAzZen(double azimuth, double zenith) {
 	return sp;	
 }
 
-void Ambient::calcSunPosition(var_map &V, DTobj &DT, double *az, double *zen){
+void Ambient::calcSunPosition(var_map &V, DTobj &DT, double *az, double *zen, bool wf_time_correction)
+{
     //[degr] [degr]
-	calcSunPosition( V.amb.latitude.val, V.amb.longitude.val, V.amb.time_zone.val, V.amb.sim_time_step.Val(), DT, az, zen);
+	calcSunPosition( V.amb.latitude.val, V.amb.longitude.val, V.amb.time_zone.val, wf_time_correction ? V.amb.sim_time_step.Val() : 0., DT, az, zen);
 }
 
 void Ambient::calcSunPosition(double lat, double lon, double timezone, double tstep, const DTobj &dt, double *az, double *zen){

--- a/solarpilot/Ambient.h
+++ b/solarpilot/Ambient.h
@@ -83,7 +83,7 @@ class Ambient : public mod_base
 	
 	//Calculation methods
     static void setDateTime(DateTime &DT, double day_hour, double year_day, double year = 2011.);
-	static void calcSunPosition(var_map &V, DTobj &DT, double *az, double *zen); //use some local info, some other info
+	static void calcSunPosition(var_map &V, DTobj &DT, double *az, double *zen, bool wf_time_correction=false); //use some local info, some other info
 	static void calcSunPosition(double lat, double lon, double timezone, double tstep, const DTobj &dt, double *az, double *zen);	//Calculate with these arguments
     static Vect calcSunVectorFromAzZen(double azimuth, double zenith);	//Calculate sun position given specified az/zen values
 	

--- a/solarpilot/AutoPilot_API.cpp
+++ b/solarpilot/AutoPilot_API.cpp
@@ -597,10 +597,10 @@ bool AutoPilot::Setup(var_map &V, bool /*for_optimize*/)
 	//-----------------------------------------------------------------
 
     //need to set up the template combo
-    V.sf.temp_which.combo_clear();
-    std::string name = "Template 1", val = "0";
-    V.sf.temp_which.combo_add_choice(name, val);
-    V.sf.temp_which.combo_select_by_choice_index( 0 ); //use the first heliostat template
+    //V.sf.temp_which.combo_clear();
+    //std::string name = "Template 1", val = "0";
+    //V.sf.temp_which.combo_add_choice(name, val);
+    //V.sf.temp_which.combo_select_by_choice_index( 0 ); //use the first heliostat template
 
 	//Dynamically allocate the solar field object, if needed
 	if(! _is_solarfield_external ){

--- a/solarpilot/IOUtil.cpp
+++ b/solarpilot/IOUtil.cpp
@@ -409,7 +409,7 @@ void ioutil::parseXMLInputFile(const string &fname,var_map &V, parametric &par_d
             {
                 std::string selection = var_node->first_node("value")->value();
                 std::vector< std::string > cbchoices = v->second->combo_get_choices();
-                if( find( cbchoices.begin(), cbchoices.end(), selection ) != cbchoices.end() )
+                if(varname == "temp_which" || find( cbchoices.begin(), cbchoices.end(), selection ) != cbchoices.end() )
                     v->second->set_from_string( selection.c_str() );
             }
             else

--- a/solarpilot/LayoutSimulateThread.cpp
+++ b/solarpilot/LayoutSimulateThread.cpp
@@ -243,7 +243,7 @@ void LayoutSimThread::StartThread() //Entry()
                     P.TOUweight = tous->at(DT.GetHourOfYear());
 
 			    //latitude, longitude, and elevation should be set in the input file
-			    Ambient::calcSunPosition(*_SF->getVarMap(), DT, &az, &zen );
+			    Ambient::calcSunPosition(*_SF->getVarMap(), DT, &az, &zen, true );
 		        //If the sun is not above the horizon, don't continue
 		        if( zen > 90. )
 				        continue;

--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -1365,7 +1365,7 @@ bool SolarField::PrepareFieldLayout(SolarField &SF, WeatherData *wdata, bool ref
 					//Calculate the sun position
                     Ambient::setDateTime(dt, hour, doy);
 					//latitude, longitude, and elevation should be set in the input file
-					Ambient::calcSunPosition(*V, dt, &az, &zen); 
+					Ambient::calcSunPosition(*V, dt, &az, &zen, true); 
 					
 					//calculate DNI
 					double dniclr = Ambient::calcInsolation(*V, az*D2R, zen*D2R, doy);
@@ -1466,7 +1466,7 @@ bool SolarField::DoLayout( SolarField *SF, sim_results *results, WeatherData *wd
         //latitude, longitude, and elevation should be set in the input file
 	    double az;
         double zen;
-		Ambient::calcSunPosition(*SF->getVarMap(), DT, &az, &zen); 
+		Ambient::calcSunPosition(*SF->getVarMap(), DT, &az, &zen, true); 
 		//If the sun is not above the horizon, don't continue
 		if( zen > 90. )
 				continue;
@@ -1857,7 +1857,7 @@ void SolarField::AnnualEfficiencySimulation( string weather_file, SolarField *SF
 		Ambient::setDateTime(DT, hour, (double)doy);
 		//latitude, longitude, and elevation should be set in the input file
 		double az, zen;
-		Ambient::calcSunPosition(*V, DT, &az, &zen);
+		Ambient::calcSunPosition(*V, DT, &az, &zen); //no time correction because 'hour' is adjusted above
 
 		double dni = wdannual->DNI.at(i);
 				

--- a/solarpilot/definitions.cpp
+++ b/solarpilot/definitions.cpp
@@ -66,6 +66,23 @@ var_map::var_map( var_map &vc )
 
 void var_map::copy( var_map &vc )
 {
+    //to copy, we need to make sure the template structures for heliostats and receivers are 
+    //parallel between both varmaps first. Then copy by iterating over the list of strings in 
+    //the varmap and set the corresponding object values in each map.
+
+    //receiver templates
+    for( size_t i=0; i<recs.size(); i++ )
+        drop_receiver(i);
+    for( size_t i=0; i<vc.recs.size(); i++ )
+        add_receiver( vc.recs.at(i).id.val );
+
+    //heliostat templates
+    for( size_t i=0; i<hels.size(); i++ )
+        drop_heliostat(i);
+    for( size_t i=0; i<vc.hels.size(); i++ )
+        add_heliostat( vc.hels.at(i).id.val );
+
+    //now add by string->obj
     for( unordered_map< std::string, spbase* >::iterator var=_varptrs.begin(); var!=_varptrs.end(); var++ )
         var->second->set_from_string( vc._varptrs.at( var->first )->as_string().c_str() );
     


### PR DESCRIPTION
* Fixes sun position calculation during performance simulations to use instantaneous time rather than time averaged over upcoming hour. This bug primarily affects flux maps, and has no effect on the default SAM case annual performance.
* Fix for heliostat and receiver templates on file loading and during optimization
* Modifies copy constructor on var_map to handle multiple templates. It was previously ignoring all but the base template. Only affect solarpilot standalone and scripting cases with multiple templates using optimization. 