### PR TITLE
Remove fgets

### DIFF
--- a/build_linux/Makefile-shared
+++ b/build_linux/Makefile-shared
@@ -1,7 +1,7 @@
 VPATH = ../shared
 CC = gcc
 CXX = g++
-WARNINGS = -Wall -Wno-strict-aliasing
+WARNINGS = -Wall -Werror -Wno-strict-aliasing
 CFLAGS = $(WARNINGS) -g -O3 -D__64BIT__ -fPIC
 CXXFLAGS=-std=c++0x $(CFLAGS)
 

--- a/shared/lib_weatherfile.cpp
+++ b/shared/lib_weatherfile.cpp
@@ -55,6 +55,7 @@
 #include <numeric>
 #include <limits>
 #include <iostream>
+#include <sstream>
 
 #if defined(__WINDOWS__)||defined(WIN32)||defined(_WIN32)
 #define CASECMP(a,b) _stricmp(a,b)
@@ -67,6 +68,8 @@
 #include "lib_util.h"
 #include "lib_weatherfile.h"
 
+using std::stof;
+using std::stoi;
 
 #ifdef _MSC_VER
 #define my_isnan(x) ::_isnan( x )
@@ -74,64 +77,25 @@
 #define my_isnan(x) std::isnan( x )
 #endif
 
-static void trimnlcr(char *buf)
+static std::string trimboth(std::string &buf)
 {
-	if (!buf) return;
+  	const auto strBegin = buf.find_first_not_of(" \t");
+	if (strBegin == std::string::npos)
+	  return std::string();
 
-	size_t len = strlen(buf);
-	if (len > 0 && buf[len - 1] == '\n') // strip newline
-		buf[len - 1] = 0;
-
-	if (len > 1 && buf[len - 2] == '\r') // strip carriage return
-		buf[len - 2] = 0;
+	const auto strEnd = buf.find_last_not_of(" \t\r\n");
+	const auto strRange = strEnd - strBegin + 1;
+	return buf.substr(strBegin, strRange);
 }
 
-static char *trimboth(char *buf)
+static std::vector<std::string> split(const std::string &buf, char delim = ',')
 {
-	if (!buf) return 0;
-
-	size_t len = strlen(buf);
-	if (len == 0) return buf;
-
-	char *p = buf + len - 1;
-	while (p > buf && p && *p
-		&& (*p == '\n' || *p == '\r' || *p == ' ' || *p == '\t'))
-	{
-		*p = 0;
-		p--;
-	}
-
-	p = buf;
-	while (p && *p && (*p == ' ' || *p == '\t'))
-		p++;
-
-	return p;
-}
-
-static int locate(char *buf, char **colidx, int colmax, char delim)
-{
-	trimnlcr(buf);
-
-	char *p = buf;
-	int i = 1;
-	int ncols = 0;
-
-	colidx[0] = p;
-	while (p && *p && i < colmax)
-	{
-		p = strchr(p, delim);
-		if (p)
-		{
-			*p = 0;
-			colidx[i++] = ++p;
-		}
-	}
-
-	ncols = i;
-
-	while (i<colmax) colidx[i++] = 0;
-
-	return ncols;
+	std::string token;
+	std::vector<std::string> tokens;
+	std::istringstream tokenStream(buf);
+	while (std::getline(tokenStream, token, delim))
+		tokens.push_back(token);
+	return tokens;
 }
 
 static double conv_deg_min_sec(double degrees,
@@ -435,7 +399,6 @@ void weather_record::reset()
 
 
 #define NBUF 2048
-#define NCOL 128
 
 
 weatherfile::weatherfile()
@@ -508,10 +471,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		return false;
 	}
 
-	char buf[NBUF + 1], *pbuf,
-		buf1[NBUF + 1], *pbuf1,
-		*cols[128], *cols1[128];
-
+	char buf[NBUF + 1], *pbuf, buf1[NBUF + 1], *pbuf1;
 
 	util::stdfile fp( file.c_str(), "r" );
 	if ( !fp.ok() )
@@ -527,8 +487,8 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		// try to autodetect a TMY3
 		fgets(buf, NBUF, fp);
 		fgets(buf1, NBUF, fp);
-		int ncols = locate(buf, cols, NCOL, ',');
-		int ncols1 = locate(buf1, cols1, NCOL, ',');
+		int ncols = split(buf).size();
+		int ncols1 = split(buf1).size();
 
 		if (ncols == 7 && (ncols1 == 68 || ncols1 == 71))
 			m_type = TMY3;
