### PR TITLE
Remove needless casts to double

### DIFF
--- a/ssc/cmod_pvwattsv0.cpp
+++ b/ssc/cmod_pvwattsv0.cpp
@@ -578,18 +578,18 @@ static void solarpos_v0(int year,int month,int day,int hour,double minute,double
 	time = jd - 51545.0;     /* Time in days referenced from noon 1 Jan 2000 */
 
 	mnlong = 280.46 + 0.9856474*time;
-	mnlong = fmod((double)mnlong,(double)360.0);         /* Finds floating point remainder */
+	mnlong = fmod(mnlong, 360.0);         /* Finds floating point remainder */
 	if( mnlong < 0.0 )
 		mnlong = mnlong + 360.0;          /* Mean longitude between 0-360 deg */
 
 	mnanom = 357.528 + 0.9856003*time;
-	mnanom = fmod((double)mnanom,(double)360.0);
+	mnanom = fmod(mnanom, 360.0);
 	if( mnanom < 0.0 )
 		mnanom = mnanom + 360.0;
 	mnanom = mnanom*DTOR;             /* Mean anomaly between 0-2pi radians */
 
 	eclong = mnlong + 1.915*sin(mnanom) + 0.020*sin(2.0*mnanom);
-	eclong = fmod((double)eclong,(double)360.0);
+	eclong = fmod(eclong, 360.0);
 	if( eclong < 0.0 )
 		eclong = eclong + 360.0;
 	eclong = eclong*DTOR;       /* Ecliptic longitude between 0-2pi radians */
@@ -606,12 +606,12 @@ static void solarpos_v0(int year,int month,int day,int hour,double minute,double
 	dec = asin( sin(oblqec)*sin(eclong) );       /* Declination in radians */
 
 	gmst = 6.697375 + 0.0657098242*time + zulu;
-	gmst = fmod(gmst,(double)24.0);
+	gmst = fmod(gmst, 24.0);
 	if( gmst < 0.0 )
 		gmst = gmst + 24.0;         /* Greenwich mean sidereal time in hours */
 
 	lmst = gmst + lng/15.0;
-	lmst = fmod(lmst,(double)24.0);
+	lmst = fmod(lmst, 24.0);
 	if( lmst < 0.0 )
 		lmst = lmst + 24.0;
 	lmst = lmst*15.0*DTOR;         /* Local mean sidereal time in radians */
@@ -656,7 +656,7 @@ static void solarpos_v0(int year,int month,int day,int hour,double minute,double
 	if( elv > -0.56 )
 		refrac = 3.51561*( 0.1594 + 0.0196*elv + 0.00002*elv*elv )/( 1.0 + 0.505*elv + 0.0845*elv*elv );
 	else
-		refrac = (double)0.56;
+		refrac = 0.56;
 	if( elv + refrac > 90.0 )
 		elv = 90.0*DTOR;
 	else

--- a/tcs/fmin.cpp
+++ b/tcs/fmin.cpp
@@ -112,7 +112,7 @@ double fminbr(double a, double b, double(*f)(double x, void *data), void *data_i
 			p = (x - v) * q - (x - w) * t;
 			q = 2 * (q - t);
 
-			if( q > (double)0 )    /* q was calculated with the op- */
+			if (q > 0)    		/* q was calculated with the op- */
 				p = -p;             /* posite sign; make q positive */
 			else                   /* and assign possible minus to     */
 				q = -q;             /* p                            */
@@ -128,7 +128,7 @@ double fminbr(double a, double b, double(*f)(double x, void *data), void *data_i
 		}
 
 		if( fabs(new_step) < tol_act ) {   /* Adjust the step to be not less */
-			if( new_step > (double)0 ) {   /* than tolerance               */
+			if (new_step > 0) {        /* than tolerance                 */
 				new_step = tol_act;
 			}
 			else {


### PR DESCRIPTION
I grepped and found a number of floating point literals that were being needlessly cast to `double`. If a `float` literal is passed to a function with a `double` argument, the type of the literal will be promoted to `double' and the cast is not necessary.

We should aim to eliminate all of the C-style casts in the long run, favouring static_cast<>.