### PR TITLE
Updates to fix sunrise/sunset bug at very high latitudes

### DIFF
--- a/shared/lib_irradproc.cpp
+++ b/shared/lib_irradproc.cpp
@@ -1097,7 +1097,7 @@ int irrad::calc()
 	double t_sunrise = sunAnglesRadians[4];
 	double t_sunset = sunAnglesRadians[5];
 
-	if (t_sunset > 24) //sunset is legitimately the next day, so recalculate sunset from the previous day
+	if (t_sunset > 24.0 && t_sunset != 100.0) //sunset is legitimately the next day but we're not in endless days, so recalculate sunset from the previous day
 	{
 		double sunanglestemp[9];
 		if (day > 1) //simply decrement day during month
@@ -1106,12 +1106,15 @@ int irrad::calc()
 			solarpos(year, month - 1, __nday[month - 2], 12, 0.0, latitudeDegrees, longitudeDegrees, timezone, sunanglestemp); //month is 1-indexed and __nday is 0 indexed
 		else //on the first day of the year, need to switch to Dec 31 of last year
 			solarpos(year - 1, 12, 31, 12, 0.0, latitudeDegrees, longitudeDegrees, timezone, sunanglestemp);
+		//on the last day of endless days, sunset is returned as 100 (hour angle too large for calculation), so use today's sunset time as a proxy
+		if (sunanglestemp[5] == 100.0)
+			t_sunset -= 24.0;		
 		//if sunset from yesterday WASN'T today, then it's ok to leave sunset > 24, which will cause the sun to rise today and not set today
-		if (sunanglestemp[5] >= 24)
+		else if (sunanglestemp[5] >= 24.0)
 			t_sunset = sunanglestemp[5] - 24.0;
 	}
 
-	if (t_sunrise < 0) //sunrise is legitimately the previous day, so recalculate for next day
+	if (t_sunrise < 0.0 && t_sunrise != -100.0) //sunrise is legitimately the previous day but we're not in endless days, so recalculate for next day
 	{
 		double sunanglestemp[9];
 		if (day < __nday[month - 1]) //simply increment the day during the month, month is 1-indexed and __nday is 0-indexed
@@ -1120,8 +1123,11 @@ int irrad::calc()
 			solarpos(year, month + 1, 1, 12, 0.0, latitudeDegrees, longitudeDegrees, timezone, sunanglestemp);
 		else //on the last day of the year, need to switch to Jan 1 of the next year
 			solarpos(year + 1, 1, 1, 12, 0.0, latitudeDegrees, longitudeDegrees, timezone, sunanglestemp);
+		//on the last day of endless days, sunrise would be returned as -100 (hour angle too large for calculations), so use today's sunrise time as a proxy
+		if (sunanglestemp[4] == -100.0)
+			t_sunrise += 24.0;		
 		//if sunrise from tomorrow isn't today, then it's ok to leave sunrise < 0, which will cause the sun to set at the right time and not rise until tomorrow
-		if (sunanglestemp[4] < 0)
+		else if (sunanglestemp[4] < 0.0)
 			t_sunrise = sunanglestemp[4] + 24.0;
 	}
 