@@ -570,8 +530,8 @@ bool weatherfile::open(const std::string &file, bool header_only)
 	{
 		/*  724699,"BROOMFIELD/JEFFCO [BOULDER - SURFRAD]",CO,-7.0,40.130,-105.240,1689 */
 		fgets(buf, NBUF, fp);
-		int nhdr = locate(buf, cols, NCOL, ',');
-		if (nhdr != 7)
+		auto cols = split(buf);
+		if (cols.size() != 7)
 		{
 			m_message = "invalid TMY3 header: must contain 7 fields.  station,city,state,tz,lat,lon,elev";
 			m_ok = false;
@@ -581,10 +541,10 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		m_hdr.location = cols[0];
 		m_hdr.city = cols[1];
 		m_hdr.state = cols[2];
-		m_hdr.tz = atof(cols[3]);
-		m_hdr.lat = atof(cols[4]);
-		m_hdr.lon = atof(cols[5]);
-		m_hdr.elev = atof(cols[6]);
+		m_hdr.tz = stof(cols[3]);
+		m_hdr.lat = stof(cols[4]);
+		m_hdr.lon = stof(cols[5]);
+		m_hdr.elev = stof(cols[6]);
 		
 		m_startSec = 1800;
 		m_stepSec  = 3600;
@@ -598,9 +558,9 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		/*  LOCATION,Alice Springs Airport,NT,AUS,RMY,943260,-23.80,133.88,9.5,547.0 */
 
 		fgets(buf, NBUF, fp);
-		int nhdr = locate(buf, cols, NCOL, ',');
+		auto cols = split(buf);
 
-		if (nhdr != 10)
+		if (cols.size() != 10)
 		{
 			m_message = "invalid EPW header: must contain 10 fields. LOCATION,city,state,country,source,station,lat,lon,tz,elev";
 			m_ok = false;
@@ -612,10 +572,10 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		m_hdr.country = cols[3];
 		m_hdr.source = cols[4];
 		m_hdr.location = cols[5];
-		m_hdr.lat = atof(cols[6]);
-		m_hdr.lon = atof(cols[7]);
-		m_hdr.tz = atof(cols[8]);
-		m_hdr.elev = atof(cols[9]);
+		m_hdr.lat = stof(cols[6]);
+		m_hdr.lon = stof(cols[7]);
+		m_hdr.tz = stof(cols[8]);
+		m_hdr.elev = stof(cols[9]);
 
 		/* skip over excess header lines */
 
@@ -635,9 +595,9 @@ bool weatherfile::open(const std::string &file, bool header_only)
 	else if (m_type == SMW)
 	{
 		fgets(buf, NBUF, fp);
-		int nhdr = locate(buf, cols, NCOL, ',');
+		auto cols = split(buf);
 
-		if (10 != nhdr)
+		if (cols.size() != 10)
 		{
 			m_message = "invalid SMW header format, 10 fields required";
 			m_ok = false;
@@ -648,13 +608,13 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		m_hdr.city = cols[1];
 		m_hdr.state = cols[2];
 
-		m_hdr.tz = atof(cols[3]);
-		m_hdr.lat = atof(cols[4]);
-		m_hdr.lon = atof(cols[5]);
-		m_hdr.elev = atof(cols[6]);
-		m_stepSec = (size_t)atof(cols[7]); // time step in seconds
-		m_startYear = atoi(cols[8]);
-		char *p = cols[9];
+		m_hdr.tz = stof(cols[3]);
+		m_hdr.lat = stof(cols[4]);
+		m_hdr.lon = stof(cols[5]);
+		m_hdr.elev = stof(cols[6]);
+		m_stepSec = (size_t)stof(cols[7]); // time step in seconds
+		m_startYear = stoi(cols[8]);
+		char *p = const_cast<char *>(cols[9].c_str());
 		
 		double start_hour = 0;
 		double start_min = 30;
@@ -696,9 +656,11 @@ bool weatherfile::open(const std::string &file, bool header_only)
 	else if (m_type == WFCSV)
 	{
 		pbuf = fgets(buf, NBUF, fp);
-		int ncols = locate(buf, cols, NCOL, ',');
+		auto cols = split(buf);
+		int ncols = cols.size();
 		pbuf1 = fgets(buf1, NBUF, fp);
-		int ncols1 = locate(buf1, cols1, NCOL, ',');
+		auto cols1 = split(buf1);
+		int ncols1 = split(buf1).size();
 
 		int hdr_step_sec = -1;
 
@@ -712,28 +674,28 @@ bool weatherfile::open(const std::string &file, bool header_only)
 
 		for (size_t i = 0; (int)i<ncols; i++)
 		{
-			std::string name = util::lower_case(trimboth(cols[i]));
-			char *value = trimboth(cols1[i]);
+		  	const std::string name = util::lower_case(trimboth(cols[i]));
+			const std::string value = trimboth(cols1[i]);
 
 			if (name == "lat" || name == "latitude")
 			{
-				m_hdr.lat = atof(value);
+				m_hdr.lat = stof(value);
 			}
 			else if (name == "lon" || name == "long" || name == "longitude" || name == "lng")
 			{
-				m_hdr.lon = atof(value);
+				m_hdr.lon = stof(value);
 			}
 			else if (name == "tz" || name == "timezone" || name == "time zone")
 			{
-				m_hdr.tz = atof(value);
+				m_hdr.tz = stof(value);
 			}
 			else if (name == "el" || name == "elev" || name == "elevation" || name == "site elevation")
 			{
-				m_hdr.elev = atof(value);
+				m_hdr.elev = stof(value);
 			}
 			else if (name == "year")
 			{
-				m_startYear = atoi(value);
+			  	m_startYear = stoi(value);
 			}
 			else if (name == "id" || name == "location" || name == "location id" || name == "station" || name == "station id" || name == "wban" || name == "wban#")
 			{
@@ -765,11 +727,11 @@ bool weatherfile::open(const std::string &file, bool header_only)
 			}
 			else if (name == "hasunits" || name == "units")
 			{
-				m_hdr.hasunits = (util::lower_case(value) == "yes" || atoi(value) != 0);
+			  	m_hdr.hasunits = (util::lower_case(value) == "yes" || stoi(value) != 0);
 			}
 			else if (name == "step")
 			{
-				hdr_step_sec = atoi(value);
+			  	hdr_step_sec = stoi(value);
 			}
 		}
 
@@ -876,7 +838,8 @@ bool weatherfile::open(const std::string &file, bool header_only)
 			return false;
 		}
 
-		int ncols = locate(buf, cols, NCOL, ',');
+		auto cols = split(buf);
+		int ncols = cols.size();
 
 		if (m_hdr.hasunits)
 		{
@@ -886,7 +849,8 @@ bool weatherfile::open(const std::string &file, bool header_only)
 				m_message = "could not read column units";
 				return false;
 			}
-			int ncols1 = locate(buf1, cols1, NCOL, ',');
+			auto cols1 = split(buf1);
+			int ncols1 = cols1.size();
 
 			if (ncols != ncols1) {
 				m_message = "column names and units must have the same number of fields";
@@ -897,10 +861,10 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		// determine columns
 		for (int i = 0; i<ncols; i++)
 		{
-			char *name_cstr = trimboth(cols[i]);
-			if (name_cstr && strlen(name_cstr) > 0)
+		    	const std::string name = trimboth(cols[i]);
+			if (name.length() > 0)
 			{
-				std::string lowname = util::lower_case(name_cstr);
+			  	std::string lowname = util::lower_case(name);
 
 				if (lowname == "yr" || lowname == "year") m_columns[YEAR].index = i;
 				else if (lowname == "mo" || lowname == "month") m_columns[MONTH].index = i;
@@ -1105,16 +1069,16 @@ bool weatherfile::open(const std::string &file, bool header_only)
 			{
 				pret = fgets(buf, NBUF, fp);
 
-				int ncols = locate(buf, cols, NCOL, ',');
-				if (ncols < 68)
+				auto cols = split(buf);
+				if (cols.size() < 68)
 				{
 					m_message = "TMY3: data line does not have at least 68 fields at record " + util::to_string(i);
 					return false;
 				}
 
-				char *p = cols[0];
+				const char *p = cols[0].c_str();
 
-				int month = atoi(p);
+				int month = stoi(p);
 				p = strchr(p, '/');
 				if (!p)
 				{
@@ -1122,7 +1086,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 					return false;
 				}
 				p++;
-				int day = atoi(p);
+				int day = stoi(p);
 				p = strchr(p, '/');
 				if (!p)
 				{
@@ -1130,9 +1094,9 @@ bool weatherfile::open(const std::string &file, bool header_only)
 					return false;
 				}
 				p++;
-				int year = atoi(p);
+				int year = stoi(p);
 
-				int hour = atoi(cols[1]) - tmy3_hour_shift;  // hour goes 0-23, not 1-24
+				int hour = stoi(cols[1]) - tmy3_hour_shift;  // hour goes 0-23, not 1-24
 				if (i == 0 && hour < 0)
 				{
 					// this was a TMY3 file but with hours going 0-23 (against the tmy3 spec)
@@ -1153,21 +1117,21 @@ bool weatherfile::open(const std::string &file, bool header_only)
 				m_columns[HOUR].data[i] = (float)hour;
 				m_columns[MINUTE].data[i] = 30;
 
-				m_columns[GHI].data[i] = (float)atof(cols[4]);
-				m_columns[DNI].data[i] = (float)atof(cols[7]);
-				m_columns[DHI].data[i] = (float)atof(cols[10]);
+				m_columns[GHI].data[i] = (float)stof(cols[4]);
+				m_columns[DNI].data[i] = (float)stof(cols[7]);
+				m_columns[DHI].data[i] = (float)stof(cols[10]);
 				m_columns[POA].data[i] = (float)(-999);       /* No POA in TMY3 */
 
-				m_columns[TDRY].data[i] = (float)atof(cols[31]);
-				m_columns[TDEW].data[i] = (float)atof(cols[34]);
+				m_columns[TDRY].data[i] = (float)stof(cols[31]);
+				m_columns[TDEW].data[i] = (float)stof(cols[34]);
 				
-				m_columns[WSPD].data[i] = (float)atof(cols[46]);
-				m_columns[WDIR].data[i] = (float)atof(cols[43]);
+				m_columns[WSPD].data[i] = (float)stof(cols[46]);
+				m_columns[WDIR].data[i] = (float)stof(cols[43]);
 
-				m_columns[RH].data[i] = (float)atof(cols[37]);
-				m_columns[PRES].data[i] = (float)atof(cols[40]);
+				m_columns[RH].data[i] = (float)stof(cols[37]);
+				m_columns[PRES].data[i] = (float)stof(cols[40]);
 				m_columns[SNOW].data[i] = -999.0; // no snowfall in TMY3
-				m_columns[ALB].data[i] = (float)atof(cols[61]);
+				m_columns[ALB].data[i] = (float)stof(cols[61]);
 				m_columns[AOD].data[i] = -999; /* no AOD in TMY3 */
 
 				m_columns[TWET].data[i] 
@@ -1192,16 +1156,16 @@ bool weatherfile::open(const std::string &file, bool header_only)
 			for(;;)
 			{
 				pret = fgets(buf, NBUF, fp);
-				int ncols = locate(buf, cols, NCOL, ',');
+				auto cols = split(buf);
 
-				if (ncols < 32)
+				if (cols.size() < 32)
 				{
 					m_message = "EPW: data line does not have at least 32 fields at record " + util::to_string(i);
 					return false;
 				}
 
-				int month = atoi(cols[1]);
-				int day = atoi(cols[2] );
+				int month = stoi(cols[1]);
+				int day = stoi(cols[2] );
 
 				if ( month == 2 && day == 29 )
 				{
@@ -1209,26 +1173,26 @@ bool weatherfile::open(const std::string &file, bool header_only)
 					continue;
 				}
 
-				m_columns[YEAR].data[i] = (float)atoi(cols[0]);
-				m_columns[MONTH].data[i] = (float)atoi(cols[1]);
-				m_columns[DAY].data[i] = (float)atoi(cols[2]);
-				m_columns[HOUR].data[i] = (float)atoi(cols[3]) - 1;  // hour goes 0-23, not 1-24;
+				m_columns[YEAR].data[i] = (float)stoi(cols[0]);
+				m_columns[MONTH].data[i] = (float)stoi(cols[1]);
+				m_columns[DAY].data[i] = (float)stoi(cols[2]);
+				m_columns[HOUR].data[i] = (float)stoi(cols[3]) - 1;  // hour goes 0-23, not 1-24;
 				m_columns[MINUTE].data[i] = 30;
 
-				m_columns[GHI].data[i] = (float)atof(cols[13]);
-				m_columns[DNI].data[i] = (float)atof(cols[14]);
-				m_columns[DHI].data[i] = (float)atof(cols[15]);
+				m_columns[GHI].data[i] = (float)stof(cols[13]);
+				m_columns[DNI].data[i] = (float)stof(cols[14]);
+				m_columns[DHI].data[i] = (float)stof(cols[15]);
 				m_columns[POA].data[i] = (float)(-999);       /* No POA in EPW */
 
-				m_columns[WSPD].data[i] = (float)atof(cols[21]);
-				m_columns[WDIR].data[i] = (float)atof(cols[20]);
+				m_columns[WSPD].data[i] = (float)stof(cols[21]);
+				m_columns[WDIR].data[i] = (float)stof(cols[20]);
 
-				m_columns[TDRY].data[i] = (float)atof(cols[6]);
-				m_columns[TWET].data[i] = (float)atof(cols[7]);
+				m_columns[TDRY].data[i] = (float)stof(cols[6]);
+				m_columns[TWET].data[i] = (float)stof(cols[7]);
 
-				m_columns[RH].data[i] = (float)atof(cols[8]);
-				m_columns[PRES].data[i] = (float)(atof(cols[9]) * 0.01); /* convert Pa in to mbar */
-				m_columns[SNOW].data[i] = (float)atof(cols[30]); // snowfall
+				m_columns[RH].data[i] = (float)stof(cols[8]);
+				m_columns[PRES].data[i] = (float)(stof(cols[9]) * 0.01); /* convert Pa in to mbar */
+				m_columns[SNOW].data[i] = (float)stof(cols[30]); // snowfall
 				m_columns[ALB].data[i] = -999; /* no albedo in EPW file */
 				m_columns[AOD].data[i] = -999; /* no AOD in EPW */
 
@@ -1246,9 +1210,9 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		else if (m_type == SMW)
 		{
 			char *pret = fgets(buf, NBUF, fp);
-			int ncols = locate(buf, cols, NCOL, ',');
+			auto cols = split(buf);
 
-			if (ncols < 12)
+			if (cols.size() < 12)
 			{
 				m_message = "SMW: data line does not have at least 12 fields at record " + util::to_string(i);
 				return false;
@@ -1264,22 +1228,22 @@ bool weatherfile::open(const std::string &file, bool header_only)
 
 			m_time += m_stepSec; // increment by step
 
-			m_columns[GHI].data[i] = (float)atof(cols[7]);
-			m_columns[DNI].data[i] = (float)atof(cols[8]);
-			m_columns[DHI].data[i] = (float)atof(cols[9]);
+			m_columns[GHI].data[i] = (float)stof(cols[7]);
+			m_columns[DNI].data[i] = (float)stof(cols[8]);
+			m_columns[DHI].data[i] = (float)stof(cols[9]);
 			m_columns[POA].data[i] = (double)(-999);       /* No POA in SMW */
 
-			m_columns[WSPD].data[i] = (float)atof(cols[4]);
-			m_columns[WDIR].data[i] = (float)atof(cols[5]);
+			m_columns[WSPD].data[i] = (float)stof(cols[4]);
+			m_columns[WDIR].data[i] = (float)stof(cols[5]);
 
-			m_columns[TDRY].data[i] = (float)atof(cols[0]);
-			m_columns[TDEW].data[i] = (float)atof(cols[1]);
-			m_columns[TWET].data[i] = (float)atof(cols[2]);
+			m_columns[TDRY].data[i] = (float)stof(cols[0]);
+			m_columns[TDEW].data[i] = (float)stof(cols[1]);
+			m_columns[TWET].data[i] = (float)stof(cols[2]);
 
-			m_columns[RH].data[i] = (float)atof(cols[3]);
-			m_columns[PRES].data[i] = (float)atof(cols[6]);
-			m_columns[SNOW].data[i] = (float)atof(cols[11]);
-			m_columns[ALB].data[i] = (float)atof(cols[10]);
+			m_columns[RH].data[i] = (float)stof(cols[3]);
+			m_columns[PRES].data[i] = (float)stof(cols[6]);
+			m_columns[SNOW].data[i] = (float)stof(cols[11]);
+			m_columns[ALB].data[i] = (float)stof(cols[10]);
 			m_columns[AOD].data[i] = -999; /* no AOD in SMW */
 
 			if ( pret!=buf )
@@ -1295,20 +1259,22 @@ bool weatherfile::open(const std::string &file, bool header_only)
 			{
 				buf[0] = 0;
 				fgets(buf, NBUF, fp);
-				pbuf = trimboth(buf);
-				if (!pbuf || !*pbuf)
+				std::string temp(buf);
+				std::string pbuf2 = trimboth(temp);
+				if (pbuf2.length() == 0)
 				{
 					m_message = "CSV: data line formatting error at record " + util::to_string(i);
 					return false;
 				}
 
-				int ncols = locate(pbuf, cols, NCOL, ',');			
+				auto cols = split(pbuf2);
+				int ncols = cols.size();
 				for (size_t k = 0; k < _MAXCOL_; k++)
 				{
 					if (m_columns[k].index >= 0
 						&& m_columns[k].index < ncols)
 					{
-						m_columns[k].data[i] = (float)atof(trimboth(cols[m_columns[k].index]));
+						m_columns[k].data[i] = (float)stof(trimboth(cols[m_columns[k].index]));
 					} 
 				}
 

--- a/shared/lib_weatherfile.cpp
+++ b/shared/lib_weatherfile.cpp
@@ -471,7 +471,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		return false;
 	}
 
-	char buf[NBUF + 1], *pbuf, buf1[NBUF + 1], *pbuf1;
+	char buf[NBUF + 1], buf1[NBUF + 1];
 
 	util::stdfile fp( file.c_str(), "r" );
 	if ( !fp.ok() )
@@ -655,18 +655,18 @@ bool weatherfile::open(const std::string &file, bool header_only)
 	}
 	else if (m_type == WFCSV)
 	{
-		pbuf = fgets(buf, NBUF, fp);
+		char *pbuf = fgets(buf, NBUF, fp);
 		auto cols = split(buf);
 		int ncols = cols.size();
-		pbuf1 = fgets(buf1, NBUF, fp);
+		char *pbuf1 = fgets(buf1, NBUF, fp);
 		auto cols1 = split(buf1);
 		int ncols1 = split(buf1).size();
 
 		int hdr_step_sec = -1;
 
 		if (ncols != ncols1
-			|| pbuf != buf
-			|| pbuf1 != buf1)
+		    	|| pbuf == NULL
+			|| pbuf1 == NULL)
 		{
 			m_message = "first two header lines must have same number of columns";
 			return false;
@@ -831,8 +831,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 	{
 		// if it's a WFCSV format file, we need to determine which columns of data exist
 
-		pbuf = fgets(buf, NBUF, fp); // read column names	
-		if (pbuf != buf)
+		if (fgets(buf, NBUF, fp) == NULL) // read column names
 		{
 			m_message = "could not read column names";
 			return false;
@@ -843,8 +842,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 
 		if (m_hdr.hasunits)
 		{
-			pbuf1 = fgets(buf1, NBUF, fp); // read column units;
-			if (pbuf1 != buf1)
+		  	if (fgets(buf1, NBUF, fp) == NULL) // read column units
 			{
 				m_message = "could not read column units";
 				return false;
@@ -1260,14 +1258,14 @@ bool weatherfile::open(const std::string &file, bool header_only)
 				buf[0] = 0;
 				fgets(buf, NBUF, fp);
 				std::string temp(buf);
-				std::string pbuf2 = trimboth(temp);
-				if (pbuf2.length() == 0)
+				std::string buf2 = trimboth(temp);
+				if (buf2.length() == 0)
 				{
 					m_message = "CSV: data line formatting error at record " + util::to_string(i);
 					return false;
 				}
 
-				auto cols = split(pbuf2);
+				auto cols = split(buf2);
 				int ncols = cols.size();
 				for (size_t k = 0; k < _MAXCOL_; k++)
 				{

--- a/shared/lib_windfile.cpp
+++ b/shared/lib_windfile.cpp
@@ -284,8 +284,6 @@ windfile::windfile()
 	: winddata_provider()
 {
 	m_nrec = 0;
-	m_buf = new char[MBUFLEN];
-	m_fp = 0;
 	close();
 }
 
@@ -293,21 +291,18 @@ windfile::windfile( const std::string &file )
 	: winddata_provider()
 {
 	m_nrec = 0;
-	m_buf = new char[MBUFLEN];
-	m_fp = 0;
 	close();
 	open( file );
 }
 
 windfile::~windfile()
 {
-	delete [] m_buf;
-	if (m_fp != 0) fclose( m_fp );
+  	ifs.close();
 }
 
 bool windfile::ok()
 {
-	return m_fp != 0;
+  	return ifs.good();
 }
 
 
@@ -325,9 +320,9 @@ bool windfile::open( const std::string &file )
 	if ( !cmp_ext(file.c_str(), "srw") )
 		return false;
 		*/
-		
-	m_fp = fopen(file.c_str(), "r");
-	if (!m_fp)
+
+	ifs.open(file);
+	if (!ifs.good())
 	{
 		m_errorMsg = "could not open file for reading: " + file;
 		return false;
@@ -335,16 +330,15 @@ bool windfile::open( const std::string &file )
 		
 	/* read header information */
 	
-	// read line 1 (header info
-	fgets( m_buf, MBUFLEN-1, m_fp );
+	// read line 1 (header info)
+	std::getline(ifs, buf);
 	std::vector<std::string> cols;
-	int ncols = locate2(m_buf, cols, ',');
+	int ncols = locate2(buf, cols, ',');
 
 	if (ncols < 8)
 	{
 		m_errorMsg = util::format("error reading header (line 1).  At least 8 columns required, %d found.", ncols);
-		fclose( m_fp );
-		m_fp = 0;
+		ifs.close();
 		return false;
 	}
 
@@ -363,18 +357,16 @@ bool windfile::open( const std::string &file )
 	catch (const std::invalid_argument &) {/* nothing to do */ };
 
 	// read line 2, description
-	fgets( m_buf, MBUFLEN-1, m_fp );
-	desc = std::string(m_buf);
+	std::getline(ifs, desc);
 	trim(desc);
 	
 	// read line 3, column names (must be pressure, temperature, speed, direction)
-	fgets( m_buf, MBUFLEN-1, m_fp );
-	ncols = locate2(m_buf, cols, ',');
+	std::getline(ifs, buf);
+	ncols = locate2(buf, cols, ',');
 	if (ncols < 3)
 	{
 		m_errorMsg = util::format("too few data column types found: %d.  at least 3 required.", ncols);
-		fclose( m_fp );
-		m_fp = 0;
+		ifs.close();
 		return false;
 	}
 	
@@ -392,8 +384,7 @@ bool windfile::open( const std::string &file )
 		else if ( ctype.length() > 0 )
 		{
 			m_errorMsg = util::format( "error reading data column type specifier in col %d of %d: '%s' len: %d", i+1, ncols, ctype.c_str(), ctype.length() );
-			fclose( m_fp );
-			m_fp = 0;
+			ifs.close();
 			return false;
 		}
 	}
@@ -402,16 +393,15 @@ bool windfile::open( const std::string &file )
 
 
 	// read line 4, units for each column (ignore this for now)
-	fgets( m_buf, MBUFLEN-1, m_fp );
+	std::getline(ifs, buf);
 
 	// read line 5, height in meters for each data column
-	fgets( m_buf, MBUFLEN-1, m_fp );
-	ncols = locate2(m_buf, cols, ',');
+	std::getline(ifs, buf);
+	ncols = locate2(buf, cols, ',');
 	if ( ncols < (int)m_heights.size() )
 	{
 		m_errorMsg = util::format("too few columns in the height row.  %d required but only %d found", (int)m_heights.size(), ncols);
-		fclose( m_fp );
-		m_fp = 0;
+		ifs.close();
 		return false;
 	}
 
@@ -421,13 +411,13 @@ bool windfile::open( const std::string &file )
 
 	// read all the lines to determine the nubmer of records in the file
 	m_nrec = 0;
-	while( fgets( m_buf, MBUFLEN-1, m_fp ) )
+	while (std::getline(ifs, buf))
 		m_nrec++;
 
 	// rewind the file and reposition right after the header information
-	rewind( m_fp );
-	for( size_t i=0;i<5;i++ )
-		fgets( m_buf, MBUFLEN-1, m_fp );
+	ifs.seekg(0);
+	for (size_t i = 0; i < 5; i++)
+		std::getline(ifs, buf);
 
 	
 	// ready to read line-by-line.  subsequent columns of data correspond to the
@@ -438,9 +428,8 @@ bool windfile::open( const std::string &file )
 
 void windfile::close()
 {
-	if ( m_fp != 0 ) fclose( m_fp );
-	
-	m_fp = 0;
+  	ifs.close();
+
 	m_file.clear();
 	city.clear();
 	state.clear();
@@ -462,8 +451,8 @@ bool windfile::read_line( std::vector<double> &values )
 	if ( !ok() ) return false;
 
 	std::vector<std::string> cols;
-	fgets( m_buf, MBUFLEN-1, m_fp );
-	int ncols = locate2(m_buf, cols, ',');
+	std::getline(ifs, buf);
+	int ncols = locate2(buf, cols, ',');
 	if (ncols >= (int)m_heights.size() 
 		&& ncols >= (int)m_dataid.size())
 	{

--- a/shared/lib_windfile.cpp
+++ b/shared/lib_windfile.cpp
@@ -297,12 +297,12 @@ windfile::windfile( const std::string &file )
 
 windfile::~windfile()
 {
-  	ifs.close();
+  	m_ifs.close();
 }
 
 bool windfile::ok()
 {
-  	return ifs.good();
+  	return m_ifs.good();
 }
 
 
@@ -321,8 +321,8 @@ bool windfile::open( const std::string &file )
 		return false;
 		*/
 
-	ifs.open(file);
-	if (!ifs.good())
+	m_ifs.open(file);
+	if (!m_ifs.good())
 	{
 		m_errorMsg = "could not open file for reading: " + file;
 		return false;
@@ -331,14 +331,14 @@ bool windfile::open( const std::string &file )
 	/* read header information */
 	
 	// read line 1 (header info)
-	std::getline(ifs, buf);
+	std::getline(m_ifs, m_buf);
 	std::vector<std::string> cols;
-	int ncols = locate2(buf, cols, ',');
+	int ncols = locate2(m_buf, cols, ',');
 
 	if (ncols < 8)
 	{
 		m_errorMsg = util::format("error reading header (line 1).  At least 8 columns required, %d found.", ncols);
-		ifs.close();
+		m_ifs.close();
 		return false;
 	}
 
@@ -357,16 +357,16 @@ bool windfile::open( const std::string &file )
 	catch (const std::invalid_argument &) {/* nothing to do */ };
 
 	// read line 2, description
-	std::getline(ifs, desc);
+	std::getline(m_ifs, desc);
 	trim(desc);
 	
 	// read line 3, column names (must be pressure, temperature, speed, direction)
-	std::getline(ifs, buf);
-	ncols = locate2(buf, cols, ',');
+	std::getline(m_ifs, m_buf);
+	ncols = locate2(m_buf, cols, ',');
 	if (ncols < 3)
 	{
 		m_errorMsg = util::format("too few data column types found: %d.  at least 3 required.", ncols);
-		ifs.close();
+		m_ifs.close();
 		return false;
 	}
 	
@@ -384,7 +384,7 @@ bool windfile::open( const std::string &file )
 		else if ( ctype.length() > 0 )
 		{
 			m_errorMsg = util::format( "error reading data column type specifier in col %d of %d: '%s' len: %d", i+1, ncols, ctype.c_str(), ctype.length() );
-			ifs.close();
+			m_ifs.close();
 			return false;
 		}
 	}
@@ -393,15 +393,15 @@ bool windfile::open( const std::string &file )
 
 
 	// read line 4, units for each column (ignore this for now)
-	std::getline(ifs, buf);
+	std::getline(m_ifs, m_buf);
 
 	// read line 5, height in meters for each data column
-	std::getline(ifs, buf);
-	ncols = locate2(buf, cols, ',');
+	std::getline(m_ifs, m_buf);
+	ncols = locate2(m_buf, cols, ',');
 	if ( ncols < (int)m_heights.size() )
 	{
 		m_errorMsg = util::format("too few columns in the height row.  %d required but only %d found", (int)m_heights.size(), ncols);
-		ifs.close();
+		m_ifs.close();
 		return false;
 	}
 
@@ -411,13 +411,13 @@ bool windfile::open( const std::string &file )
 
 	// read all the lines to determine the nubmer of records in the file
 	m_nrec = 0;
-	while (std::getline(ifs, buf))
+	while (std::getline(m_ifs, m_buf))
 		m_nrec++;
 
 	// rewind the file and reposition right after the header information
-	ifs.seekg(0);
+	m_ifs.seekg(0);
 	for (size_t i = 0; i < 5; i++)
-		std::getline(ifs, buf);
+		std::getline(m_ifs, m_buf);
 
 	
 	// ready to read line-by-line.  subsequent columns of data correspond to the
@@ -428,7 +428,7 @@ bool windfile::open( const std::string &file )
 
 void windfile::close()
 {
-  	ifs.close();
+  	m_ifs.close();
 
 	m_file.clear();
 	city.clear();
@@ -451,8 +451,8 @@ bool windfile::read_line( std::vector<double> &values )
 	if ( !ok() ) return false;
 
 	std::vector<std::string> cols;
-	std::getline(ifs, buf);
-	int ncols = locate2(buf, cols, ',');
+	std::getline(m_ifs, m_buf);
+	int ncols = locate2(m_buf, cols, ',');
 	if (ncols >= (int)m_heights.size() 
 		&& ncols >= (int)m_dataid.size())
 	{

--- a/shared/lib_windfile.cpp
+++ b/shared/lib_windfile.cpp
@@ -97,9 +97,6 @@ static int locate2(std::string buf, std::vector<std::string> &vstring, char deli
 	return (int)vstring.size();
 }
 
-#define MBUFLEN 4096
-
-
 winddata_provider::winddata_provider()
 {
 	year = 1900;
@@ -331,7 +328,7 @@ bool windfile::open( const std::string &file )
 	/* read header information */
 	
 	// read line 1 (header info)
-	std::getline(m_ifs, m_buf);
+	getline(m_ifs, m_buf);
 	std::vector<std::string> cols;
 	int ncols = locate2(m_buf, cols, ',');
 
@@ -357,12 +354,12 @@ bool windfile::open( const std::string &file )
 	catch (const std::invalid_argument &) {/* nothing to do */ };
 
 	// read line 2, description
-	std::getline(m_ifs, desc);
+	getline(m_ifs, desc);
 	trim(desc);
 	
 	// read line 3, column names (must be pressure, temperature, speed, direction)
-	std::getline(m_ifs, m_buf);
-	ncols = locate2(m_buf, cols, ',');
+	getline(m_ifs, m_buf);
+	ncols = locate2( m_buf, cols, ',' );
 	if (ncols < 3)
 	{
 		m_errorMsg = util::format("too few data column types found: %d.  at least 3 required.", ncols);
@@ -393,11 +390,11 @@ bool windfile::open( const std::string &file )
 
 
 	// read line 4, units for each column (ignore this for now)
-	std::getline(m_ifs, m_buf);
+	getline(m_ifs, m_buf);
 
 	// read line 5, height in meters for each data column
-	std::getline(m_ifs, m_buf);
-	ncols = locate2(m_buf, cols, ',');
+	getline(m_ifs, m_buf);
+	ncols = locate2( m_buf, cols, ',' );
 	if ( ncols < (int)m_heights.size() )
 	{
 		m_errorMsg = util::format("too few columns in the height row.  %d required but only %d found", (int)m_heights.size(), ncols);
@@ -411,13 +408,13 @@ bool windfile::open( const std::string &file )
 
 	// read all the lines to determine the nubmer of records in the file
 	m_nrec = 0;
-	while (std::getline(m_ifs, m_buf))
+	while (getline(m_ifs, m_buf))
 		m_nrec++;
 
 	// rewind the file and reposition right after the header information
 	m_ifs.seekg(0);
 	for (size_t i = 0; i < 5; i++)
-		std::getline(m_ifs, m_buf);
+		getline(m_ifs, m_buf);
 
 	
 	// ready to read line-by-line.  subsequent columns of data correspond to the
@@ -451,7 +448,7 @@ bool windfile::read_line( std::vector<double> &values )
 	if ( !ok() ) return false;
 
 	std::vector<std::string> cols;
-	std::getline(m_ifs, m_buf);
+	getline(m_ifs, m_buf);
 	int ncols = locate2(m_buf, cols, ',');
 	if (ncols >= (int)m_heights.size() 
 		&& ncols >= (int)m_dataid.size())

--- a/shared/lib_windfile.h
+++ b/shared/lib_windfile.h
@@ -114,8 +114,8 @@ protected:
 class windfile : public winddata_provider
 {
 private:
-  	std::ifstream ifs;
-	std::string buf;
+  	std::ifstream m_ifs;
+	std::string m_buf;
 	std::string m_file;
 	size_t m_nrec;
 

--- a/shared/lib_windfile.h
+++ b/shared/lib_windfile.h
@@ -51,6 +51,7 @@
 #define __lib_windfile_h
 
 #include <string>
+#include <fstream>
 #include "lib_util.h"
 
 class winddata_provider
@@ -113,8 +114,8 @@ protected:
 class windfile : public winddata_provider
 {
 private:
-	FILE *m_fp;
-	char *m_buf;
+  	std::ifstream ifs;
+	std::string buf;
 	std::string m_file;
 	size_t m_nrec;
 


### PR DESCRIPTION
This set of patches eliminates the use of the C fgets() function in favour of C++ streams. This eliminates lots of error-prone pointer arithmetic. This eliminates the last of the G++ warnings, so the last patch in this set enables -Werror.

Note that I renamed `locate` to `split` (as that is what it does!) and removed the arbitrary limitation on the maximum number of columns that can be handled.