### PR TITLE
solarpilot layout and optimization failing

### DIFF
--- a/ssc/cmod_solarpilot.cpp
+++ b/ssc/cmod_solarpilot.cpp
@@ -270,6 +270,13 @@ public:
 				throw exec_error("solarpilot", "failed to calculate a correct flux map table");
 
 		}
+		else 
+		{
+			//fluxmaps not required, so declare required variables and fill with zeros
+			ssc_number_t * opteff = allocate("opteff_table", 1, 3);
+			ssc_number_t * fluxdata = allocate("flux_table", 1, 1);
+		}
+
 	}
 };
 

--- a/ssc/cmod_solarpilot.cpp
+++ b/ssc/cmod_solarpilot.cpp
@@ -273,8 +273,8 @@ public:
 		else 
 		{
 			//fluxmaps not required, so declare required variables and fill with zeros
-			ssc_number_t * opteff = allocate("opteff_table", 1, 3);
-			ssc_number_t * fluxdata = allocate("flux_table", 1, 1);
+			allocate("opteff_table", 1, 3);
+			allocate("flux_table", 1, 1);
 		}
 
 	}


### PR DESCRIPTION
Replacing old code that was removed during compiler warning cleanup. Calls were needed to allocate arrays for output, even though return pointers weren't used and were causing warnings.