### PR TITLE
flag class for pv_io_manager using safe bool idiom

### DIFF
--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -75,12 +75,8 @@ public:
 
 	/// safe bool conversion operator
 	operator bool_type() const {
-		return init ? &flag::safeBool : &flag::checkInit;
-	}
-
-	operator int() const {
 		checkInit();
-		return value;
+		return value ? &flag::safeBool : 0;
 	}
 
 	bool operator ==(const int testValue) {
@@ -419,7 +415,7 @@ public:
 	double groundCoverageRatio;			// The ground coverage ratio [0 - 1]
 	double tiltDegrees;					// The surface tilt [degrees]						
 	double azimuthDegrees;				// The surface azimuth [degrees]
-	flag trackMode;						// The tracking mode [0 = fixed, 1 = single-axis tracking, 2 = two-axis tracking, 3 = azimuth-axis tracking, 4 = seasonal-tilt
+	int trackMode;						// The tracking mode [0 = fixed, 1 = single-axis tracking, 2 = two-axis tracking, 3 = azimuth-axis tracking, 4 = seasonal-tilt
 	double trackerRotationLimitDegrees; // The rotational limit of the tracker [degrees]
 	flag tiltEqualLatitude;				// Set the tilt equal to the latitude
 	std::vector<double> monthlyTiltDegrees; // The seasonal tilt [degrees]
@@ -440,7 +436,7 @@ public:
 
 	// Shading and snow	
 	flag enableSelfShadingOutputs;		// Choose whether additional self-shading outputs are displayed
-	flag shadeMode;						// The shading mode of the subarray [0 = none, 1 = standard (non-linear), 2 = thin film (linear)]
+	int shadeMode;						// The shading mode of the subarray [0 = none, 1 = standard (non-linear), 2 = thin film (linear)]
 	flag usePOAFromWeatherFile;			// Flag for whether or not a shading model has been selected that means POA can't be used directly for that subarray
 	ssinputs selfShadingInputs;			// Inputs and calculation methods for self-shading of the subarray
 	ssoutputs selfShadingOutputs;		// Outputs for the self-shading of the subarray

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -44,6 +44,57 @@ struct Inverter_IO;
 struct PVSystem_IO;
 
 /**
+* \class flag
+*
+* This class implements error checking for bool or enum flags, such as checking for initialization
+* before use in comparisons. Allows only == and !=  operations with integral types and with other flags.
+*
+*/
+class flag
+{
+	typedef void (flag::*bool_type)() const;
+	void safeBool() const {}
+
+public:
+	bool init = false;
+	int value;				//< for enum or boolean values
+
+	/// set enum or implicit bool value
+	void operator =(int setValue) {
+		if (setValue <= -1)
+			return;
+		init = true;
+		value = setValue;
+	}
+
+	void checkInit() const {
+		if (!init)
+			throw compute_module::exec_error("PV IO Manager", 
+				"Flag used without initialization.");
+	}
+
+	/// safe bool conversion operator
+	operator bool_type() const {
+		return init ? &flag::safeBool : &flag::checkInit;
+	}
+
+	operator int() const {
+		checkInit();
+		return value;
+	}
+
+	bool operator ==(const int testValue) {
+		checkInit();
+		return (value == testValue);
+	}
+	bool operator !=(const int testValue) {
+		checkInit();
+		return (value != testValue);
+	}
+};
+
+
+/**
 * \class PVIOManager
 *
 * This class contains the input and output data needed by all of the submodels in the detailed PV model
@@ -142,14 +193,14 @@ struct Irradiance_IO
 	weather_record weatherRecord;								  /// Describes the weather data
 	weather_header weatherHeader;								  /// Describes the weather data header
 	double tsShiftHours;										  /// Sun position time offset
-	bool instantaneous;											  /// Describes whether the weather data is instantaneous (or not)
+	flag instantaneous;											  /// Describes whether the weather data is instantaneous (or not)
 	size_t numberOfWeatherFileRecords;							  /// The number of records in the weather file
 	size_t stepsPerHour;										  /// The number of steps per hour
 	size_t numberOfSubarrays;									  /// The number of subarrays (needed if reading POA data from weather file)
 	double dtHour;											      /// The timestep in hours
 	int radiationMode;											  /// Specify which components of radiance should be used: 0=B&D, 1=G&B, 2=G&D, 3=POA-Ref, 4=POA-Pyra
 	int skyModel;												  /// Specify which sky diffuse model should be used: 0=isotropic, 1=hdkr, 2=perez
-	bool useWeatherFileAlbedo;									  /// Specify whether to use the weather file albedo
+	flag useWeatherFileAlbedo;									  /// Specify whether to use the weather file albedo
 	std::vector<double> userSpecifiedMonthlyAlbedo;				  /// User can provide monthly ground albedo values (0-1)
 	
 	// Irradiance data Outputs (p_ is just a convention to organize all pointer outputs)
@@ -179,7 +230,7 @@ struct Simulation_IO
 	size_t numberOfSteps;
 	size_t stepsPerHour;
 	double dtHour;
-	bool useLifetimeOutput = 0;
+	flag useLifetimeOutput = { true, false};
 };
 
 /***
@@ -206,16 +257,16 @@ struct PVSystem_IO
 	std::unique_ptr<SharedInverter> m_sharedInverter;
 
 	// Inputs assumed to apply to all subarrays
-	bool enableDCLifetimeLosses;
-	bool enableACLifetimeLosses;
-	bool enableSnowModel;	
+	flag enableDCLifetimeLosses;
+	flag enableACLifetimeLosses;
+	flag enableSnowModel;
 
 	int stringsInParallel;
 	double ratedACOutput;  ///< AC Power rating for whole system (all inverters)
 
-	bool clipMpptWindow;
+	flag clipMpptWindow;
 	std::vector<std::vector<int> > mpptMapping;	///< vector to hold the mapping between subarrays and mppt inputs
-	bool enableMismatchVoltageCalc;		///< Whether or not to compute mismatch between multiple subarrays attached to the same mppt input
+	flag enableMismatchVoltageCalc;		///< Whether or not to compute mismatch between multiple subarrays attached to the same mppt input
 
 	std::vector<double> dcDegradationFactor; 
 	double acDerate;
@@ -357,7 +408,7 @@ public:
 	std::unique_ptr<Module_IO> Module; // The PV module for this subarray
 
 	// Inputs
-	bool enable;						// Whether or not the subarray is enabled
+	flag enable;						// Whether or not the subarray is enabled
 
 	// Electrical characteristics
 	size_t nStrings;					// Number of strings in the subarray
@@ -368,11 +419,11 @@ public:
 	double groundCoverageRatio;			// The ground coverage ratio [0 - 1]
 	double tiltDegrees;					// The surface tilt [degrees]						
 	double azimuthDegrees;				// The surface azimuth [degrees]
-	int trackMode;						// The tracking mode [0 = fixed, 1 = single-axis tracking, 2 = two-axis tracking, 3 = azimuth-axis tracking, 4 = seasonal-tilt
+	flag trackMode;						// The tracking mode [0 = fixed, 1 = single-axis tracking, 2 = two-axis tracking, 3 = azimuth-axis tracking, 4 = seasonal-tilt
 	double trackerRotationLimitDegrees; // The rotational limit of the tracker [degrees]
-	bool tiltEqualLatitude;				// Set the tilt equal to the latitude
+	flag tiltEqualLatitude;				// Set the tilt equal to the latitude
 	std::vector<double> monthlyTiltDegrees; // The seasonal tilt [degrees]
-	bool backtrackingEnabled;			// Backtracking enabled or not
+	flag backtrackingEnabled;			// Backtracking enabled or not
 	double moduleAspectRatio;			// The aspect ratio of the models used in the subarray
 	int nStringsBottom;					// Number of strings along bottom from self-shading
 
@@ -388,13 +439,13 @@ public:
 	double dcLossTotalPercent;			/// The DC loss due to mismatch, diodes, wiring, tracking, optimizers [%]
 
 	// Shading and snow	
-	bool enableSelfShadingOutputs;		// Choose whether additional self-shading outputs are displayed
-	int shadeMode;						// The shading mode of the subarray [0 = none, 1 = standard (non-linear), 2 = thin film (linear)]
-	bool usePOAFromWeatherFile;			// Flag for whether or not a shading model has been selected that means POA can't be used directly for that subarray
+	flag enableSelfShadingOutputs;		// Choose whether additional self-shading outputs are displayed
+	flag shadeMode;						// The shading mode of the subarray [0 = none, 1 = standard (non-linear), 2 = thin film (linear)]
+	flag usePOAFromWeatherFile;			// Flag for whether or not a shading model has been selected that means POA can't be used directly for that subarray
 	ssinputs selfShadingInputs;			// Inputs and calculation methods for self-shading of the subarray
 	ssoutputs selfShadingOutputs;		// Outputs for the self-shading of the subarray
 	shading_factor_calculator shadeCalculator; // The shading calculator model for self-shading
-	bool subarrayEnableSnow;            //a copy of the enableSnowModel flag has to exist in each subarray for setting up snow model inputs specific to each subarray
+	flag subarrayEnableSnow;            //a copy of the enableSnowModel flag has to exist in each subarray for setting up snow model inputs specific to each subarray
 	pvsnowmodel snowModel;				// A structure to store the geometry inputs for the snow model for this subarray- even though the snow model is system wide, its effect is subarray-dependent
 
 	/// Calculated plane-of-array (POA) irradiace for the subarray and related geometry
@@ -446,14 +497,14 @@ public:
 	double moduleWattsSTC;				/// The module energy output at STC [W]
 	double voltageMaxPower;				/// The voltage at max power [V]
 	double selfShadingFillFactor;		/// Self shading fill factor
-	bool isConcentratingPV;				/// If the sandia model is being used for CPV
-	bool isBifacial;					/// If the model is bifacial
+	flag isConcentratingPV;				/// If the sandia model is being used for CPV
+	flag isBifacial;					/// If the model is bifacial
 	double bifaciality;					/// The relative efficiency of the rearside to the front side
 	double bifacialTransmissionFactor;  /// Factor describing how much light can travel through the module
 	double groundClearanceHeight;		/// The ground clearance of a module [m]
 
-	bool simpleEfficiencyForceNoPOA;	/// Flag to avoid calling as_integer(...) repeatedly later on
-	bool mountingSpecificCellTemperatureForceNoPOA;
+	flag simpleEfficiencyForceNoPOA;	/// Flag to avoid calling as_integer(...) repeatedly later on
+	flag mountingSpecificCellTemperatureForceNoPOA;
 
 	spe_module_t simpleEfficiencyModel;
 	cec6par_module_t cecModel;

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -59,6 +59,9 @@ public:
 	/// Create a PVIOManager object by parsing the compute model
 	PVIOManager(compute_module* cm, std::string cmName);
 
+	/// Allocate Outputs
+	void allocateOutputs(compute_module*  cm);
+
 	/// Return pointer to compute module
 	compute_module * getComputeModule();
 
@@ -79,7 +82,6 @@ public:
 
 	/// Get Shade Database
 	ShadeDB8_mpp * getShadeDatabase();
-
 
 public:
 
@@ -209,13 +211,13 @@ struct PVSystem_IO
 	bool enableSnowModel;	
 
 	int stringsInParallel;
-	double ratedACOutput;  /// AC Power rating for whole system (all inverters)
+	double ratedACOutput;  ///< AC Power rating for whole system (all inverters)
 
 	bool clipMpptWindow;
-	std::vector<std::vector<int> > mpptMapping;	///vector to hold the mapping between subarrays and mppt inputs
-	bool enableMismatchVoltageCalc;		/// Whether or not to compute mismatch between multiple subarrays attached to the same mppt input
+	std::vector<std::vector<int> > mpptMapping;	///< vector to hold the mapping between subarrays and mppt inputs
+	bool enableMismatchVoltageCalc;		///< Whether or not to compute mismatch between multiple subarrays attached to the same mppt input
 
-
+	std::vector<double> dcDegradationFactor; 
 	double acDerate;
 	double acLossPercent;
 	double transmissionDerate;

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1911,7 +1911,7 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 
 					//module degradation and lifetime DC losses apply to all subarrays
 					if (system_use_lifetime_output == 1)
-						dcPowerNetPerSubarray[nn] *= PVSystem->p_dcDegradationFactor[iyear + 1];
+						dcPowerNetPerSubarray[nn] *= PVSystem->dcDegradationFactor[iyear + 1];
 
 					//dc adjustment factors apply to all subarrays
 					if (iyear == 0) annual_dc_adjust_loss += dcPowerNetPerSubarray[nn] * (1 - dc_haf(hour)) * util::watt_to_kilowatt * ts_hour; //only keep track of this loss for year 0, convert from power W to energy kWh
@@ -1992,6 +1992,11 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 		}
 		// using single weather file initially - so rewind to use for next year
 		wdprov->rewind();
+
+		// Assign annual lifetime DC outputs
+		if (system_use_lifetime_output) {
+			PVSystem->p_dcDegradationFactor[iyear] = PVSystem->dcDegradationFactor[iyear];
+		}
 	}
 
 	// Initialize DC battery predictive controller
@@ -2127,11 +2132,13 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 		if (iyear == 0)
 		{
 			int year_idx = 0;
-			if (system_use_lifetime_output)
+			if (system_use_lifetime_output) {
 				year_idx = 1;
+			}
 			// accumulate DC power after the battery
-			if (en_batt && (batt_topology == ChargeController::DC_CONNECTED))
+			if (en_batt && (batt_topology == ChargeController::DC_CONNECTED)) {
 				annual_battery_loss = batt.outAnnualEnergyLoss[year_idx];
+			}
 		}
 	}
 
@@ -2180,7 +2187,7 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 				PVSystem->p_systemACPower[idx] *= haf(hour);
 
 				//apply lifetime daily AC losses only if they are enabled
-				if (system_use_lifetime_output == 1 && PVSystem->enableACLifetimeLosses)
+				if (system_use_lifetime_output && PVSystem->enableACLifetimeLosses)
 				{
 					//current index of the lifetime daily AC losses is the number of years that have passed (iyear, because it is 0-indexed) * days in a year + the number of complete days that have passed
 					int ac_loss_index = (int)iyear * 365 + (int)floor(hour / 24); //in units of days


### PR DESCRIPTION
Added flag class to lib_pv_io_manager.h as a wrapper for a bool/int value that is used for equality comparisons in pv_io_manager. The class implements an initialization check before each comparison is evaluated. Common comparison usages such as (flag), (flag == x) and (flag != x) overloaded with initCheck.

Mostly follows https://www.artima.com/cppsource/safeboolP.html. Disallowing comparisons to other types using templated overload was not used in order to allow comparisons given implicit conversion of enum values to int (otherwise a comparison with an enum could use both the int and templated version, resulting in error).

Since the flag class is intended for *_IO_Managers, I left it in lib_pv_io_manager.h for now. Perhaps if we had several *_IO_Managers in the future, then we could separate it.