--- a/test/shared_test/lib_irradproc_test.cpp
+++ b/test/shared_test/lib_irradproc_test.cpp
@@ -72,15 +72,16 @@ TEST_F(IrradTest, sunriseAndSunsetAtDifferentLocationsTest_lib_irradproc) {
 	location near the international dateline with positive longitude and negative time zone: Lomaji, Fiji
 	arctic circle: Kotzebue, Alaska
 	arctic circle #2: Point Hope, Alaska
+	arctic circle #3: Kotzebue, Alaska on the first day of continuous days
 	*/
 	e = 0.001;
-	vector<double> latitudes = { 39.77, 52.5, -12.03, 40.43, -17.75, 66.9, 68.35 };
-	vector<double> longitudes = { -105.22, 13.3, -77.06, -3.72, -179.3, -162.6, -166.8 };
-	vector<double> time_zones = { -7, 1, -5, 1, 12, -9, -9 };
-	vector<double> sunrise_times = { 4.636, 3.849, 6.521, 5.833, 6.513, -100.0, 2.552 };
-	vector<double> sunset_times = { 19.455, 20.436, 17.814, 20.723, 17.449, 100.0, 25.885 };
-	vector<int> month = { 6, 6, 6, 6, 6, 6, 7 };
-	vector<int> day = { 21, 21, 21, 21, 21, 21, 14 };
+	vector<double> latitudes = { 39.77, 52.5, -12.03, 40.43, -17.75, 66.9, 68.35, 66.9 };
+	vector<double> longitudes = { -105.22, 13.3, -77.06, -3.72, -179.3, -162.6, -166.8, -162.6 };
+	vector<double> time_zones = { -7, 1, -5, 1, 12, -9, -9, -9 };
+	vector<double> sunrise_times = { 4.636, 3.849, 6.521, 5.833, 6.513, -100.0, 2.552, -100.0 };
+	vector<double> sunset_times = { 19.455, 20.436, 17.814, 20.723, 17.449, 100.0, 25.885, 100.0 };
+	vector<int> month = { 6, 6, 6, 6, 6, 6, 7, 6 };
+	vector<int> day = { 21, 21, 21, 21, 21, 21, 14, 11 };
 
 
 	double sun_results[9]; //vector to hold the results of solarpos function

--- a/test/shared_test/lib_irradproc_test.cpp
+++ b/test/shared_test/lib_irradproc_test.cpp
@@ -77,8 +77,8 @@ TEST_F(IrradTest, sunriseAndSunsetAtDifferentLocationsTest_lib_irradproc) {
 	vector<double> latitudes = { 39.77, 52.5, -12.03, 40.43, -17.75, 66.9, 68.35 };
 	vector<double> longitudes = { -105.22, 13.3, -77.06, -3.72, -179.3, -162.6, -166.8 };
 	vector<double> time_zones = { -7, 1, -5, 1, 12, -9, -9 };
-	vector<double> sunrise_times = { 4.636, 3.849, 6.521, 5.833, 6.513, -1.0, 2.552 };
-	vector<double> sunset_times = { 19.455, 20.436, 17.814, 20.723, 17.449, 25.0, 25.885 };
+	vector<double> sunrise_times = { 4.636, 3.849, 6.521, 5.833, 6.513, -100.0, 2.552 };
+	vector<double> sunset_times = { 19.455, 20.436, 17.814, 20.723, 17.449, 100.0, 25.885 };
 	vector<int> month = { 6, 6, 6, 6, 6, 6, 7 };
 	vector<int> day = { 21, 21, 21, 21, 21, 21, 14 };
 

--- a/test/shared_test/lib_irradproc_test.cpp
+++ b/test/shared_test/lib_irradproc_test.cpp
@@ -71,19 +71,23 @@ TEST_F(IrradTest, sunriseAndSunsetAtDifferentLocationsTest_lib_irradproc) {
 	location near Greenwich meridian with negative longitude and positive time zone: Madrid Spain
 	location near the international dateline with positive longitude and negative time zone: Lomaji, Fiji
 	arctic circle: Kotzebue, Alaska
+	arctic circle #2: Point Hope, Alaska
 	*/
 	e = 0.001;
-	vector<double> latitudes = { 39.77, 52.5, -12.03, 40.43, -17.75, 66.9 };
-	vector<double> longitudes = { -105.22, 13.3, -77.06, -3.72, -179.3, -162.6 };
-	vector<double> time_zones = { -7, 1, -5, 1, 12, -9 };
-	vector<double> sunrise_times = { 4.636, 3.849, 6.521, 5.833, 6.513, 0 };
-	vector<double> sunset_times = { 19.455, 20.436, 17.814, 20.723, 17.449, 24 };
+	vector<double> latitudes = { 39.77, 52.5, -12.03, 40.43, -17.75, 66.9, 68.35 };
+	vector<double> longitudes = { -105.22, 13.3, -77.06, -3.72, -179.3, -162.6, -166.8 };
+	vector<double> time_zones = { -7, 1, -5, 1, 12, -9, -9 };
+	vector<double> sunrise_times = { 4.636, 3.849, 6.521, 5.833, 6.513, -1.0, 2.552 };
+	vector<double> sunset_times = { 19.455, 20.436, 17.814, 20.723, 17.449, 25.0, 25.885 };
+	vector<int> month = { 6, 6, 6, 6, 6, 6, 7 };
+	vector<int> day = { 21, 21, 21, 21, 21, 21, 14 };
+
 
 	double sun_results[9]; //vector to hold the results of solarpos function
 	for (int i = 0; i < latitudes.size(); i++)
 	{
 		//run the solarpos function and check sunrise and sunset for each location
-		solarpos(2010, 6, 21, 14, 30, latitudes[i], longitudes[i], time_zones[i], sun_results);
+		solarpos(2010, month[i], day[i], 14, 30, latitudes[i], longitudes[i], time_zones[i], sun_results);
 		EXPECT_NEAR((double)sun_results[4], sunrise_times[i], e) << "sunrise time for lat " << latitudes[i] << " long " << longitudes[i] << " failed\n";
 		EXPECT_NEAR((double)sun_results[5], sunset_times[i], e) << "sunset time for lat" << latitudes[i] << " long " << longitudes[i] << "failed\n";
 	}
@@ -233,7 +237,7 @@ TEST_F(NightCaseIrradProc, CalcTestRadMode0_lib_irradproc){
 	irr_hourly_night.get_irrad(&rad_p[0], &rad_p[1], &rad_p[2]);
 
 	sun_p[6] = (double)sunup;
-	vector<double> sun_solution = { -999, -999, -999, 20.795182, 5.711921, 19.515852, 0, 0.968315, 11.386113, 1286.786711 };
+	vector<double> sun_solution = { 15.400603, 125.406063, -35.406063, 20.874693, 5.707588, 19.519211, 0, 0.968315, 0.886600, 0 };
 	for (int i = 0; i < 10; i++){
 		EXPECT_NEAR(sun_p[i], sun_solution[i], e) << "hourly_night, sun parameter " << i << " fail\n";
 	}
@@ -258,7 +262,7 @@ TEST_F(NightCaseIrradProc, CalcTestRadMode0_lib_irradproc){
 	irr_15m_night.get_irrad(&rad_p[0], &rad_p[1], &rad_p[2]);
 
 	sun_p[6] = (double)sunup;
-	sun_solution = { -999, -999, -999, 20.795182, 5.711921, 19.515852, 0, 0.968315, 11.386113, 1286.786711 };
+	sun_solution = { 11.146986, 126.137563, -36.137563, 20.876572, 5.707486, 19.519211, 0, 0.968315, 0.636612, 0 };
 	for (int i = 0; i < 10; i++){
 		EXPECT_NEAR(sun_p[i], sun_solution[i], e) << "15m_night, sun parameter " << i << " fail\n";
 	}


### PR DESCRIPTION
Updated previous fix to be a more robust fix for sunrise and sunset calculations at high latitudes. This includes calculating sunrise and sunset correctly and allowing power to be calculated when the sunset occurs on the next day (e.g. sunset is at 1:30AM from the previous day, sunrise is at 2:30AM that day). Added a test for the days where the high latitude locations proved problematic. In this update, also changed the nighttime sun angles that are reported so that they represent real values calculated at the actual time in question, and updated the NightCase irradproc tests accordingly (previously, the angles were either set to -999 or leftover values from calculating at noon that day).

I would appreciate a review on these changes and some testing by @cpaulgilman to confirm that they make sense.