### PR TITLE
Initialise some variables to suppress '<variable> may be used uninitialized in this function' warnings.

### DIFF
--- a/solarpilot/Flux.cpp
+++ b/solarpilot/Flux.cpp
@@ -2756,8 +2756,6 @@ void Flux::imageSizeAimPoint(Heliostat &H, SolarField &SF, double args[], bool i
 	double dpsave, dprod, sigx, sigy, dx, dy, fsave, imsizex, imsizey, theta_img, rnaz, rnel, stretch_factor, ftmp;
 	double e_bound_box[4];
 	int nfx, nfy, ny_in, ny_del, istart, jstart, iend, jend, jsave,kk,jspan;
-	//double *fvals;
-	//-------
 
 
 	switch (recgeom)

--- a/solarpilot/Flux.cpp
+++ b/solarpilot/Flux.cpp
@@ -2862,7 +2862,9 @@ void Flux::imageSizeAimPoint(Heliostat &H, SolarField &SF, double args[], bool i
 	case Receiver::REC_GEOM_TYPE::PLANE_RECT:
 	{
 		//3	|	Planar rectangle
-		
+
+		jsave = 0;
+
 		//Get the receiver that this heliostat is aiming at
 		FS = &rec->getFluxSurfaces()->at(0);	//Should be only one flux surface for this type of receiver
 		FG = FS->getFluxMap();

--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -47,6 +47,7 @@
 *  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************************************/
 
+#include <assert.h>
 #include <algorithm>
 #include <math.h>
 
@@ -2870,7 +2871,11 @@ void SolarField::cornfieldPositions(vector<sp_point> &HelPos){
 	y_loc = 0.;
 	hex_factor = 0.57735026919; //1./tan(PI/3.);
 	Nhelio = 0;
-	switch(_var_map->sf.xy_field_shape.mapval())
+
+	var_solarfield::XY_FIELD_SHAPE::EN shape =
+	  static_cast<var_solarfield::XY_FIELD_SHAPE::EN>(_var_map->sf.xy_field_shape.mapval());
+	assert (shape >= 0 && shape <= var_solarfield::XY_FIELD_SHAPE::UNDEFINED);
+	switch (shape)
 	{
     case var_solarfield::XY_FIELD_SHAPE::HEXAGON:
 	//case 0:	//hex
@@ -2899,7 +2904,10 @@ void SolarField::cornfieldPositions(vector<sp_point> &HelPos){
 		}
 
 		//Calculate the maximum x position
-		switch(_var_map->sf.xy_field_shape.mapval())
+		var_solarfield::XY_FIELD_SHAPE::EN shape =
+		  static_cast<var_solarfield::XY_FIELD_SHAPE::EN>(_var_map->sf.xy_field_shape.mapval());
+		assert (shape >= 0 && shape <= var_solarfield::XY_FIELD_SHAPE::UNDEFINED);
+		switch (shape)
 		{
         case var_solarfield::XY_FIELD_SHAPE::HEXAGON:
 		//case 0:	//hex

--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -1815,10 +1815,6 @@ void SolarField::AnnualEfficiencySimulation( string weather_file, SolarField *SF
 		helios->at(i)->setRankingMetricValue(0.);
 	}
 
-	//If the ranking requires TOD factors, get the array now
-	vector<int> *TOD;
-	if(rindex == helio_perf_data::PERF_VALUES::POWER_VALUE)
-		TOD = SF->getFinancialObject()->getScheduleArray(); 
 	vector<double> pfs = V->fin.pmt_factors.val; 
 	bool is_pmt_factors = V->fin.is_pmt_factors.val; 
 	//Get design point DNI for some simulations
@@ -1932,7 +1928,10 @@ void SolarField::AnnualEfficiencySimulation( string weather_file, SolarField *SF
 			{
 			case helio_perf_data::PERF_VALUES::POWER_VALUE:
 				if(is_pmt_factors)
-					payfactor = pfs[TOD->at(i)-1];
+				  {
+				    vector<int> *TOD = SF->getFinancialObject()->getScheduleArray();
+				    payfactor = pfs[TOD->at(i)-1];
+				  }
 			case helio_perf_data::PERF_VALUES::POWER_TO_REC:
 				zval = dni/dni_des * payfactor * z_interp * nsimd;
 				break;
@@ -2697,7 +2696,7 @@ void SolarField::radialStaggerPositions(vector<sp_point> &HelPos)
 
 		double daz_init;	//The initial physical spacing between heliostats azimuthally
 		double az_ang, azmin, azmid, haz;
-		int Nhelio = 0, hpr;
+		int Nhelio = 0, hpr = -1;
         //initialize the heliostat template again
         {
             sp_point hpos;
@@ -2788,7 +2787,7 @@ void SolarField::cornfieldPositions(vector<sp_point> &HelPos){
 
 	//Calculate an upper estimate of the size of the heliostat positions array to avoid resizing all the time
 	double 
-		r_coll_temp,
+		r_coll_temp = 0,
 		r_coll_min = 9.e9; 
 	for(htemp_map::iterator it=_helio_templates.begin(); it != _helio_templates.end(); it++){
 		r_coll_temp = it->second->getCollisionRadius();


### PR DESCRIPTION
`TOD` was moved down to its location of use to ensure it is initialised just before use.