### PR TITLE
Fix warning: array subscript is above array bounds.

### DIFF
--- a/tcs/sam_mw_type234.cpp
+++ b/tcs/sam_mw_type234.cpp
@@ -260,7 +260,10 @@ public:
 		m_pb_bd_frac = std::numeric_limits<double>::quiet_NaN();	
 		m_P_cond_min = std::numeric_limits<double>::quiet_NaN();	
 		m_n_pl_inc = -1;	
-		m_F_wc[9] = std::numeric_limits<double>::quiet_NaN();
+
+		for (unsigned i = 0; i < sizeof(m_F_wc) / sizeof(double); i++) {
+		    m_F_wc[i] = std::numeric_limits<double>::quiet_NaN();
+		}
 		
 		m_F_wcmin = std::numeric_limits<double>::quiet_NaN();
 		m_F_wcmax = std::numeric_limits<double>::quiet_NaN();


### PR DESCRIPTION
Properly initialise m_F_wc. Fixes issue #37 