### PR TITLE
* build_linux/Makefile-nlopt (CFLAGS): Remove -Wall.

### DIFF
--- a/build_linux/Makefile-nlopt
+++ b/build_linux/Makefile-nlopt
@@ -1,7 +1,8 @@
 VPATH = ../nlopt ../nlopt/direct ../nlopt/cdirect ../nlopt/praxis ../nlopt/luksan ../nlopt/crs
 CC = gcc
 CXX = g++
-CFLAGS = -fPIC -Wall -g -O3 -I../ -D__64BIT__ -I../nlopt/api -I../nlopt/util -I../nlopt
+WARNINGS = -Wno-deprecated-declarations
+CFLAGS = -fPIC -g $(WARNINGS) -O3 -I../ -D__64BIT__ -I../nlopt/api -I../nlopt/util -I../nlopt
 CXXFLAGS=-std=c++0x $(CFLAGS)
 
 OBJECTS = \


### PR DESCRIPTION
 nlopt is an external library, so there is not much point reporting warnings in this directory. Also disable -Wdeprecated-declarations.