### PR TITLE
 Fix warning: m_phi_rc_1 is uninitialized

### DIFF
--- a/tcs/sco2_pc_core.h
+++ b/tcs/sco2_pc_core.h
@@ -1019,7 +1019,7 @@ public:
 			
 			m_W_dot_net = m_W_dot_net_adj = m_P_high = m_m_dot_total =
 				m_N_mc = m_w_tip_ratio_mc = m_eta_mc = 
-				m_N_rc = m_phi_rc_1, m_phi_rc_2 = m_w_tip_ratio_rc = m_eta_rc =
+				m_N_rc = m_phi_rc_1 = m_phi_rc_2 = m_w_tip_ratio_rc = m_eta_rc =
 				m_eta_t = std::numeric_limits<double>::quiet_NaN();
 		}
 	};


### PR DESCRIPTION
A misplaced comma in `sco2_pc_core.h` is prevening `m_phi_rc_1` from being initialised to `quiet_NaN`.
Fixes:

    ‘s_temp.C_RecompCycle::S_od_turbo_bal_csp_solved::m_phi_rc_1’  is used uninitialized in this function [-Wuninitialized]