### PR TITLE
fix(): Address bugs and increase usability of ml module model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,6 +337,8 @@ build_linux/config.status
 linux_test\.txt
 
 nlopt/config\.h
+nlopt/config.h
+build_osx/config.status
 
 doc/html/*
 doc/latex/*


### PR DESCRIPTION
Fixes #229, #227 and provides a short-term fix for #228. For now, changed ml model so that it calculates efficiency like the other models, i.e. 

eff = P / (module_area * POA_shaded_soiled)

However, the larger question of how module efficiency _should_ be calculated consistently remains open.