### PR TITLE
Using `my_isnan` macro for cross-platform support

### DIFF
--- a/shared/lib_weatherfile.cpp
+++ b/shared/lib_weatherfile.cpp
@@ -1436,7 +1436,7 @@ bool weatherfile::has_data_column( size_t id )
 }
 
 bool weatherfile::has_calculated_data(size_t id){
-	return !std::isnan(m_columns[id].data[0]);
+	return !my_isnan(m_columns[id].data[0]);
 }
 
 bool weatherfile::convert_to_wfcsv( const std::string &input, const std::string &output )


### PR DESCRIPTION
It looks like at some point the `my_isnan` macro was defined to better support MS Visual Studio toolchains, but was never actually integrated into the `isnan` call later in the code. Then, it looks like that same code was modified to support builds on Linux in 36cb9cc3d43e85ff456e913c973db49f2a04baee.

This PR simply replaces that call with the macro instead so as to include support for both MSVSC and Linux.