### PR TITLE
sdktool fixes

### DIFF
--- a/build_linux/Makefile-sdktool
+++ b/build_linux/Makefile-sdktool
@@ -7,7 +7,7 @@ LKLIB = $(LKDIR)/lkuxwx3.a
 
 CC = gcc
 CXX = g++
-WARNINGS=-Wall
+WARNINGS=-Wall -Wno-unknown-pragmas
 CFLAGS =  -g -O2 -I. -I$(WEXDIR)/include -I$(LKDIR)/include -I../ssc -I../shared -DLK_USE_WXWIDGETS `wx-config-3 --cflags` $(WARNINGS)
 LDFLAGS = -std=c++0x $(WEXLIB) $(LKLIB) `wx-config-3 --libs stc` `wx-config-3 --libs aui` `wx-config-3 --libs` -lm  -lfontconfig -ldl -lcurl 
 CXXFLAGS=-std=c++0x $(CFLAGS)

--- a/sdktool/dataview.cpp
+++ b/sdktool/dataview.cpp
@@ -289,10 +289,10 @@ END_EVENT_TABLE()
 
 DataView::DataView( wxWindow *parent ) 
 	: wxPanel( parent ),
-	m_vt(0),
-	m_root_item(0),
+  	m_frozen(false),
 	m_grid_table(0),
-	m_frozen(false)
+	m_root_item(0),
+	m_vt(0)
 {
 	wxBoxSizer *tb_sizer = new wxBoxSizer(wxHORIZONTAL);
 	tb_sizer->Add( new wxButton(this, ID_ADD_VARIABLE, "Add...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT), 0, wxALL|wxEXPAND, 2);


### PR DESCRIPTION
This couple of very straightforward changes clears all warnings in the sdktools directory.