### PR TITLE
Re-enable asserts to fix the solarpilot warnings

### DIFF
--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -47,6 +47,7 @@
 *  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************************************/
 
+#include <assert.h>
 #include <algorithm>
 #include <math.h>
 
@@ -2873,7 +2874,7 @@ void SolarField::cornfieldPositions(vector<sp_point> &HelPos){
 
 	var_solarfield::XY_FIELD_SHAPE::EN shape =
 	  static_cast<var_solarfield::XY_FIELD_SHAPE::EN>(_var_map->sf.xy_field_shape.mapval());
-	//assert (shape >= 0 && shape <= var_solarfield::XY_FIELD_SHAPE::UNDEFINED);
+	assert (shape >= 0 && shape <= var_solarfield::XY_FIELD_SHAPE::UNDEFINED);
 	switch (shape)
 	{
     case var_solarfield::XY_FIELD_SHAPE::HEXAGON:
@@ -2905,7 +2906,7 @@ void SolarField::cornfieldPositions(vector<sp_point> &HelPos){
 		//Calculate the maximum x position
 		var_solarfield::XY_FIELD_SHAPE::EN shape =
 		  static_cast<var_solarfield::XY_FIELD_SHAPE::EN>(_var_map->sf.xy_field_shape.mapval());
-		//assert (shape >= 0 && shape <= var_solarfield::XY_FIELD_SHAPE::UNDEFINED);
+		assert (shape >= 0 && shape <= var_solarfield::XY_FIELD_SHAPE::UNDEFINED);
 		switch (shape)
 		{
         case var_solarfield::XY_FIELD_SHAPE::HEXAGON:


### PR DESCRIPTION
This change re-enables the asserts to fix two warnings in the solarpilot directory:

    ../solarpilot/SolarField.cpp: In member function ‘void SolarField::cornfieldPositions(std::vector<sp_point>&)’:
    ../solarpilot/SolarField.cpp:2927:15: warning: ‘x_max’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       while(x_loc <= x_max){
                   ^
    ../solarpilot/SolarField.cpp:2894:14: warning: ‘y_max’ may be used uninitialized in this function    [-Wmaybe-uninitialized]
      while(y_loc <= y_max)

Assertions are convenient for telling GCC's value range analysis that `shape` is guaranteed to be in the range [0, XY_FIELD_SHAPE::UNDEFINED].  GCC can then determine that all `enum` cases are handled in the switch and, therefore, `x_max`/`y_max` is always be initialised by one of the cases.