### PR TITLE
feat(): Apply diffuse self-shading in all racking/shade-behavior scenarios and improve self-shading algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,7 +339,6 @@ nlopt/config.status
 build_osx/config.status
 build_sdk/sdk-release/linux64/dependencies\.txt
 build_sdk/sdk-release/linux64/filetypes\.txt
-
 doc/html/*
 doc/latex/*
 build_linux/linux_errors

--- a/build_osx/config.status
+++ b/build_osx/config.status
@@ -427,7 +427,7 @@ Copyright (C) 2012 Free Software Foundation, Inc.
 This config.status script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it."
 
-ac_pwd='/Users/imacuser/Public/Projects/GitHub/NREL/ssc/build_osx'
+ac_pwd='/Users/caseyzak/repos/sam_dev/ssc/build_osx'
 srcdir='../nlopt'
 test -n "$AWK" || AWK=awk
 # The default lists apply if the user does not specify any file.

--- a/shared/lib_pv_io_manager.cpp
+++ b/shared/lib_pv_io_manager.cpp
@@ -363,7 +363,7 @@ Subarray_IO::Subarray_IO(compute_module* cm, std::string cmName, size_t subarray
 		selfShadingInputs.nstrx = selfShadingInputs.nmodx / nModulesPerString;
 		poa.nonlinearDCShadingDerate = 1;
 
-		if (trackMode == irrad::FIXED_TILT || trackMode == irrad::SEASONAL_TILT || (trackMode == irrad::SINGLE_AXIS && !backtrackingEnabled))
+		if (trackMode == irrad::FIXED_TILT || trackMode == irrad::SEASONAL_TILT || (trackMode == irrad::SINGLE_AXIS))
 		{
 			if (shadeMode != NO_SHADING)
 			{

--- a/shared/lib_pvshade.cpp
+++ b/shared/lib_pvshade.cpp
@@ -2,7 +2,7 @@
 *  Copyright 2017 Alliance for Sustainable Energy, LLC
 *
 *  NOTICE: This software was developed at least in part by Alliance for Sustainable Energy, LLC
-*  (“Alliance”) under Contract No. DE-AC36-08GO28308 with the U.S. Department of Energy and the U.S.
+*  (ï¿½Allianceï¿½) under Contract No. DE-AC36-08GO28308 with the U.S. Department of Energy and the U.S.
 *  The Government retains for itself and others acting on its behalf a nonexclusive, paid-up,
 *  irrevocable worldwide license in the software to reproduce, prepare derivative works, distribute
 *  copies to the public, perform publicly and display publicly, and to permit others to do so.
@@ -26,8 +26,8 @@
 *  4. Redistribution of this software, without modification, must refer to the software by the same
 *  designation. Redistribution of a modified version of this software (i) may not refer to the modified
 *  version by the same designation, or by any confusingly similar designation, and (ii) must refer to
-*  the underlying software originally provided by Alliance as “System Advisor Model” or “SAM”. Except
-*  to comply with the foregoing, the terms “System Advisor Model”, “SAM”, or any confusingly similar
+*  the underlying software originally provided by Alliance as ï¿½System Advisor Modelï¿½ or ï¿½SAMï¿½. Except
+*  to comply with the foregoing, the terms ï¿½System Advisor Modelï¿½, ï¿½SAMï¿½, or any confusingly similar
 *  designation may not be used to refer to any modified version of this software or any modified
 *  version of the underlying software originally provided by Alliance without the prior written consent
 *  of Alliance.
@@ -310,7 +310,7 @@ Chris Deline 4/9/2012 - updated 4/19/2012 - update 4/23/2012
 see SAM shade geometry_v2.docx
 Updated 1/18/13 to match new published coefficients in Solar Energy "A simplified model of uniform shading in large photovoltaic arrays"
 
-Definitions of X and S in SAM for the four layout conditions – portrait, landscape and vertical / horizontal strings.
+Definitions of X and S in SAM for the four layout conditions ï¿½ portrait, landscape and vertical / horizontal strings.
 Definitions:
 S: Fraction of submodules that are shaded in a given parallel string
 X: Fraction of parallel strings in the system that are shaded
@@ -466,6 +466,11 @@ bool ss_exec(
 		//relative shaded area, Applebaum equation A15
 		double relative_shaded_area = Hs * (m_row_length - g) / (m_A * m_row_length); //numerator is shadow area, denom is row area
 		outputs.m_shade_frac_fixed = relative_shaded_area;
+		//determine reduction of diffuse incident on shaded sections due to self-shading (beam is not derated because that shading is taken into account in dc derate)
+	    diffuse_reduce( solzen, tilt, Gb_nor, Gd_poa, m_B/m_R, mask_angle, albedo, m_r,
+		// outputs
+		outputs.m_reduced_diffuse, outputs.m_diffuse_derate, outputs.m_reduced_reflected, outputs.m_reflected_derate );
+
 		return true;
 	}
 

--- a/shared/lib_pvshade.cpp
+++ b/shared/lib_pvshade.cpp
@@ -213,20 +213,32 @@ void diffuse_reduce(
 	double Gbh = Gb_nor * cosd(solzen); // beam irradiance on horizontal surface
 	// double poa_sky_iso = Gdh * (1 + cosd(stilt)) / 2;
 
-	// sky diffuse reduction
-    double arg = (gcr * cosd(stilt) - 1) / (gcr * sind(stilt));
-    double gamma = (-M_PI / 2) + atan(arg);
-    double Asky_shade = M_PI + M_PI / pow((1 + pow(tan(stilt * DTOR + gamma), 2)), 0.5);
-    if ((stilt * DTOR + gamma) > (M_PI / 2))
-	{
-		Asky_shade = 2 * M_PI - Asky_shade;
-	}
-	double Asky = M_PI + M_PI / pow((1 + pow(tan(stilt * DTOR), 2)), 0.5);
-	Fskydiff = Asky_shade / Asky;
-	reduced_skydiff = Fskydiff * poa_sky;
-
 	double B = 1.0;
 	double R = B / gcr;
+
+	// sky diffuse reduction
+	double step = 1.0 / 1000.0;
+	double g = 0.0;
+	Fskydiff = 0.0;
+	for (int n = 0; n < 1000; n++)
+	{
+        g = n * step;
+        double arg = (1 / tand(stilt)) - (1 / (gcr * sind(stilt) * (1 - g)));
+        double gamma = (-M_PI / 2) + atan(arg);
+        double Asky_shade = M_PI + M_PI / pow((1 + pow(tan(stilt * DTOR + gamma), 2)), 0.5);
+        double Asky = M_PI + M_PI / pow((1 + pow(tan(stilt * DTOR), 2)), 0.5);
+        if (isnan(Asky_shade))
+        {
+            Asky_shade = Asky;
+        }
+        else if ((stilt * DTOR + gamma) > (M_PI / 2))
+        {
+            Asky_shade = 2 * M_PI - Asky_shade;
+        }
+        else {}
+        Fskydiff += (Asky_shade / Asky) * step;
+	}
+	reduced_skydiff = Fskydiff * poa_sky;
 
 	double solalt = 90 - solzen;
 

--- a/shared/lib_pvshade.cpp
+++ b/shared/lib_pvshade.cpp
@@ -211,12 +211,18 @@ void diffuse_reduce(
 
 	// view factor  and shade derate calculations assume isotropic sky
 	double Gbh = Gb_nor * cosd(solzen); // beam irradiance on horizontal surface
-	double poa_sky_iso = Gdh * (1 + cosd(stilt)) / 2;
+	// double poa_sky_iso = Gdh * (1 + cosd(stilt)) / 2;
 
 	// sky diffuse reduction
-
-	double reduced_skydiff_iso = poa_sky_iso - Gdh*(1 - pow(cosd(phi0 / 2), 2))*(nrows - 1.0) / nrows;
-	Fskydiff = reduced_skydiff_iso / poa_sky_iso;
+    double arg = (gcr * cosd(stilt) - 1) / (gcr * sind(stilt));
+    double gamma = (-M_PI / 2) + atand(arg);
+    double Asky_shade = M_PI + M_PI / pow((1 + pow(tand(stilt + gamma), 2)), 0.5);
+    if ((stilt + gamma) > (M_PI / 2))
+	{
+		Asky_shade = 2 * M_PI - Asky_shade;
+	}
+	double Asky = M_PI + M_PI / pow((1 + pow(tand(stilt), 2)), 0.5);
+	Fskydiff = Asky_shade / Asky;
 	reduced_skydiff = Fskydiff * poa_sky;
 
 	double B = 1.0;

--- a/shared/lib_pvshade.cpp
+++ b/shared/lib_pvshade.cpp
@@ -215,13 +215,13 @@ void diffuse_reduce(
 
 	// sky diffuse reduction
     double arg = (gcr * cosd(stilt) - 1) / (gcr * sind(stilt));
-    double gamma = (-M_PI / 2) + atand(arg);
-    double Asky_shade = M_PI + M_PI / pow((1 + pow(tand(stilt + gamma), 2)), 0.5);
-    if ((stilt + gamma) > (M_PI / 2))
+    double gamma = (-M_PI / 2) + atan(arg);
+    double Asky_shade = M_PI + M_PI / pow((1 + pow(tan(stilt * DTOR + gamma), 2)), 0.5);
+    if ((stilt * DTOR + gamma) > (M_PI / 2))
 	{
 		Asky_shade = 2 * M_PI - Asky_shade;
 	}
-	double Asky = M_PI + M_PI / pow((1 + pow(tand(stilt), 2)), 0.5);
+	double Asky = M_PI + M_PI / pow((1 + pow(tan(stilt * DTOR), 2)), 0.5);
 	Fskydiff = Asky_shade / Asky;
 	reduced_skydiff = Fskydiff * poa_sky;
 

--- a/shared/lib_pvshade.h
+++ b/shared/lib_pvshade.h
@@ -2,7 +2,7 @@
 *  Copyright 2017 Alliance for Sustainable Energy, LLC
 *
 *  NOTICE: This software was developed at least in part by Alliance for Sustainable Energy, LLC
-*  (“Alliance”) under Contract No. DE-AC36-08GO28308 with the U.S. Department of Energy and the U.S.
+*  (ï¿½Allianceï¿½) under Contract No. DE-AC36-08GO28308 with the U.S. Department of Energy and the U.S.
 *  The Government retains for itself and others acting on its behalf a nonexclusive, paid-up,
 *  irrevocable worldwide license in the software to reproduce, prepare derivative works, distribute
 *  copies to the public, perform publicly and display publicly, and to permit others to do so.
@@ -26,8 +26,8 @@
 *  4. Redistribution of this software, without modification, must refer to the software by the same
 *  designation. Redistribution of a modified version of this software (i) may not refer to the modified
 *  version by the same designation, or by any confusingly similar designation, and (ii) must refer to
-*  the underlying software originally provided by Alliance as “System Advisor Model” or “SAM”. Except
-*  to comply with the foregoing, the terms “System Advisor Model”, “SAM”, or any confusingly similar
+*  the underlying software originally provided by Alliance as ï¿½System Advisor Modelï¿½ or ï¿½SAMï¿½. Except
+*  to comply with the foregoing, the terms ï¿½System Advisor Modelï¿½, ï¿½SAMï¿½, or any confusingly similar
 *  designation may not be used to refer to any modified version of this software or any modified
 *  version of the underlying software originally provided by Alliance without the prior written consent
 *  of Alliance.
@@ -83,19 +83,23 @@ bool selfshade_simple(
 
 
 void diffuse_reduce( 
-		double solzen,
-		double stilt,
-		double Gb_nor,
-		double Gd_poa,
-		double gcr,
-		double phi0, // mask angle (degrees)
-		double alb,
-		double nrows,
-		
-		double &reduced_skydiff,
-		double &Fskydiff,
-		double &reduced_gnddiff,
-		double &Fgnddiff );
+	// inputs (angles in degrees)
+	double solzen,
+	double stilt,
+	double Gb_nor,
+	double Gdh,
+	double poa_sky,
+	double poa_gnd,
+	double gcr,
+	double phi0, // mask angle
+	double alb,
+	double nrows,
+
+	// outputs
+	double &reduced_skydiff,
+	double &Fskydiff,  // derate factor on sky diffuse
+	double &reduced_gnddiff,
+	double &Fgnddiff); // derate factor on ground diffuse
 
 
 
@@ -156,8 +160,10 @@ bool ss_exec(
 	double solzen,		// solar zenith (deg)
 	double solazi,		// solar azimuth (deg)
 	double Gb_nor,		// beam normal irradiance (W/m2)
+	double Gdh,         // diffuse horizontal irradiance (W/m2)
 	double Gb_poa,		// POA beam irradiance (W/m2)
-	double Gd_poa,		// POA diffuse, sky+gnd (W/m2)
+	double poa_sky,		// POA diffuse sky irradiance (W/m2)
+	double poa_gnd,     // POA diffuse gnd irradiance (W/m2)
 	double albedo,		// used to calculate reduced relected irradiance
 	bool trackmode,		// 0 for fixed tilt, 1 for one-axis tracking
 	bool linear,		// 0 for non-linear shading (C. Deline's full algorithm), 1 to stop at linear shading

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1408,7 +1408,7 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 
 					//self-shading calculations
 					if (((Subarrays[nn]->trackMode == 0 || Subarrays[nn]->trackMode == 4) && (Subarrays[nn]->shadeMode == 1 || Subarrays[nn]->shadeMode == 2)) //fixed tilt or timeseries tilt, self-shading (linear or non-linear) OR
-						|| (Subarrays[nn]->trackMode == 1 && (Subarrays[nn]->shadeMode == 1 || Subarrays[nn]->shadeMode == 2) && Subarrays[nn]->backtrackingEnabled == 0)) //one-axis tracking, self-shading, not backtracking
+						|| (Subarrays[nn]->trackMode == 1 && (Subarrays[nn]->shadeMode == 1 || Subarrays[nn]->shadeMode == 2))) //one-axis tracking, self-shading (linear or non-linear)
 					{
 
 						if (radmode == irrad::POA_R || radmode == irrad::POA_P){
@@ -1422,46 +1422,75 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 						bool linear = (Subarrays[nn]->shadeMode == 2); //0 for full self-shading, 1 for linear self-shading
 
 						//geometric fraction of the array that is shaded for one-axis trackers.
-						//USES A DIFFERENT FUNCTION THAN THE SELF-SHADING BECAUSE SS IS MEANT FOR FIXED ONLY. shadeFraction1x IS FOR ONE-AXIS TRACKERS ONLY.
+						//USES A DIFFERENT FUNCTION THAN THE SELF-SHADING BECAUSE SS IS MEANT FOR FIXED ONLY. shadeFraction1x IS FOR TRUE-TRACKING ONE-AXIS TRACKERS ONLY.
 						//used in the non-linear self-shading calculator for one-axis tracking only
-						double shad1xf = 0;
-						if (trackbool)
-							shad1xf = shadeFraction1x(solazi, solzen, Subarrays[nn]->tiltDegrees, Subarrays[nn]->azimuthDegrees, Subarrays[nn]->groundCoverageRatio, rot);
+						double shad1xf = 0.0;
+						if (trackbool && (Subarrays[nn]->backtrackingEnabled == false))
+						    shad1xf = shadeFraction1x(solazi, solzen, Subarrays[nn]->tiltDegrees, Subarrays[nn]->azimuthDegrees, Subarrays[nn]->groundCoverageRatio, rot);
 
 						//execute self-shading calculations
 						ssc_number_t beam_to_use; //some self-shading calculations require DNI, NOT ibeam (beam in POA). Need to know whether to use DNI from wf or calculated, depending on radmode
 						if (radmode == irrad::DN_DF || radmode == irrad::DN_GH) beam_to_use = (ssc_number_t)wf.dn;
 						else beam_to_use = Irradiance->p_IrradianceCalculated[2][hour * step_per_hour]; // top of hour in first year
 
-						if (linear && trackbool) //one-axis linear
+						if (ss_exec(Subarrays[nn]->selfShadingInputs, stilt, sazi, solzen, solazi, beam_to_use, ibeam, (iskydiff + ignddiff), alb, trackbool, linear, shad1xf, Subarrays[nn]->selfShadingOutputs))
 						{
-							ibeam *= (1 - shad1xf); //derate beam irradiance linearly by the geometric shading fraction calculated above per Chris Deline 2/10/16
-							beam_shading_factor *= (1 - shad1xf);
-							if (iyear == 0)
-							{
-								PVSystem->p_derateSelfShading[nn][idx] = (ssc_number_t)1;
-								PVSystem->p_derateLinear[nn][idx] = (ssc_number_t)(1 - shad1xf);
-								PVSystem->p_derateSelfShadingDiffuse[nn][idx] = (ssc_number_t)1; //no diffuse derate for linear shading
-								PVSystem->p_derateSelfShadingReflected[nn][idx] = (ssc_number_t)1; //no reflected derate for linear shading
-							}
-						}
 
-						else if (ss_exec(Subarrays[nn]->selfShadingInputs, stilt, sazi, solzen, solazi, beam_to_use, ibeam, (iskydiff + ignddiff), alb, trackbool, linear, shad1xf, Subarrays[nn]->selfShadingOutputs))
-						{
-							if (linear) //fixed tilt linear
+						    if (linear && trackbool) //one-axis linear
+						    {
+                                ibeam *= (1 - shad1xf); //derate beam irradiance linearly by the geometric shading fraction calculated above per Chris Deline 2/10/16
+                                beam_shading_factor *= (1 - shad1xf);
+                                // Sky diffuse and ground-reflected diffuse are derated according to C. Deline's algorithm
+                                iskydiff *= Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+                                ignddiff *= Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
+
+                                if (iyear == 0)
+                                {
+                                    PVSystem->p_derateSelfShading[nn][idx] = (ssc_number_t)1;
+                                    PVSystem->p_derateLinear[nn][idx] = (ssc_number_t)(1 - shad1xf);
+                                    PVSystem->p_derateSelfShadingDiffuse[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+                                    PVSystem->p_derateSelfShadingReflected[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
+                                }
+                            }
+
+						    else if (linear) //fixed tilt linear
 							{
 								ibeam *= (1 - Subarrays[nn]->selfShadingOutputs.m_shade_frac_fixed);
 								beam_shading_factor *= (1 - Subarrays[nn]->selfShadingOutputs.m_shade_frac_fixed);
+								iskydiff *= Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+                                ignddiff *= Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
+
 								if (iyear == 0)
 								{
 									PVSystem->p_derateSelfShading[nn][idx] = (ssc_number_t)1;
 									PVSystem->p_derateLinear[nn][idx] = (ssc_number_t)(1 - Subarrays[nn]->selfShadingOutputs.m_shade_frac_fixed);
-									PVSystem->p_derateSelfShadingDiffuse[nn][idx] = (ssc_number_t)1; //no diffuse derate for linear shading
-									PVSystem->p_derateSelfShadingReflected[nn][idx] = (ssc_number_t)1; //no reflected derate for linear shading
+									PVSystem->p_derateSelfShadingDiffuse[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+								    PVSystem->p_derateSelfShadingReflected[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
 								}
 							}
-							else //non-linear: fixed tilt AND one-axis
+
+							else if (trackbool && (Subarrays[nn]->backtrackingEnabled == true)) //non-linear backtracking one-axis
 							{
+							    iskydiff *= Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+								ignddiff *= Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
+
+								if (iyear == 0)
+								{
+									PVSystem->p_derateSelfShading[nn][idx] = (ssc_number_t)1;
+                                    PVSystem->p_derateLinear[nn][idx] = (ssc_number_t)1;
+									PVSystem->p_derateSelfShadingDiffuse[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+									PVSystem->p_derateSelfShadingReflected[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
+								}
+							}
+
+							else //non-linear: fixed tilt AND one-axis true-tracking
+							{
+                                // Beam is not derated- all beam derate effects (linear and non-linear) are taken into account in the nonlinear_dc_shading_derate
+								Subarrays[nn]->poa.nonlinearDCShadingDerate = Subarrays[nn]->selfShadingOutputs.m_dc_derate;
+
+								iskydiff *= Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
+								ignddiff *= Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
+
 								if (iyear == 0)
 								{
 									PVSystem->p_derateSelfShadingDiffuse[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
@@ -1469,12 +1498,6 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 									PVSystem->p_derateSelfShading[nn][idx] = (ssc_number_t)Subarrays[nn]->selfShadingOutputs.m_dc_derate;
 									PVSystem->p_derateLinear[nn][idx] = (ssc_number_t)1;
 								}
-
-								// Sky diffuse and ground-reflected diffuse are derated according to C. Deline's algorithm
-								iskydiff *= Subarrays[nn]->selfShadingOutputs.m_diffuse_derate;
-								ignddiff *= Subarrays[nn]->selfShadingOutputs.m_reflected_derate;
-								// Beam is not derated- all beam derate effects (linear and non-linear) are taken into account in the nonlinear_dc_shading_derate
-								Subarrays[nn]->poa.nonlinearDCShadingDerate = Subarrays[nn]->selfShadingOutputs.m_dc_derate;
 							}
 						}
 						else

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1430,10 +1430,13 @@ void cm_pvsamv1::exec( ) throw (compute_module::general_error)
 
 						//execute self-shading calculations
 						ssc_number_t beam_to_use; //some self-shading calculations require DNI, NOT ibeam (beam in POA). Need to know whether to use DNI from wf or calculated, depending on radmode
+						ssc_number_t dhi_to_use; //some self-shading calculations require DHI, NOT iskydiff (sky diff in POA). Need to know whether to use DHI from wf or calculated, depending on radmode
 						if (radmode == irrad::DN_DF || radmode == irrad::DN_GH) beam_to_use = (ssc_number_t)wf.dn;
 						else beam_to_use = Irradiance->p_IrradianceCalculated[2][hour * step_per_hour]; // top of hour in first year
+						if (radmode == irrad::DN_DF || radmode == irrad::GH_DF) dhi_to_use = (ssc_number_t)wf.df;
+						else dhi_to_use = Irradiance->p_IrradianceCalculated[1][hour * step_per_hour]; // top of hour in first year
 
-						if (ss_exec(Subarrays[nn]->selfShadingInputs, stilt, sazi, solzen, solazi, beam_to_use, ibeam, (iskydiff + ignddiff), alb, trackbool, linear, shad1xf, Subarrays[nn]->selfShadingOutputs))
+						if (ss_exec(Subarrays[nn]->selfShadingInputs, stilt, sazi, solzen, solazi, beam_to_use, dhi_to_use, ibeam, iskydiff, ignddiff, alb, trackbool, linear, shad1xf, Subarrays[nn]->selfShadingOutputs))
 						{
 
 						    if (linear && trackbool) //one-axis linear

--- a/ssc/cmod_pvwattsv1.cpp
+++ b/ssc/cmod_pvwattsv1.cpp
@@ -2,7 +2,7 @@
 *  Copyright 2017 Alliance for Sustainable Energy, LLC
 *
 *  NOTICE: This software was developed at least in part by Alliance for Sustainable Energy, LLC
-*  (“Alliance”) under Contract No. DE-AC36-08GO28308 with the U.S. Department of Energy and the U.S.
+*  (ï¿½Allianceï¿½) under Contract No. DE-AC36-08GO28308 with the U.S. Department of Energy and the U.S.
 *  The Government retains for itself and others acting on its behalf a nonexclusive, paid-up,
 *  irrevocable worldwide license in the software to reproduce, prepare derivative works, distribute
 *  copies to the public, perform publicly and display publicly, and to permit others to do so.
@@ -26,8 +26,8 @@
 *  4. Redistribution of this software, without modification, must refer to the software by the same
 *  designation. Redistribution of a modified version of this software (i) may not refer to the modified
 *  version by the same designation, or by any confusingly similar designation, and (ii) must refer to
-*  the underlying software originally provided by Alliance as “System Advisor Model” or “SAM”. Except
-*  to comply with the foregoing, the terms “System Advisor Model”, “SAM”, or any confusingly similar
+*  the underlying software originally provided by Alliance as ï¿½System Advisor Modelï¿½ or ï¿½SAMï¿½. Except
+*  to comply with the foregoing, the terms ï¿½System Advisor Modelï¿½, ï¿½SAMï¿½, or any confusingly similar
 *  designation may not be used to refer to any modified version of this software or any modified
 *  version of the underlying software originally provided by Alliance without the prior written consent
 *  of Alliance.
@@ -353,7 +353,7 @@ public:
 						// calculate sky and gnd diffuse derate factors
 						// based on view factor reductions from self-shading
 						diffuse_reduce( solzen, stilt,
-							wf.dn, iskydiff+ignddiff,
+							wf.dn, wf.df, iskydiff, ignddiff,
 							gcr, phi0, alb, 1000,
 
 							// outputs (pass by reference)

--- a/ssc/cmod_pvwattsv5_lifetime.cpp
+++ b/ssc/cmod_pvwattsv5_lifetime.cpp
@@ -63,26 +63,26 @@
 enum pvwatts_tracking_input { FIXED_OPEN_RACK, FIXED_ROOF_MOUNT, ONE_AXIS_SELF_SHADED, ONE_AXIS_BACKTRACKED, TWO_AXIS, AZIMUTH_AXIS };
 
 static var_info _cm_vtab_pvwattsv5_part1[] = {
-	/*   VARTYPE           DATATYPE          NAME                         LABEL                                               UNITS        META                      GROUP          REQUIRED_IF                 CONSTRAINTS                      UI_HINTS*/
-		{ SSC_INPUT,        SSC_NUMBER,      "system_use_lifetime_output",     "Run lifetime simulation",                    "0/1",        "",                       "",            "*",                        "",                              "" },
-		{ SSC_INPUT,        SSC_NUMBER,      "analysis_period",                "Analysis period",                            "years",      "",                       "",            "system_use_lifetime_output=1", "",                          "" },
-		{ SSC_INPUT,        SSC_ARRAY,       "dc_degradation",                 "Annual AC degradation",                      "%/year",    "",                        "",            "system_use_lifetime_output=1", "",                          "" },
-		{ SSC_INPUT,        SSC_STRING,      "solar_resource_file",            "Weather file path",                           "",          "",                       "Weather",     "?",                        "",                              "" },
-		{ SSC_INPUT,        SSC_TABLE,       "solar_resource_data",            "Weather data",                                "",          "dn,df,tdry,wspd,lat,lon,tz", "Weather", "?",                        "",                              "" },
-
-		var_info_invalid };
+/*   VARTYPE           DATATYPE          NAME                         LABEL                                               UNITS        META                      GROUP          REQUIRED_IF                 CONSTRAINTS                      UI_HINTS*/
+	{ SSC_INPUT,        SSC_NUMBER,      "system_use_lifetime_output",     "Run lifetime simulation",                    "0/1",        "",                       "",            "*",                        "",                              "" },
+	{ SSC_INPUT,        SSC_NUMBER,      "analysis_period",                "Analysis period",                            "years",      "",                       "",            "system_use_lifetime_output=1", "",                          "" },
+	{ SSC_INPUT,        SSC_ARRAY,       "dc_degradation",                 "Annual AC degradation",                      "%/year",    "",                        "",            "system_use_lifetime_output=1", "",                          "" },
+	{ SSC_INPUT,        SSC_STRING,      "solar_resource_file",            "Weather file path",                           "",          "",                       "Weather",     "?",                        "",                              "" },
+	{ SSC_INPUT,        SSC_TABLE,       "solar_resource_data",            "Weather data",                                "",          "dn,df,tdry,wspd,lat,lon,tz", "Weather", "?",                        "",                              "" },
+	
+	var_info_invalid };
 
 static var_info _cm_vtab_pvwattsv5_common[] = {
 	{ SSC_INPUT,        SSC_NUMBER,      "system_capacity",                "System size (DC nameplate)",                  "kW",        "",                           "PVWatts",      "*",                       "",                      "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "module_type",                    "Module type",                                 "0/1/2",     "Standard,Premium,Thin film", "PVWatts",      "?=0",                       "MIN=0,MAX=2,INTEGER",                      "" },
+	{ SSC_INPUT,        SSC_NUMBER,      "module_type",                    "Module type",                                 "0/1/2",     "Standard,Premium,Thin film", "PVWatts",      "?=0",                       "MIN=0,MAX=2,INTEGER",                      "" }, 
 	{ SSC_INPUT,        SSC_NUMBER,      "dc_ac_ratio",                    "DC to AC ratio",                              "ratio",     "",                           "PVWatts",      "?=1.1",                   "POSITIVE",                                 "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "inv_eff",                        "Inverter efficiency at rated power",          "%",         "",                           "PVWatts",      "?=96",                        "MIN=90,MAX=99.5",                              "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "losses",                         "System losses",                               "%",         "Total system losses",                               "PVWatts",      "*",                       "MIN=-5,MAX=99",                              "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "array_type",                     "Array type",                                  "0/1/2/3/4", "Fixed OR,Fixed Roof,1Axis,Backtracked,2Axis",  "PVWatts",      "*",                       "MIN=0,MAX=4,INTEGER",                      "" },
+	{ SSC_INPUT,        SSC_NUMBER,      "array_type",                     "Array type",                                  "0/1/2/3/4", "Fixed OR,Fixed Roof,1Axis,Backtracked,2Axis",  "PVWatts",      "*",                       "MIN=0,MAX=4,INTEGER",                      "" }, 
 	{ SSC_INPUT,        SSC_NUMBER,      "tilt",                           "Tilt angle",                                  "deg",       "H=0,V=90",                                     "PVWatts",      "array_type<4",                       "MIN=0,MAX=90",                             "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "azimuth",                        "Azimuth angle",                               "deg",       "E=90,S=180,W=270",                             "PVWatts",      "array_type<4",                       "MIN=0,MAX=360",                            "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "gcr",                            "Ground coverage ratio",                       "0..1",      "",                                             "PVWatts",      "?=0.4",                   "MIN=0,MAX=3",               "" },
-
+	
 	var_info_invalid };
 
 static var_info _cm_vtab_pvwattsv5_part2[] = {
@@ -90,7 +90,7 @@ static var_info _cm_vtab_pvwattsv5_part2[] = {
 	{ SSC_INPUT,        SSC_MATRIX,      "shading:mxh",                    "Month x Hour beam shading loss",              "%",         "",                        "PVWatts",      "?",                        "",                              "" },
 	{ SSC_INPUT,        SSC_MATRIX,      "shading:azal",                   "Azimuth x altitude beam shading loss",        "%",         "",                        "PVWatts",      "?",                        "",                              "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "shading:diff",                   "Diffuse shading loss",                        "%",         "",                        "PVWatts",      "?",                        "",                              "" },
-
+	
 	/* battery */
 	{ SSC_INPUT,        SSC_NUMBER,      "batt_simple_enable",             "Enable Battery",                              "0/1",        "",                      "battwatts",     "?=0",                     "BOOLEAN",                        "" },
 
@@ -106,8 +106,8 @@ static var_info _cm_vtab_pvwattsv5_part2[] = {
 	{ SSC_OUTPUT,       SSC_ARRAY,       "aoi",                            "Angle of incidence",                          "deg",    "",                        "Time Series",      "*",                       "",                          "" },
 	{ SSC_OUTPUT,       SSC_ARRAY,       "poa",                            "Plane of array irradiance",                   "W/m2",   "",                        "Time Series",      "*",                       "",                          "" },
 	{ SSC_OUTPUT,       SSC_ARRAY,       "tpoa",                           "Transmitted plane of array irradiance",       "W/m2",   "",                        "Time Series",      "*",                       "",                          "" },
-	{ SSC_OUTPUT,       SSC_ARRAY,       "tcell",                          "Module temperature",                          "C",      "",                        "Time Series",      "*",                       "",                          "" },
-
+	{ SSC_OUTPUT,       SSC_ARRAY,       "tcell",                          "Module temperature",                          "C",      "",                        "Time Series",      "*",                       "",                          "" },	
+	
 	{ SSC_OUTPUT,       SSC_ARRAY,       "dc",                             "DC array power",                              "W",     "",                         "Time Series",      "*",                       "",                          "" },
 	{ SSC_OUTPUT,       SSC_ARRAY,       "ac",                             "AC inverter power",                           "W",     "",                         "Time Series",      "*",                       "",                          "" },
 	//{ SSC_OUTPUT,       SSC_ARRAY,       "gen",                            "System Power Generated",                      "kW",    "",                         "Time Series",      "*",                       "",                          "" },
@@ -154,10 +154,10 @@ protected:
 	int array_type;
 	double gcr;
 
-
+	
 	double ibeam, iskydiff, ignddiff;
 	double solazi, solzen, solalt, aoi, stilt, sazi, rot, btd;
-	int sunup;
+	int sunup;		
 
 	pvwatts_celltemp *tccalc;
 
@@ -181,25 +181,25 @@ public:
 
 	virtual ~cm_pvwattsv5_base()
 	{
-		if (tccalc) delete tccalc;
+		if ( tccalc ) delete tccalc;
 	}
 
 	void setup_system_inputs()
 	{
-		dc_nameplate = as_double("system_capacity") * 1000;
+		dc_nameplate = as_double("system_capacity")*1000;
 		dc_ac_ratio = as_double("dc_ac_ratio");
 		ac_nameplate = dc_nameplate / dc_ac_ratio;
 		inv_eff_percent = as_double("inv_eff");
-
-		loss_percent = as_double("losses");
-		if (is_assigned("tilt")) tilt = as_double("tilt");
+		
+		loss_percent = as_double("losses");        
+		if(is_assigned("tilt")) tilt = as_double("tilt");
 		if (is_assigned("azimuth")) azimuth = as_double("azimuth");
 
 		gamma = 0;
 		use_ar_glass = false;
 
 		module_type = as_integer("module_type");
-		switch (module_type)
+		switch( module_type )
 		{
 		case 0: // standard module
 			gamma = -0.0047; use_ar_glass = false; break;
@@ -209,12 +209,12 @@ public:
 			gamma = -0.0020; use_ar_glass = false; break;
 		}
 
-		track_mode = 0;
+		track_mode =  0;
 		inoct = 45;
 		shade_mode_1x = 0; // self shaded
-
+		
 		array_type = as_integer("array_type"); // 0, 1, 2, 3, 4		
-		switch (array_type)
+		switch( array_type )
 		{
 		case FIXED_OPEN_RACK: // fixed open rack
 			track_mode = 0; inoct = 45; shade_mode_1x = 0; break;
@@ -230,131 +230,131 @@ public:
 			track_mode = 3; inoct = 45; shade_mode_1x = 0; break;
 		}
 
-
+		
 		gcr = 0.4;
-		if (track_mode == 1 && is_assigned("gcr")) gcr = as_double("gcr");
+		if ( track_mode == 1 && is_assigned("gcr") ) gcr = as_double("gcr");
 	}
 
-	void initialize_cell_temp(double ts_hour, double last_tcell = -9999, double last_poa = -9999)
+	void initialize_cell_temp( double ts_hour, double last_tcell = -9999, double last_poa = -9999 )
 	{
-		tccalc = new pvwatts_celltemp(inoct + 273.15, PVWATTS_HEIGHT, ts_hour);
-		if (last_tcell > -99 && last_poa >= 0)
-			tccalc->set_last_values(last_tcell, last_poa);
+		tccalc = new pvwatts_celltemp ( inoct+273.15, PVWATTS_HEIGHT, ts_hour );
+		if ( last_tcell > -99 && last_poa >= 0 )
+			tccalc->set_last_values( last_tcell, last_poa );
 	}
 
-
+	
 	int process_irradiance(int year, int month, int day, int hour, double minute, double ts_hour,
-		double lat, double lon, double tz, double dn, double df, double alb)
+		double lat, double lon, double tz, double dn, double df, double alb )
 	{
 		irrad irr;
-		irr.set_time(year, month, day, hour, minute, ts_hour);
-		irr.set_location(lat, lon, tz);
-		irr.set_sky_model(2, alb);
+		irr.set_time( year, month, day, hour, minute, ts_hour );
+		irr.set_location( lat, lon, tz );
+		irr.set_sky_model(2, alb );
 		irr.set_beam_diffuse(dn, df);
-		irr.set_surface(track_mode, tilt, azimuth, 45.0,
+		irr.set_surface( track_mode, tilt, azimuth, 45.0, 
 			shade_mode_1x == 1, // backtracking mode
-			gcr);
+			gcr );
 
 		int code = irr.calc();
+			
 
-
-		irr.get_sun(&solazi, &solzen, &solalt, 0, 0, 0, &sunup, 0, 0, 0);
-		irr.get_angles(&aoi, &stilt, &sazi, &rot, &btd);
-		irr.get_poa(&ibeam, &iskydiff, &ignddiff, 0, 0, 0);
+		irr.get_sun( &solazi, &solzen, &solalt, 0, 0, 0, &sunup, 0, 0, 0 );		
+		irr.get_angles( &aoi, &stilt, &sazi, &rot, &btd );
+		irr.get_poa( &ibeam, &iskydiff, &ignddiff, 0, 0, 0);	
 
 		return code;
 	}
 
 	void powerout(double time, double &shad_beam, double shad_diff, double dni, double dhi, double alb, double wspd, double tdry)
 	{
-
+		
 		if (sunup > 0)
-		{
-			if (sunup > 0 && track_mode == 1
-				&& shade_mode_1x == 0) // selfshaded mode
-			{
-				double shad1xf = shadeFraction1x(solazi, solzen, tilt, azimuth, gcr, rot);
-				shad_beam *= (ssc_number_t)(1 - shad1xf);
+		{				
+			if ( sunup > 0 && track_mode == 1
+				&& shade_mode_1x == 0 ) // selfshaded mode
+			{	
+				double shad1xf = shadeFraction1x( solazi, solzen, tilt, azimuth, gcr, rot );
+				shad_beam *= (ssc_number_t)(1-shad1xf);
 
-				if (shade_mode_1x == 0 && iskydiff > 0)
+				if ( shade_mode_1x == 0 && iskydiff > 0 )
 				{
 					double reduced_skydiff = iskydiff;
 					double Fskydiff = 1.0;
 					double reduced_gnddiff = ignddiff;
 					double Fgnddiff = 1.0;
-
+						
 					// worst-case mask angle using calculated surface tilt
-					double phi0 = 180 / 3.1415926*atan2(sind(stilt), 1 / gcr - cosd(stilt));
+					double phi0 = 180/3.1415926*atan2( sind( stilt ), 1/gcr - cosd( stilt ) );
 
 					// calculate sky and gnd diffuse derate factors
 					// based on view factor reductions from self-shading
-                    diffuse_reduce( solzen, stilt,
+					diffuse_reduce( solzen, stilt,
 						dni, dhi, iskydiff, ignddiff,
 						gcr, phi0, alb, 1000,
 
-                        // outputs (pass by reference)
+						// outputs (pass by reference)
 						reduced_skydiff, Fskydiff,
-						reduced_gnddiff, Fgnddiff);
+						reduced_gnddiff, Fgnddiff );
 
-					if (Fskydiff >= 0 && Fskydiff <= 1) iskydiff *= Fskydiff;
-					else log(util::format("sky diffuse reduction factor invalid at time %lg: fskydiff=%lg, stilt=%lg", time, Fskydiff, stilt), SSC_NOTICE, (float)time);
+					if ( Fskydiff >= 0 && Fskydiff <= 1 ) iskydiff *= Fskydiff;
+					else log( util::format("sky diffuse reduction factor invalid at time %lg: fskydiff=%lg, stilt=%lg", time, Fskydiff, stilt), SSC_NOTICE, (float)time );
 
-					if (Fgnddiff >= 0 && Fgnddiff <= 1) ignddiff *= Fgnddiff;
-					else log(util::format("gnd diffuse reduction factor invalid at time %lg: fgnddiff=%lg, stilt=%lg", time, Fgnddiff, stilt), SSC_NOTICE, (float)time);
+					if ( Fgnddiff >= 0 && Fgnddiff <= 1 ) ignddiff *= Fgnddiff;
+					else log( util::format("gnd diffuse reduction factor invalid at time %lg: fgnddiff=%lg, stilt=%lg", time, Fgnddiff, stilt), SSC_NOTICE, (float)time );
 				}
 
 			}
 
 			// apply hourly shading factors to beam (if none enabled, factors are 1.0)
 			ibeam *= shad_beam;
-
+				
 			// apply sky diffuse shading factor (specified as constant, nominally 1.0 if disabled in UI)
 			iskydiff *= shad_diff;
-
-			poa = ibeam + iskydiff + ignddiff;
-
-			double wspd_corr = wspd < 0 ? 0 : wspd;
+				
+			poa = ibeam + iskydiff +ignddiff;
+				
+			double wspd_corr = wspd < 0 ? 0 : wspd;					
 
 			// module cover			
 			tpoa = poa;
-			if (aoi > AOI_MIN && aoi < AOI_MAX)
+			if ( aoi > AOI_MIN && aoi < AOI_MAX )
 			{
-				double mod = iam(aoi, use_ar_glass);
-				tpoa = poa - (1.0 - mod)*dni*cosd(aoi);
-				if (tpoa < 0.0) tpoa = 0.0;
-				if (tpoa > poa) tpoa = poa;
+				double mod = iam( aoi, use_ar_glass );
+				tpoa = poa - ( 1.0 - mod )*dni*cosd(aoi);
+				if( tpoa < 0.0 ) tpoa = 0.0;
+				if( tpoa > poa ) tpoa = poa;
 			}
-
+						
 			// cell temperature
-			pvt = (*tccalc)(poa, wspd_corr, tdry);
+			pvt = (*tccalc)( poa, wspd_corr, tdry );
 
 			// dc power output (Watts)
-			dc = dc_nameplate * (1.0 + gamma * (pvt - 25.0))*tpoa / 1000.0;
+			dc = dc_nameplate*(1.0+gamma*(pvt-25.0))*tpoa/1000.0;
 
 			// dc losses
-			dc = dc * (1 - loss_percent / 100);
+			dc = dc*(1-loss_percent/100);
 
 			// inverter efficiency
-			double etanom = inv_eff_percent / 100.0;
+			double etanom = inv_eff_percent/100.0;
 			double etaref = 0.9637;
-			double A = -0.0162;
+			double A =  -0.0162;
 			double B = -0.0059;
-			double C = 0.9858;
-			double pdc0 = ac_nameplate / etanom;
+			double C =  0.9858;
+			double pdc0 = ac_nameplate/etanom;
 			double plr = dc / pdc0;
 			ac = 0;
-
-			if (plr > 0)
+				
+			if ( plr > 0 )
 			{ // normal operation
-				double eta = (A*plr + B / plr + C)*etanom / etaref;
-				ac = dc * eta;
+				double eta = (A*plr + B/plr + C)*etanom/etaref;
+				ac = dc*eta;
 			}
 
-			if (ac > ac_nameplate) // clipping
+			if ( ac > ac_nameplate ) // clipping
 				ac = ac_nameplate;
 
 			// make sure no negative AC values (no parasitic nighttime losses calculated)
-			if (ac < 0) ac = 0;
+			if ( ac < 0 ) ac = 0;
 		}
 		else
 		{
@@ -367,74 +367,74 @@ public:
 	}
 };
 
-class cm_pvwattsv5 : public cm_pvwattsv5_base
+class cm_pvwattsv5_lifetime : public cm_pvwattsv5_base
 {
 public:
-
-	cm_pvwattsv5()
+	
+	cm_pvwattsv5_lifetime()
 	{
-		add_var_info(_cm_vtab_pvwattsv5_part1);
-		add_var_info(_cm_vtab_pvwattsv5_common);
-		add_var_info(_cm_vtab_pvwattsv5_part2);
+		add_var_info( _cm_vtab_pvwattsv5_part1 );
+		add_var_info( _cm_vtab_pvwattsv5_common );
+		add_var_info( _cm_vtab_pvwattsv5_part2 );
 		add_var_info(vtab_adjustment_factors);
 	}
 
 
-	void exec() throw(general_error)
+	void exec( ) throw( general_error )
 	{
-
+		
 		// don't add "gen" output if battery enabled, gets added later
 		if (!as_boolean("batt_simple_enable"))
 			add_var_info(vtab_technology_outputs);
 
 		std::unique_ptr<weather_data_provider> wdprov;
 
-		if (is_assigned("solar_resource_file"))
+		if ( is_assigned( "solar_resource_file" ) )
 		{
 			const char *file = as_string("solar_resource_file");
-			wdprov = std::unique_ptr<weather_data_provider>(new weatherfile(file));
+			wdprov = std::unique_ptr<weather_data_provider>( new weatherfile( file ) );
 
 			weatherfile *wfile = dynamic_cast<weatherfile*>(wdprov.get());
 			if (!wfile->ok()) throw exec_error("pvwattsv5", wfile->message());
-			if (wfile->has_message()) log(wfile->message(), SSC_WARNING);
+			if( wfile->has_message() ) log( wfile->message(), SSC_WARNING);
 		}
-		else if (is_assigned("solar_resource_data"))
+		else if ( is_assigned( "solar_resource_data" ) )
 		{
-			wdprov = std::unique_ptr<weather_data_provider>(new weatherdata(lookup("solar_resource_data")));
+			wdprov = std::unique_ptr<weather_data_provider>( new weatherdata( lookup("solar_resource_data") ) );
 		}
 		else
 			throw exec_error("pvwattsv5", "no weather data supplied");
 
 		setup_system_inputs(); // setup all basic system specifications
-
-		adjustment_factors haf(this, "adjust");
-		if (!haf.setup())
-			throw exec_error("pvwattsv5", "failed to setup adjustment factors: " + haf.error());
-
+				
+		adjustment_factors haf( this, "adjust" );
+		if ( !haf.setup() )
+			throw exec_error("pvwattsv5", "failed to setup adjustment factors: " + haf.error() );
+		
 		// read all the shading input data and calculate the hourly factors for use subsequently
 		shading_factor_calculator shad;
-		if (!shad.setup(this, ""))
-			throw exec_error("pvwattsv5", shad.get_error());
+		if ( !shad.setup( this, "" ) )
+			throw exec_error( "pvwattsv5", shad.get_error() );
 
 		weather_header hdr;
-		wdprov->header(&hdr);
-
+		wdprov->header( &hdr );
+					
 		// assumes instantaneous values, unless hourly file with no minute column specified
 		double ts_shift_hours = 0.0;
 		bool instantaneous = true;
-		if (wdprov->has_data_column(weather_data_provider::MINUTE))
+		if ( wdprov->has_data_column( weather_data_provider::MINUTE ) )
 		{
 			// if we have an file with a minute column, then
 			// the starting time offset equals the time 
 			// of the first record (for correct plotting)
 			// this holds true even for hourly data with a minute column
 			weather_record rec;
-			if (wdprov->read(&rec))
-				ts_shift_hours = rec.minute / 60.0;
+			if ( wdprov->read( &rec ) )
+				ts_shift_hours = rec.minute/60.0;
 
 			wdprov->rewind();
 		}
-		else if (wdprov->nrecords() == 8760)
+		else if ( wdprov->nrecords() == 8760 )
 		{
 			// hourly file with no minute data column.  assume
 			// integrated/averaged values and use mid point convention for interpreting results
@@ -442,12 +442,12 @@ public:
 			ts_shift_hours = 0.5;
 		}
 		else
-			throw exec_error("pvwattsv5", "subhourly weather files must specify the minute for each record");
+			throw exec_error("pvwattsv5", "subhourly weather files must specify the minute for each record" );
 
-		assign("ts_shift_hours", var_data((ssc_number_t)ts_shift_hours));
+		assign( "ts_shift_hours", var_data( (ssc_number_t)ts_shift_hours ) );
 
 		weather_record wf;
-
+		
 		size_t nyears = 1;
 		std::vector<double> degradationFactor;
 		if (as_boolean("system_use_lifetime_output")) {
@@ -471,17 +471,17 @@ public:
 
 		size_t nrec = wdprov->nrecords();
 		size_t nlifetime = nrec * nyears;
-		size_t step_per_hour = nrec / 8760;
-		if (step_per_hour < 1 || step_per_hour > 60 || step_per_hour * 8760 != nrec)
-			throw exec_error("pvwattsv5", util::format("invalid number of data records (%d): must be an integer multiple of 8760", (int)nrec));
-
-		/* allocate output arrays */
+		size_t step_per_hour = nrec /8760;
+		if ( step_per_hour < 1 || step_per_hour > 60 || step_per_hour*8760 != nrec )
+			throw exec_error( "pvwattsv5", util::format("invalid number of data records (%d): must be an integer multiple of 8760", (int)nrec ) );
+		
+		/* allocate output arrays */		
 		ssc_number_t *p_gh = allocate("gh", nrec);
 		ssc_number_t *p_dn = allocate("dn", nrec);
 		ssc_number_t *p_df = allocate("df", nrec);
 		ssc_number_t *p_tamb = allocate("tamb", nrec);
 		ssc_number_t *p_wspd = allocate("wspd", nrec);
-
+		
 		ssc_number_t *p_sunup = allocate("sunup", nrec);
 		ssc_number_t *p_aoi = allocate("aoi", nrec);
 		ssc_number_t *p_shad_beam = allocate("shad_beam_factor", nrec); // just for reporting output
@@ -493,12 +493,12 @@ public:
 		ssc_number_t *p_ac = allocate("ac", nrec);
 		ssc_number_t *p_gen = allocate("gen", nlifetime);
 
-		double ts_hour = 1.0 / step_per_hour;
+		double ts_hour = 1.0/step_per_hour;
 
-		initialize_cell_temp(ts_hour);
+		initialize_cell_temp( ts_hour );
 
-		double annual_kwh = 0;
-
+		double annual_kwh = 0; 
+		
 		size_t idx_life = 0;
 		float percent = 0;
 		for (size_t y = 0; y < nyears; y++)
@@ -518,7 +518,7 @@ public:
 
 				for (size_t jj = 0; jj < step_per_hour; jj++)
 				{
-                    if (!wdprov->read(&wf))
+					if (!wdprov->read(&wf))
 						throw exec_error("pvwattsv5", util::format("could not read data line %d of %d in weather file", (int)(idx + 1), (int)nrec));
 
 
@@ -583,32 +583,32 @@ public:
 			}
 		}
 
-		accumulate_monthly("dc", "dc_monthly", 0.001*ts_hour);
-		accumulate_monthly("ac", "ac_monthly", 0.001*ts_hour);
+		accumulate_monthly( "dc", "dc_monthly", 0.001*ts_hour );
+		accumulate_monthly( "ac", "ac_monthly", 0.001*ts_hour );
 
-		ssc_number_t *poam = accumulate_monthly("poa", "poa_monthly", 0.001*ts_hour); // convert to energy
-		ssc_number_t *solrad = allocate("solrad_monthly", 12);
+		ssc_number_t *poam = accumulate_monthly( "poa", "poa_monthly", 0.001*ts_hour ); // convert to energy
+		ssc_number_t *solrad = allocate( "solrad_monthly", 12 );
 		ssc_number_t solrad_ann = 0;
-		for (int m = 0; m < 12; m++)
+		for ( int m=0;m<12;m++ )
 		{
-			solrad[m] = poam[m] / util::nday[m];
+			solrad[m] = poam[m]/util::nday[m];
 			solrad_ann += solrad[m];
 		}
-		assign("solrad_annual", var_data(solrad_ann / 12));
+		assign( "solrad_annual", var_data( solrad_ann/12 ) );
 
-		accumulate_annual("ac", "ac_annual", 0.001*ts_hour);
+		accumulate_annual( "ac", "ac_annual", 0.001*ts_hour );
 
-		assign("location", var_data(hdr.location));
-		assign("city", var_data(hdr.city));
-		assign("state", var_data(hdr.state));
-		assign("lat", var_data((ssc_number_t)hdr.lat));
-		assign("lon", var_data((ssc_number_t)hdr.lon));
-		assign("tz", var_data((ssc_number_t)hdr.tz));
-		assign("elev", var_data((ssc_number_t)hdr.elev));
+		assign( "location", var_data( hdr.location ) );
+		assign( "city", var_data( hdr.city ) );
+		assign( "state", var_data( hdr.state ) );
+		assign( "lat", var_data( (ssc_number_t)hdr.lat ) );
+		assign( "lon", var_data( (ssc_number_t)hdr.lon ) );
+		assign( "tz", var_data( (ssc_number_t)hdr.tz ) );
+		assign( "elev", var_data( (ssc_number_t)hdr.elev ) );
 		assign("percent_complete", var_data((ssc_number_t)percent));
 
 		// for battery model, force inverter model
-		assign("inverter_model", var_data((ssc_number_t)4));
+		assign("inverter_model", var_data((ssc_number_t)4) );
 		assign("inverter_efficiency", var_data((ssc_number_t)(as_double("inv_eff"))));
 
 		// metric outputs moved to technology
@@ -618,93 +618,5 @@ public:
 	}
 };
 
-DEFINE_MODULE_ENTRY( pvwattsv5, "PVWatts V5 - integrated hourly weather reader and PV system simulator.", 3 )
+DEFINE_MODULE_ENTRY( pvwattsv5_lifetime, "PVWatts V5 lifetime - integrated hourly weather reader and PV system simulator.", 1 )
 
-
-
-/* *****************************************************************************
-			SINGLE TIME STEP VERSION   29oct2014
- ***************************************************************************** */
-
-
-static var_info _cm_vtab_pvwattsv5_1ts_weather[] = {
-	{ SSC_INPUT,        SSC_NUMBER,      "year",                     "Year",                                        "yr",     "",                        "PVWatts",      "*",                       "",               "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "month",                    "Month",                                       "mn",     "1-12",                    "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "day",                      "Day",                                         "dy",     "1-days in month",         "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "hour",                     "Hour",                                        "hr",     "0-23",                    "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "minute",                   "Minute",                                      "min",    "0-59",                    "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "lat",                      "Latitude",                                    "deg",    "",                        "PVWatts",      "*",                        "",                      "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "lon",                      "Longitude",                                   "deg",    "",                        "PVWatts",      "*",                        "",                      "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "tz",                       "Time zone",                                   "hr",     "",                        "PVWatts",      "*",                        "",                      "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "beam",                     "Beam normal irradiance",                      "W/m2",   "",                        "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "diffuse",                  "Diffuse irradiance",                          "W/m2",   "",                        "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "tamb",                     "Ambient temperature",                         "C",      "",                        "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "wspd",                     "Wind speed",                                  "m/s",    "",                        "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "alb",                      "Albedo",                                      "frac",     "",                      "PVWatts",      "?=0.2",                     "",                          "" },
-	{ SSC_INPUT,        SSC_NUMBER,      "time_step",                "Time step of input data",                     "hr",    "",                         "PVWatts",      "?=1",                     "POSITIVE",                  "" },
-	
-	var_info_invalid };
-	
-static var_info _cm_vtab_pvwattsv5_1ts_outputs[] = {
-	/* input/output variable: tcell & poa from previous time must be given */
-	{ SSC_INOUT,        SSC_NUMBER,      "tcell",                    "Module temperature",                          "C",      "",                        "PVWatts",      "*",                       "",                          "" },	
-	{ SSC_INOUT,        SSC_NUMBER,      "poa",                      "Plane of array irradiance",                   "W/m2",   "",                        "PVWatts",      "*",                       "",                          "" },
-			
-	/* outputs */
-	{ SSC_OUTPUT,       SSC_NUMBER,      "dc",                      "DC array output",                             "Wdc",    "",                        "PVWatts",      "*",                       "",                          "" },
-	{ SSC_OUTPUT,       SSC_NUMBER,      "ac",                      "AC system output",                            "Wac",    "",                        "PVWatts",      "*",                       "",                          "" },
-
-	var_info_invalid };
-
-class cm_pvwattsv5_1ts : public cm_pvwattsv5_base
-{
-public:
-	
-	cm_pvwattsv5_1ts()
-	{
-		add_var_info( _cm_vtab_pvwattsv5_1ts_weather );
-		add_var_info( _cm_vtab_pvwattsv5_common );
-		add_var_info( _cm_vtab_pvwattsv5_1ts_outputs );
-	}
-
-	void exec( ) throw( general_error )
-	{	
-		int year = as_integer("year");
-		int month = as_integer("month");
-		int day = as_integer("day");
-		int hour = as_integer("hour");
-		double minute = as_double("minute");
-		double lat = as_double("lat");
-		double lon = as_double("lon");
-		double tz = as_double("tz");
-		double beam = as_double("beam");
-		double diff = as_double("diffuse");
-		double tamb = as_double("tamb");
-		double wspd = as_double("wspd");
-		double alb = as_double("alb");
-		double time_step = as_double("time_step");
-			
-		double last_tcell = as_double("tcell");
-		double last_poa = as_double("poa");
-
-		setup_system_inputs();
-		initialize_cell_temp( time_step, last_tcell, last_poa );
-		
-		int code = process_irradiance(year, month, day, hour, minute, 
-			IRRADPROC_NO_INTERPOLATE_SUNRISE_SUNSET,
-			lat, lon, tz, beam, diff, alb );
-
-		if (code != 0)
-			throw exec_error( "pvwattsv5_1ts", "failed to calculate plane of array irradiance with given input parameters" );
-
-		double shad_beam = 1.0;
-		powerout(0, shad_beam, 1.0, beam, diff, alb, wspd, tamb);
-
-		assign( "poa", var_data( (ssc_number_t)poa ) );
-		assign( "tcell", var_data( (ssc_number_t)pvt ) );
-		assign( "dc", var_data( (ssc_number_t)dc ) );
-		assign( "ac", var_data( (ssc_number_t)ac ) );		
-	}
-};
-
-DEFINE_MODULE_ENTRY( pvwattsv5_1ts, "pvwattsv5_1ts- single timestep calculation of PV system performance.", 1 )


### PR DESCRIPTION
There are 3 major updates in this PR:
- Resolve Issue #236 by applying the currently existing diffuse self-shading model in all scenarios
- Improve the diffuse self-shading algorithm so that the results more closely match PVsyst
- Correct miscalculation of self-shading albedo derate

After making the necessary changes so that diffuse self-shading could be applied to SAT systems, I ran a representative simulation and compared the self-shading diffuse derate to that calculated for the same scenario in PVsyst:

_5MW Backtracking SAT system in Oregon with 355 Mono modules (ML model) and a 30% GCR_
Below are the results:
<img width="539" alt="sam_diffuse_shading_vs_PVsyst" src="https://user-images.githubusercontent.com/29411281/59891168-f3679d00-9388-11e9-817c-c04cd94c47da.png">

The results show poor agreement that varies along with the magnitude of the derate.

In order to improve the agreement with the PVsyst model, I implemented the [PlantPredict diffuse self-shading model](https://plantpredict.com/algorithm/optical-losses/#near-diffuse-shading-factor). After doing so, for the same representative scenario, the agreement had significantly improved:
<img width="555" alt="sam_vs_PVsyst_with_PPshading" src="https://user-images.githubusercontent.com/29411281/59891679-f19ed900-938a-11e9-979c-17d8ba75c11f.png">

Now the variability that trended with the derate magnitude is significantly reduced and the ssc derate is now consistently slightly higher than the PVsyst derate.

To confirm that this model still results in acceptable behavior for FT systems and across GCR and location, we ran the model for a number of scenarios. Below are plots of monthly relative error between the ssc model and PVsyst. 
<img width="1128" alt="Mono_agreement" src="https://user-images.githubusercontent.com/29411281/59891944-0c258200-938c-11e9-8929-e09475ee4d2a.png">
Note that the linear shading (e.g. thin film) scenario is not represented here, but the diffuse shading model should be the same.

Finally, I also noticed that the ground shading derate had very poor agreement with PVsyst. After review, I noticed that the math described in the paper referenced by the technical documentation did not match the technical documentation or the code and fixed that as well.

### The Rub ###
I have made the fixes explicitly to improve agreement of the ssc model with PVsyst, because for our purposes (a Utility-scale developer) that is how the software brings us the most value, but I understand that PVsyst shoudl not necessarily be considered truly representative of real system performance. In this case, I do think that there are probably some incorrect trig calculations being used in the current ssc model. Regardless, I am happy to retract this PR and submit one that only addresses Issue #236 if that is what the team would prefer.

### This PR does not pass all tests ###
As far as I can tell, the only tests it is failing are ones with result-based tests, which should fail now that the model results in reduced DC production. As discussed with @janinefreeman I don't have the expertise to efficiently fix these tests