### PR TITLE
Fix module coefficient generator for CdTe modules

### DIFF
--- a/shared/6par_newton.h
+++ b/shared/6par_newton.h
@@ -47,7 +47,8 @@
 *  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************************************/
 
-
+/// Newton Method using Line Search and Backtracking
+/// from Globally Convergent Methods for Nonlinear Systems of Equations, "Numerical Recipes in C"
 template< typename Real, typename F, int n >
 int newton( Real x[n], Real residual[n], bool &check, F &func, 
 	int MAXITER, const Real TOLF, const Real TOLMIN, const Real STPMX,

--- a/shared/6par_solve.h
+++ b/shared/6par_solve.h
@@ -129,7 +129,7 @@ public:
 		
 		f[5] = gamma - gPmp;
 	}
-	
+
 	bool exec(Real &_a, Real &_Il, Real &_Io, Real &_Rs, Real &_Rsh, Real &_Adj, 
 		int max_iter, double tol, notification_interface *nif )
 	{	
@@ -503,7 +503,7 @@ public:
 		int err = solve<Real>( max_iter, tol, nif );
 		
 		
-		if ( err < 0 && Type == Amorphous )
+		if ( err < 0 && (Type == Amorphous || Type == CdTe) )
 		{
 			// attempt decreasing 'a' and solving
 			int downattempt = 0;


### PR DESCRIPTION
The numerical [solver](http://www.aip.de/groups/soe/local/numres/bookcpdf/c9-7.pdf) (globally convergent newton method) is very sensitive to initial guesses. Effect on convergence due to differing initial guesses for each of the 6 parameters and uniqueness of convergent solution was explored over the search space. 

Due to large difference in magnitude of the parameters (1e-17 to 1e3), rescaling of the problem to unity was attempted but did not have any effect on convergence.

Since convergence was found to be dependent primarily on initial guess of 'a', the ideality factor, the method of iterating over different values of initial guesses for 'a', the same process which is currently done for Amorphous type modules, was implemented for CdTe type. 

For the given module specifications, searching over realistic range of 'a' provided two solutions. However, only one satisfied the "[sanity](http://solarenergyengineering.asmedigitalcollection.asme.org/article.aspx?articleid=1458865#d12)" check, so it can be accepted as unique. (And in fact, plotting the I-V curves produced by both solutions show very similar curves.)

All First Solar Series 6 Modules solve.

fix #129 