### PR TITLE
SolarPILOT post-layout calculations in a method

### DIFF
--- a/solarpilot/SolarField.h
+++ b/solarpilot/SolarField.h
@@ -242,6 +242,7 @@ public:
 	static bool DoLayout( SolarField *SF, sim_results *results, WeatherData *wdata, int sim_first=-1, int sim_last=-1);
 	void ProcessLayoutResults(sim_results *results, int nsim_total);	//Call after simulation for multithreaded apps
 	void ProcessLayoutResultsNoSim();	//Call after layout with no simulations to process
+	void UpdateLayoutAfterChange();  //update land, layout object, and solar field calculations after the layout has changed
 	static void AnnualEfficiencySimulation( SolarField &SF, sim_results &results); //, double *azs, double *zens, double *met);
 	static void AnnualEfficiencySimulation( std::string weather_file, SolarField *SF, sim_results &results); //, double *azs, double *zens, double *met);	//overload
 	bool UpdateNeighborList(double lims[4], double zen);


### PR DESCRIPTION
Several methods are needed to fully update after the layout has been modified. These are now in a single method that is called after layout, or after the layout has been altered. Fixes #149.

This change does not appear to affect SAM. 