### PR TITLE
Fix compilation error on Linux (strcmp was not declared).

### DIFF
--- a/solarpilot/Toolbox.cpp
+++ b/solarpilot/Toolbox.cpp
@@ -1840,7 +1840,8 @@ double Toolbox::intersect_ellipse_rect(double rect[4], double ellipse[2]){
 }
 
 string Toolbox::getDelimiter(std::string &text){
-	if( strcmp(text.c_str(), "")==0 ) return ",";
+	if (text.empty())
+	  return ",";
 	//Find the type of delimiter
 	vector<string> delims;
 	delims.push_back(",");


### PR DESCRIPTION
* solarpilot/Toolbox.cpp (Toolbox::getDelimiter): Do not use strcmp. If we want to use the C++ standard library, then we should stop trying to escape to C. :-)