### PR TITLE
* build_linux/Makefile-sdktool, Makefile-tcsconsole: Add -Werror now.

### DIFF
--- a/build_linux/Makefile-sdktool
+++ b/build_linux/Makefile-sdktool
@@ -7,7 +7,7 @@ LKLIB = $(LKDIR)/lkuxwx3.a
 
 CC = gcc
 CXX = g++
-WARNINGS=-Wall -Wno-unknown-pragmas
+WARNINGS=-Wall -Wno-unknown-pragmas -Werror
 CFLAGS =  -g -O2 -I. -I$(WEXDIR)/include -I$(LKDIR)/include -I../ssc -I../shared -DLK_USE_WXWIDGETS `wx-config-3 --cflags` $(WARNINGS)
 LDFLAGS = -std=c++0x $(WEXLIB) $(LKLIB) `wx-config-3 --libs stc` `wx-config-3 --libs aui` `wx-config-3 --libs` -lm  -lfontconfig -ldl -lcurl 
 CXXFLAGS=-std=c++0x $(CFLAGS)

--- a/build_linux/Makefile-tcsconsole
+++ b/build_linux/Makefile-tcsconsole
@@ -7,7 +7,7 @@ LKLIB = $(LKDIR)/lkuxwx3.a
 
 CC = gcc
 CXX = g++
-WARNINGS=-Wall -Wno-unknown-pragmas
+WARNINGS=-Wall -Wno-unknown-pragmas -Werror
 CFLAGS = -g -O2  -I. -I$(WEXDIR)/include -I$(LKDIR)/include -I../tcs -DLK_USE_WXWIDGETS `wx-config-3 --cflags` $(WARNINGS)
 LDFLAGS = -std=c++0x $(WEXLIB) $(LKLIB) tcs.a nlopt.a solarpilot.a shared.a `wx-config-3 --libs stc` `wx-config-3 --libs aui` `wx-config-3 --libs` -lm  -lfontconfig -ldl -lcurl
 


### PR DESCRIPTION
The -Werror option can now be added for sdktool and tcsconsole directories.