### PR TITLE
Fixes NREL/SAM#25

### DIFF
--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -59,6 +59,9 @@ public:
 	/// Create a PVIOManager object by parsing the compute model
 	PVIOManager(compute_module* cm, std::string cmName);
 
+	/// Allocate Outputs
+	void allocateOutputs(compute_module*  cm);
+
 	/// Return pointer to compute module
 	compute_module * getComputeModule();
 
@@ -79,7 +82,6 @@ public:
 
 	/// Get Shade Database
 	ShadeDB8_mpp * getShadeDatabase();
-
 
 public:
 
@@ -209,13 +211,13 @@ struct PVSystem_IO
 	bool enableSnowModel;	
 
 	int stringsInParallel;
-	double ratedACOutput;  /// AC Power rating for whole system (all inverters)
+	double ratedACOutput;  ///< AC Power rating for whole system (all inverters)
 
 	bool clipMpptWindow;
-	std::vector<std::vector<int> > mpptMapping;	///vector to hold the mapping between subarrays and mppt inputs
-	bool enableMismatchVoltageCalc;		/// Whether or not to compute mismatch between multiple subarrays attached to the same mppt input
+	std::vector<std::vector<int> > mpptMapping;	///< vector to hold the mapping between subarrays and mppt inputs
+	bool enableMismatchVoltageCalc;		///< Whether or not to compute mismatch between multiple subarrays attached to the same mppt input
 
-
+	std::vector<double> dcDegradationFactor; 
 	double acDerate;
 	double acLossPercent;
 	double transmissionDerate;

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1911,7 +1911,7 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 
 					//module degradation and lifetime DC losses apply to all subarrays
 					if (system_use_lifetime_output == 1)
-						dcPowerNetPerSubarray[nn] *= PVSystem->p_dcDegradationFactor[iyear + 1];
+						dcPowerNetPerSubarray[nn] *= PVSystem->dcDegradationFactor[iyear + 1];
 
 					//dc adjustment factors apply to all subarrays
 					if (iyear == 0) annual_dc_adjust_loss += dcPowerNetPerSubarray[nn] * (1 - dc_haf(hour)) * util::watt_to_kilowatt * ts_hour; //only keep track of this loss for year 0, convert from power W to energy kWh
@@ -1992,6 +1992,11 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 		}
 		// using single weather file initially - so rewind to use for next year
 		wdprov->rewind();
+
+		// Assign annual lifetime DC outputs
+		if (system_use_lifetime_output) {
+			PVSystem->p_dcDegradationFactor[iyear] = PVSystem->dcDegradationFactor[iyear];
+		}
 	}
 
 	// Initialize DC battery predictive controller
@@ -2127,11 +2132,13 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 		if (iyear == 0)
 		{
 			int year_idx = 0;
-			if (system_use_lifetime_output)
+			if (system_use_lifetime_output) {
 				year_idx = 1;
+			}
 			// accumulate DC power after the battery
-			if (en_batt && (batt_topology == ChargeController::DC_CONNECTED))
+			if (en_batt && (batt_topology == ChargeController::DC_CONNECTED)) {
 				annual_battery_loss = batt.outAnnualEnergyLoss[year_idx];
+			}
 		}
 	}
 
@@ -2180,7 +2187,7 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 				PVSystem->p_systemACPower[idx] *= haf(hour);
 
 				//apply lifetime daily AC losses only if they are enabled
-				if (system_use_lifetime_output == 1 && PVSystem->enableACLifetimeLosses)
+				if (system_use_lifetime_output && PVSystem->enableACLifetimeLosses)
 				{
 					//current index of the lifetime daily AC losses is the number of years that have passed (iyear, because it is 0-indexed) * days in a year + the number of complete days that have passed
 					int ac_loss_index = (int)iyear * 365 + (int)floor(hour / 24); //in units of days


### PR DESCRIPTION
This pull request attempts to make it less likely that a programmer will inadvertently try to use or assign to un-allocated outputs by forcing the allocation process to occur for all structures at the end of the construction of PVIOManager.

This pull request also creates an intermediate variable to store the lifetime dc degradation factor, which was previously being allocated at an output but calculated directly in the constructor of the PVSystem.  This was problematic once all output allocation was moved to to the end.  Typically outputs should be calculated with the compute module itself (pvsamv1), not in the IOManager, which is responsible for setting up inputs to the model and allocated the memory required for storing outputs.