### PR TITLE
Fix all warnings in sdktool

### DIFF
--- a/sdktool/editvariable.cpp
+++ b/sdktool/editvariable.cpp
@@ -273,8 +273,6 @@ void EditVariableDialog::OnRowsColsChange( wxCommandEvent & )
 	nr = (size_t) numRows->AsInteger();
 	nc = (size_t) numCols->AsInteger();
 
-	if (nr < 0 || nc < 0) return;
-
 	if (m_var.type == SSC_ARRAY)
 	{
 		util::matrix_t<ssc_number_t> old;


### PR DESCRIPTION
    ../sdktool/editvariable.cpp:276:9: error: comparison of unsigned expression < 0 is always false  [-Werror,-Wtautological-compare]
            if (nr < 0 || nc < 0) return;
                ~~ ^ ~
    ../sdktool/editvariable.cpp:276:19: error: comparison of unsigned expression < 0 is always false [-Werror,-Wtautological-compare]
            if (nr < 0 || nc < 0) return;
                          ~~ ^ ~