### PR TITLE
Fix memory leaks

### DIFF
--- a/ssc/cmod_sp_ty.cpp
+++ b/ssc/cmod_sp_ty.cpp
@@ -796,7 +796,9 @@ class cm_sp_ty : public compute_module
 								optical_table.AddYAxis(yax, n_zenith + 1);
 								optical_table.AddData(data);
 
-								delete[] xax, yax, data;
+								delete [] xax;
+								delete [] yax;
+								delete [] data;
 
 								opt_eta_point = optical_table.interpolate(az_sp, solzen);
 							}
@@ -1061,7 +1063,9 @@ class cm_sp_ty : public compute_module
 			optical_table.AddYAxis(yax, n_zenith+1);
 			optical_table.AddData(data);
 
-			delete[] xax, yax, data;
+			delete [] xax;
+			delete [] yax;
+			delete [] data;
 
 			// Simulate each hour
 			weatherfile wf(as_string("solar_resource_file"));

--- a/tcs/csp_solver_gen_collector_receiver.cpp
+++ b/tcs/csp_solver_gen_collector_receiver.cpp
@@ -237,7 +237,9 @@ void C_csp_gen_collector_receiver::init(const C_csp_collector_receiver::S_csp_cr
 		mc_optical_table.AddXAxis(xax, (int)ms_params.m_optical_table.ncols() - 1);
 		mc_optical_table.AddYAxis(yax, (int)ms_params.m_optical_table.nrows() - 1);
 		mc_optical_table.AddData(data);
-		delete[] xax, yax, data;	
+		delete [] xax;
+		delete [] yax;
+		delete [] data;
 	}
 	else
 	{

--- a/tcs/csp_solver_lf_dsg_collector_receiver.cpp
+++ b/tcs/csp_solver_lf_dsg_collector_receiver.cpp
@@ -441,7 +441,9 @@ void C_csp_lf_dsg_collector_receiver::init(const C_csp_collector_receiver::S_csp
 	b_optical_table.AddXAxis(xax, n_cols_abs - 1);
 	b_optical_table.AddYAxis(yax, n_rows_abs - 1);
 	b_optical_table.AddData(data);
-	delete[] xax, yax, data;
+	delete [] xax;
+	delete [] yax;
+	delete [] data;
 	optical_tables.Set_Table(&b_optical_table, 0);
 
 	// *************************
@@ -483,7 +485,9 @@ void C_csp_lf_dsg_collector_receiver::init(const C_csp_collector_receiver::S_csp
 		sh_optical_table.AddXAxis(xax1, n_cols - 1);
 		sh_optical_table.AddYAxis(yax1, n_rows - 1);
 		sh_optical_table.AddData(data1);
-		delete[] xax1, yax1, data1;
+		delete [] xax1;
+		delete [] yax1;
+		delete []data1;
 		optical_tables.Set_Table(&sh_optical_table, 1);
 	}
 	//0608

--- a/tcs/sam_mw_gen_Type260.cpp
+++ b/tcs/sam_mw_gen_Type260.cpp
@@ -637,7 +637,9 @@ public:
 		    optical_table.AddXAxis(xax, ncol_OpticalTable-1);
 		    optical_table.AddYAxis(yax, nrow_OpticalTable-1);
 		    optical_table.AddData(data);
-		    delete [] xax, yax, data;
+		    delete [] xax;
+		    delete [] yax;
+		    delete [] data;
         }
         else
         {

--- a/tcs/sam_mw_lf_type261_steam.cpp
+++ b/tcs/sam_mw_lf_type261_steam.cpp
@@ -1363,7 +1363,9 @@ public:
 		b_optical_table.AddXAxis(xax, n_cols-1);
 		b_optical_table.AddYAxis(yax, n_rows-1);
 		b_optical_table.AddData(data);
-		delete [] xax, yax, data;
+		delete [] xax;
+		delete [] yax;
+		delete [] data;
 		optical_tables.Set_Table( &b_optical_table, 0 );
 
 		// *************************
@@ -1405,7 +1407,9 @@ public:
 			sh_optical_table.AddXAxis(xax1, n_cols-1);
 			sh_optical_table.AddYAxis(yax1, n_rows-1);
 			sh_optical_table.AddData(data1);
-			delete [] xax1, yax1, data1;
+			delete [] xax1;
+			delete [] yax1;
+			delete [] data1;
 			optical_tables.Set_Table( &sh_optical_table, 1 );
 		}
 		// ****************************************************************************

--- a/tcs/sam_mw_lf_type262_salt.cpp
+++ b/tcs/sam_mw_lf_type262_salt.cpp
@@ -912,7 +912,9 @@ public:
 		optical_table.AddXAxis(xax, ncol_OpticalTable-1);
 		optical_table.AddYAxis(yax, nrow_OpticalTable-1);
 		optical_table.AddData(data);
-		delete [] xax, yax, data;
+		delete [] xax;
+		delete [] yax;
+		delete [] data;
 
 		//The glazingintact array should be converted to bools
 		GlazingIntact.resize(nval_GlazingIntactIn);


### PR DESCRIPTION
`delete [] a, b, c;` only deletes `a`. The comma operator applies to b and c, so those operands on the right-hand side of the commas are unused values.