### PR TITLE
Fix warning: deleting object  of polymorphic class type ‘AutoPilot_S’ which has non-virtual  destructor might cause undefined behaviour

### DIFF
--- a/solarpilot/AutoPilot_API.h
+++ b/solarpilot/AutoPilot_API.h
@@ -112,7 +112,7 @@ protected:
 
 public:
 	AutoPilot();
-	~AutoPilot();
+	virtual ~AutoPilot();
 	//Callbacks for progress updates
 	void SetSummaryCallback( bool (*callback)(simulation_info* siminfo, void *data), void *cdata);
 	void SetDetailCallback( bool (*callback)(simulation_info* siminfo, void *data), void *cdata);


### PR DESCRIPTION
It is unsafe to delete an instance of a derived class through a pointer to a base class if the base class does not have a virtual destructor. This patch fixes the AutoPilot declaration and silences the warning,