### PR TITLE
Batt bug

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -1564,6 +1564,7 @@ void thermal_t::updateTemperature(double I, double R, double dt, size_t lifetime
 		_T_battery = implicit_euler(I, dt*HR2SEC, lifetimeIndex);
 	else
 		_message.add("Computed battery temperature below zero or greater than max allowed, consider reducing C-rate");
+	_T_battery = fmax(_T_battery, _T_room[util::yearOneIndex(_dt_hour, lifetimeIndex)]);
 }
 
 double thermal_t::f(double T_battery, double I, size_t lifetimeindex)
@@ -1857,7 +1858,7 @@ double battery_t::calculate_max_discharge_kw(double *max_current_A) {
     return _voltage->calculate_max_discharge_w(q, qmax, _thermal->T_battery(), max_current_A) / 1000.;
 }
 
-double battery_t::run(size_t lifetimeIndex, double I)
+double battery_t::run(size_t lifetimeIndex, double &I)
 {
 	// Temperature affects capacity, but capacity model can reduce current, which reduces temperature, need to iterate
 	double I_initial = I;

--- a/shared/lib_battery.h
+++ b/shared/lib_battery.h
@@ -758,7 +758,7 @@ public:
 	void initialize(capacity_t *, voltage_t *, lifetime_t *, thermal_t *, losses_t *);
 
 	// Run all for single time step, updating all component model states and return the dispatched power [kW]
-	double run(size_t lifetimeIndex, double I);
+	double run(size_t lifetimeIndex, double &I);
 
 	double calculate_voltage_for_current(double I);
 

--- a/shared/lib_battery_dispatch.cpp
+++ b/shared/lib_battery_dispatch.cpp
@@ -774,7 +774,6 @@ void dispatch_automatic_t::dispatch(size_t year,
 
 bool dispatch_automatic_t::check_constraints(double &I, size_t count)
 {
-    m_batteryPowerFlow->calculate();
     // check common constraints before checking manual dispatch specific ones
 	bool iterate = dispatch_t::check_constraints(I, count);
 
@@ -784,13 +783,13 @@ bool dispatch_automatic_t::check_constraints(double &I, size_t count)
 		double P_battery = I * _Battery->battery_voltage() * util::watt_to_kilowatt;
 		double P_target = m_batteryPower->powerBatteryTarget;
 
-		// Comomon to automated behind the meter and front of meter
+		// Common to automated behind the meter and front of meter
 		iterate = true;
-		
-		
+
+
 		// Don't respect target if bidirectional inverter efficiency is low while charging
-		if (m_batteryPower->connectionMode == dispatch_t::DC_CONNECTED && 
-			m_batteryPower->sharedInverter->efficiencyAC <= m_batteryPower->inverterEfficiencyCutoff && 
+		if (m_batteryPower->connectionMode == dispatch_t::DC_CONNECTED &&
+			m_batteryPower->sharedInverter->efficiencyAC <= m_batteryPower->inverterEfficiencyCutoff &&
 			P_target < 0)
 		{
 			iterate = false;
@@ -798,7 +797,7 @@ bool dispatch_automatic_t::check_constraints(double &I, size_t count)
 			//I += dP * util::kilowatt_to_watt / _Battery->battery_voltage();
 			//m_batteryPower->powerBatteryTarget += dP;
 		}
-		
+
 		// Try and force controller to meet target or custom dispatch
 		else if (P_battery > P_target + tolerance || P_battery < P_target - tolerance)
 		{
@@ -817,8 +816,8 @@ bool dispatch_automatic_t::check_constraints(double &I, size_t count)
 					iterate = false;
 				}
 				// Don't charge more if would violate current or power charge limits
-				if (I > m_batteryPower->currentChargeMax - tolerance || 
-					fabs(P_battery) > m_batteryPower->powerBatteryChargeMaxDC - tolerance || 
+				if (I > m_batteryPower->currentChargeMax - tolerance ||
+					fabs(P_battery) > m_batteryPower->powerBatteryChargeMaxDC - tolerance ||
 					fabs(m_batteryPower->powerBatteryAC) > m_batteryPower->powerBatteryChargeMaxAC - tolerance){
 					iterate = false;
 				}
@@ -836,7 +835,7 @@ bool dispatch_automatic_t::check_constraints(double &I, size_t count)
 					iterate = false;
 				}
 				// Don't discharge more if would violate current or power discharge limits
-				if (I > m_batteryPower->currentDischargeMax - tolerance || 
+				if (I > m_batteryPower->currentDischargeMax - tolerance ||
 					P_battery > m_batteryPower->powerBatteryDischargeMaxDC - tolerance ||
 					m_batteryPower->powerBatteryAC > m_batteryPower->powerBatteryDischargeMaxAC - tolerance) {
 					iterate = false;

--- a/tcs/CMakeLists.txt
+++ b/tcs/CMakeLists.txt
@@ -111,6 +111,7 @@ set(TCS_SRC
 		sumprod.cpp
 		thermocline_tes.cpp
 		tou_translator.cpp
+		flat_plate_solar_collector.cpp
 )
 
 

--- a/test/shared_test/lib_battery_dispatch_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_test.cpp
@@ -81,7 +81,6 @@ TEST_F(BatteryDispatchTest_lib_battery_dispatch, DispatchFOMInput_lib_battery_di
 
 	dispatchAutoFOM->set_custom_dispatch(P_batt);
 	dispatchAutoFOM->dispatch(0, 0, 0);
-
 }
 
 TEST_F(BatteryDispatchTest_lib_battery_dispatch, DispatchFOM_DCAuto)
@@ -121,9 +120,7 @@ TEST_F(BatteryDispatchTest_lib_battery_dispatch, DispatchFOM_DCAuto)
 		batteryPower->powerPVClipped = clip[h];
 		dispatchAutoDC->dispatch(0, h, 0);
 		p_batterykW.push_back(batteryPower->powerBatteryAC);
-}
-
-
+    }
 
 	if (m_sharedInverter) {
 		delete m_sharedInverter;
@@ -141,8 +138,8 @@ TEST_F(BatteryDispatchTest_lib_battery_dispatch, DispatchFOM_DCAuto)
 		delete ond;
 		ond = nullptr;
 	}
-
 }
 
+TEST_F(BatteryDispatchTest_lib_battery_dispatch, checkConstraints_SOC){
 
-
+}

--- a/test/shared_test/lib_battery_powerflow_test.cpp
+++ b/test/shared_test/lib_battery_powerflow_test.cpp
@@ -7,7 +7,7 @@
 #include "lib_shared_inverter.h"
 
 
-void BatteryPowerFlowTest::SetUp()
+void BatteryPowerFlowTest_lib_battery_powerflow::SetUp()
 {
 	error = 0.02;
 	double dtHour = 1.0;
@@ -42,7 +42,7 @@ void BatteryPowerFlowTest::SetUp()
 	m_batteryPower->setSharedInverter(m_sharedInverter);
 }
 
-TEST_F(BatteryPowerFlowTest, TestInitialize_lib_battery_powerflow)
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, TestInitialize)
 {
 	// PV Charging Scenario
 	m_batteryPower->canPVCharge = true;
@@ -64,57 +64,490 @@ TEST_F(BatteryPowerFlowTest, TestInitialize_lib_battery_powerflow)
 	EXPECT_EQ(m_batteryPower->powerBatteryDC, m_batteryPower->powerBatteryDischargeMaxDC);
 }
 
-TEST_F(BatteryPowerFlowTest, TestACConnected_lib_battery_powerflow)
+// Excess PV production
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, PVChargingAC_ExcessPV) {
+    m_batteryPower->connectionMode = ChargeController::AC_CONNECTED;
+
+    m_batteryPower->canPVCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canGridCharge = false;
+    m_batteryPower->powerPV = 100;
+    m_batteryPower->powerLoad = 50;
+
+    // Try to charge
+    m_batteryPower->powerBatteryDC = -50 * m_batteryPower->singlePointEfficiencyACToDC;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.0, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // Try to charge more than is available from PV, disallowed
+    m_batteryPower->powerBatteryDC = -100;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.0, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // Try to discharge
+    m_batteryPower->powerBatteryDC = 50;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 48, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.0, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+// Not enough PV for load
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, PVChargingAC_ExcessLoad) {
+    m_batteryPower->connectionMode = ChargeController::AC_CONNECTED;
+
+    m_batteryPower->canPVCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canGridCharge = false;
+    m_batteryPower->powerPV = 25;
+    m_batteryPower->powerLoad = 50;
+
+    // do not discharge battery
+    m_batteryPower->powerBatteryDC = 0;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // discharge battery
+    m_batteryPower->powerBatteryDC = 20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 5.8, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.8, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // try to charge battery from grid, not allowed
+    m_batteryPower->powerBatteryDC = -20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+// Excess PV production
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, GridChargingAC_ExcessPV) {
+    m_batteryPower->connectionMode = ChargeController::AC_CONNECTED;
+
+    m_batteryPower->canGridCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canPVCharge = false;
+    m_batteryPower->powerPV = 100;
+    m_batteryPower->powerLoad = 50;
+
+    // charging will be from grid
+    m_batteryPower->powerBatteryDC = -50;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -52.08, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 52.08, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.08, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // discharge to grid
+    m_batteryPower->powerBatteryDC = 20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 19.2, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 19.2, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.80, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+// Not enough PV, pull from grid
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, GridChargingAC_ExcessLoad)
 {
-	m_batteryPower->connectionMode = ChargeController::AC_CONNECTED;
+    m_batteryPower->connectionMode = ChargeController::AC_CONNECTED;
 
-	// PV and Grid Charging Scenario
-	m_batteryPower->canPVCharge = true;
-	m_batteryPower->powerPV = 100;
-	m_batteryPower->powerLoad = 50;
-	m_batteryPowerFlow->initialize(50);
-	m_batteryPowerFlow->calculate();
+    m_batteryPower->canGridCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canPVCharge = false;
+    m_batteryPower->powerPV = 10;
+    m_batteryPower->powerLoad = 50;
 
-	EXPECT_NEAR(m_batteryPower->powerBatteryAC, -52.08, error); // The extra 2.08 kW is due to conversion efficiency
-	EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToBattery, 50, error);
-	EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);  
-	EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.0, error);
+    // don't dispatch
+    m_batteryPower->powerBatteryDC = 0;
+    m_batteryPowerFlow->calculate();
 
-	// Exclusive Grid Charging Scenario
-	m_batteryPower->canGridCharge = true;
-	m_batteryPower->canPVCharge = false;
-	m_batteryPower->powerPV = 100;
-	m_batteryPower->powerLoad = 50;
-	m_batteryPowerFlow->initialize(50);
-	m_batteryPowerFlow->calculate();
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 10, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 40, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0, error);
 
-	EXPECT_NEAR(m_batteryPower->powerBatteryAC, -104.166, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
-	EXPECT_NEAR(m_batteryPower->powerGridToBattery, 104.166, error);
-	EXPECT_NEAR(m_batteryPower->powerConversionLoss, 4.166, error);
-	
-	// Discharging Scenario
-	m_batteryPower->canDischarge = true;
-	m_batteryPower->powerPV = 50;
-	m_batteryPower->powerLoad = 100;
-	m_batteryPowerFlow->initialize(50);
-	m_batteryPowerFlow->calculate();
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
 
-	EXPECT_NEAR(m_batteryPower->powerBatteryAC, 48 , error);
-	EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 48, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
-	EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
-	EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
-	EXPECT_NEAR(m_batteryPower->powerGridToLoad, 2, error);
-	EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2, error);
+    // charging will happen from grid
+    m_batteryPower->powerBatteryDC = -20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -20.83, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 10, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 20.83, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 40, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.83, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // discharge
+    m_batteryPower->powerBatteryDC = 20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 10, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 20.8, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.8, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
 }
 
 
-TEST_F(BatteryPowerFlowTest, TestDCConnected_lib_battery_powerflow)
+// Excess PV production
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, PVChargingDC_ExcessPV) {
+    m_batteryPower->connectionMode = ChargeController::DC_CONNECTED;
+
+    m_batteryPower->canPVCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canGridCharge = false;
+    m_batteryPower->powerPV = 100;
+    m_batteryPower->powerLoad = 50;
+
+    // Try to charge
+    m_batteryPower->powerBatteryDC = -50 * m_batteryPower->singlePointEfficiencyACToDC;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -48.97, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 48.24, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 48.97, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 1.75, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 3.76, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryDC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // Try to charge more than is available from PV, disallowed
+    m_batteryPower->powerBatteryDC = -100;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.0, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // Try to discharge
+    m_batteryPower->powerBatteryDC = 50;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 48, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.0, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+// Not enough PV for load
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, PVChargingDC_ExcessLoad) {
+    m_batteryPower->connectionMode = ChargeController::DC_CONNECTED;
+
+    m_batteryPower->canPVCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canGridCharge = false;
+    m_batteryPower->powerPV = 25;
+    m_batteryPower->powerLoad = 50;
+
+    // do not discharge battery
+    m_batteryPower->powerBatteryDC = 0;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // discharge battery
+    m_batteryPower->powerBatteryDC = 20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 5.8, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.8, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // try to charge battery from grid, not allowed
+    m_batteryPower->powerBatteryDC = -20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 25, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+// Excess PV production
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, GridChargingDC_ExcessPV) {
+    m_batteryPower->connectionMode = ChargeController::DC_CONNECTED;
+
+    m_batteryPower->canGridCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canPVCharge = false;
+    m_batteryPower->powerPV = 100;
+    m_batteryPower->powerLoad = 50;
+
+    // charging will be from grid
+    m_batteryPower->powerBatteryDC = -50;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -52.08, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 52.08, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.08, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // discharge to grid
+    m_batteryPower->powerBatteryDC = 20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 19.2, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 50, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 19.2, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.80, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+// Not enough PV, pull from grid
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, GridChargingDC_ExcessLoad)
+{
+    m_batteryPower->connectionMode = ChargeController::DC_CONNECTED;
+
+    m_batteryPower->canGridCharge = true;
+    m_batteryPower->canDischarge = true;
+    m_batteryPower->canPVCharge = false;
+    m_batteryPower->powerPV = 10;
+    m_batteryPower->powerLoad = 50;
+
+    // don't dispatch
+    m_batteryPower->powerBatteryDC = 0;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 10, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 40, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0, error);
+
+    double gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // charging will happen from grid
+    m_batteryPower->powerBatteryDC = -20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, -20.83, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 10, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 20.83, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 40, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.83, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+
+    // discharge
+    m_batteryPower->powerBatteryDC = 20;
+    m_batteryPowerFlow->calculate();
+
+    EXPECT_NEAR(m_batteryPower->powerBatteryAC, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToLoad, 10, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToBattery, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerGridToLoad, 20.8, error);
+    EXPECT_NEAR(m_batteryPower->powerPVToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 19.19, error);
+    EXPECT_NEAR(m_batteryPower->powerBatteryToGrid, 0, error);
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 0.8, error);
+
+    gen = m_batteryPower->powerPV + m_batteryPower->powerBatteryAC;
+    EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, error);
+    EXPECT_NEAR(m_batteryPower->powerLoad, 50, error);
+}
+
+TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, TestDCConnected)
 {
 	m_batteryPower->connectionMode = ChargeController::DC_CONNECTED;
 

--- a/test/shared_test/lib_battery_powerflow_test.h
+++ b/test/shared_test/lib_battery_powerflow_test.h
@@ -15,7 +15,7 @@ class sandia_inverter_t;
 class partload_inverter_t;
 class ond_inverter;
 
-class BatteryPowerFlowTest : public ::testing::Test
+class BatteryPowerFlowTest_lib_battery_powerflow : public ::testing::Test
 {
 protected:
 	BatteryPowerFlow * m_batteryPowerFlow;

--- a/test/shared_test/lib_battery_powerflow_test.h
+++ b/test/shared_test/lib_battery_powerflow_test.h
@@ -29,7 +29,24 @@ protected:
 public:
 
 	void SetUp();
-	
+
+	double calc_dc_gen(){
+		return m_batteryPower->powerPVToLoad + m_batteryPower->powerPVToGrid + m_batteryPower->powerBatteryToLoad
+			   + m_batteryPower->powerBatteryToGrid - m_batteryPower->powerGridToBattery * m_batteryPower->sharedInverter->efficiencyAC/100;
+	}
+
+	double calc_met_load(){
+		return m_batteryPower->powerBatteryToLoad + m_batteryPower->powerGridToLoad + m_batteryPower->powerPVToLoad;
+	}
+
+	void check_net_flows(){
+	    // increased error due to efficiencies
+		double gen = calc_dc_gen();
+		EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, 3);
+		double met_load = calc_met_load();
+		EXPECT_NEAR(met_load, m_batteryPower->powerLoad, 3);
+	}
+
 	void TearDown()
 	{
 		if (m_batteryPowerFlow) {

--- a/test/shared_test/lib_battery_powerflow_test.h
+++ b/test/shared_test/lib_battery_powerflow_test.h
@@ -32,19 +32,19 @@ public:
 
 	double calc_dc_gen(){
 		return m_batteryPower->powerPVToLoad + m_batteryPower->powerPVToGrid + m_batteryPower->powerBatteryToLoad
-			   + m_batteryPower->powerBatteryToGrid - m_batteryPower->powerGridToBattery * m_batteryPower->sharedInverter->efficiencyAC/100;
+			   + m_batteryPower->powerBatteryToGrid - m_batteryPower->powerGridToBattery * m_batteryPower->singlePointEfficiencyDCToDC;
 	}
 
 	double calc_met_load(){
 		return m_batteryPower->powerBatteryToLoad + m_batteryPower->powerGridToLoad + m_batteryPower->powerPVToLoad;
 	}
 
-	void check_net_flows(){
+	void check_net_flows(std::string id_string) {
 	    // increased error due to efficiencies
 		double gen = calc_dc_gen();
-		EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, 3);
+		EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, 5) << id_string;
 		double met_load = calc_met_load();
-		EXPECT_NEAR(met_load, m_batteryPower->powerLoad, 3);
+		EXPECT_NEAR(met_load, m_batteryPower->powerLoad, 5) << id_string;
 	}
 
 	void TearDown()

--- a/test/shared_test/lib_battery_powerflow_test.h
+++ b/test/shared_test/lib_battery_powerflow_test.h
@@ -31,8 +31,9 @@ public:
 	void SetUp();
 
 	double calc_dc_gen(){
-		return m_batteryPower->powerPVToLoad + m_batteryPower->powerPVToGrid + m_batteryPower->powerBatteryToLoad
-			   + m_batteryPower->powerBatteryToGrid - m_batteryPower->powerGridToBattery * m_batteryPower->singlePointEfficiencyDCToDC;
+//		return m_batteryPower->powerPVToLoad + m_batteryPower->powerPVToGrid + m_batteryPower->powerBatteryToLoad
+//			   + m_batteryPower->powerBatteryToGrid - m_batteryPower->powerGridToBattery * m_batteryPower->singlePointEfficiencyDCToDC;
+	    return m_batteryPower->powerBatteryAC + m_batteryPower->powerPV;
 	}
 
 	double calc_met_load(){
@@ -40,11 +41,12 @@ public:
 	}
 
 	void check_net_flows(std::string id_string) {
-	    // increased error due to efficiencies
+	    // increased error due to PV dc to ac conversion
+	    double dc_error = 4;
 		double gen = calc_dc_gen();
-		EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, 5) << id_string;
+		EXPECT_NEAR(m_batteryPower->powerGeneratedBySystem, gen, dc_error) << id_string;
 		double met_load = calc_met_load();
-		EXPECT_NEAR(met_load, m_batteryPower->powerLoad, 5) << id_string;
+		EXPECT_NEAR(met_load, m_batteryPower->powerLoad, dc_error) << id_string;
 	}
 
 	void TearDown()

--- a/test/shared_test/lib_battery_test.cpp
+++ b/test/shared_test/lib_battery_test.cpp
@@ -98,7 +98,8 @@ TEST_F(BatteryTest, AugmentCapacity)
 	for (size_t y = 0; y < replacement_schedule.size(); y++) {
 		for (size_t t = 0; t < 8760; t++) {
 			mult = fmod(t, 2) == 0 ? 1 : -1;
-			batteries[replaceCount]->run(i, mult*I);
+			double current = mult*I;
+			batteries[replaceCount]->run(i, current);
 		}
 		if (replacement_schedule[y] == 1) {
 			replaceCount++;

--- a/test/shared_test/lib_resilience_test.cpp
+++ b/test/shared_test/lib_resilience_test.cpp
@@ -56,8 +56,9 @@ TEST_F(ResilienceTest_lib_resilience, DischargeBatteryModelHourly)
     auto cap = batt->battery_model->capacity_model();
     auto vol = batt->battery_model->voltage_model();
     cap->change_SOC_limits(0, 100);
+    double current = 1;
     while (cap->SOC() > 40)
-        batt->battery_model->run(0, 1);
+        batt->battery_model->run(0, current);
 
     battery_t initial_batt = battery_t(*batt->battery_model);
     auto battery = new battery_t(initial_batt);
@@ -73,7 +74,7 @@ TEST_F(ResilienceTest_lib_resilience, DischargeBatteryModelHourly)
         cap = battery->capacity_model();
         vol = battery->voltage_model();
 
-        double current = vol->calculate_current_for_target_w(desired_power, cap->q0(), cap->qmax(), 0);
+        current = vol->calculate_current_for_target_w(desired_power, cap->q0(), cap->qmax(), 0);
 
         battery->run(1, current);
 
@@ -100,8 +101,9 @@ TEST_F(ResilienceTest_lib_resilience, DischargeBatteryModelSubHourly)
     auto cap = batt->battery_model->capacity_model();
     auto vol = batt->battery_model->voltage_model();
     cap->change_SOC_limits(0, 100);
+    double current = 1;
     while (cap->SOC() > 40)
-        batt->battery_model->run(0, 1);
+        batt->battery_model->run(0, current);
 
     battery_t initial_batt = battery_t(*batt->battery_model);
     auto battery = new battery_t(initial_batt);
@@ -116,7 +118,7 @@ TEST_F(ResilienceTest_lib_resilience, DischargeBatteryModelSubHourly)
         cap = battery->capacity_model();
         vol = battery->voltage_model();
 
-        double current = vol->calculate_current_for_target_w(desired_power, cap->q0(), cap->qmax(), 0);
+        current = vol->calculate_current_for_target_w(desired_power, cap->q0(), cap->qmax(), 0);
 
         battery->run(1, current);
         double actual_power = cap->I() * vol->battery_voltage();
@@ -142,8 +144,9 @@ TEST_F(ResilienceTest_lib_resilience, ChargeBatteryModelHourly)
     auto cap = batt->battery_model->capacity_model();
     auto vol = batt->battery_model->voltage_model();
     cap->change_SOC_limits(0, 100);
+    double current = -1;
     while (cap->SOC() > 90)
-        batt->battery_model->run(0, -1);
+        batt->battery_model->run(0, current);
 
     battery_t initial_batt = battery_t(*batt->battery_model);
     auto battery = new battery_t(initial_batt);
@@ -155,7 +158,7 @@ TEST_F(ResilienceTest_lib_resilience, ChargeBatteryModelHourly)
         cap = battery->capacity_model();
         vol = battery->voltage_model();
 
-        double current = vol->calculate_current_for_target_w(-desired_power, cap->q0(), cap->qmax(), 0);
+        current = vol->calculate_current_for_target_w(-desired_power, cap->q0(), cap->qmax(), 0);
         battery->run(1, current);
 
         printf("%f\t target p, %f\t q0, %f\t soc, %f\t current, %f\t voltage, %f\t power, %f\t temp\n", desired_power, cap->q0(), cap->SOC(),
@@ -181,8 +184,9 @@ TEST_F(ResilienceTest_lib_resilience, ChargeBatteryModelSubhourly)
     auto cap = batt->battery_model->capacity_model();
     auto vol = batt->battery_model->voltage_model();
     cap->change_SOC_limits(0, 100);
+    double current = -1;
     while (cap->SOC() > 90)
-        batt->battery_model->run(0, -1);
+        batt->battery_model->run(0, current);
 
     battery_t initial_batt = battery_t(*batt->battery_model);
     auto battery = new battery_t(initial_batt);
@@ -194,7 +198,7 @@ TEST_F(ResilienceTest_lib_resilience, ChargeBatteryModelSubhourly)
         cap = battery->capacity_model();
         vol = battery->voltage_model();
 
-        double current = vol->calculate_current_for_target_w(-desired_power, cap->q0(), cap->qmax(), 0);
+        current = vol->calculate_current_for_target_w(-desired_power, cap->q0(), cap->qmax(), 0);
         battery->run(1, current);
 
         printf("%f\t target p, %f\t q0, %f\t soc, %f\t current, %f\t voltage, %f\t power, %f\t temp\n", desired_power, cap->q0(), cap->SOC(),
@@ -533,7 +537,11 @@ TEST_F(ResilienceTest_lib_resilience, PVWattsACHourly_Discharge)
         resilience.run_surviving_batteries(load[i], 0, 0, 0, 0, 0);
         batt->advance(vartab, ac[i], voltage, load[i]);
         charge_total.emplace_back(batt->battery_model->battery_charge_total());
-        EXPECT_NEAR(batt->outBatteryPower[i], 1., 1e-3) << "timestep " << i;
+        if (i < 5)
+            EXPECT_NEAR(batt->outBatteryPower[i], 1., 1e-3) << "timestep " << i;
+        else
+            EXPECT_LT(batt->outBatteryPower[i], 1.) << "timestep " << i;
+
     }
     std::vector<double> correct_charge_total = {13.86, 11.96, 10.05, 8.10, 6.10, 4.57, 4.57, 4.57, 4.57, 4.57};
 

--- a/test/shared_test/lib_resilience_test.cpp
+++ b/test/shared_test/lib_resilience_test.cpp
@@ -659,7 +659,7 @@ TEST_F(ResilienceTest_lib_resilience, PVWattsDCHourly_Discharge)
         if (i < 5)
             EXPECT_NEAR(batt->outBatteryPower[i], 1. * inverter->efficiencyAC/100. * batt_vars->batt_dc_dc_bms_efficiency/100., 1e-3) << "timestep " << i << " battery discharging";
         else if (i == 5)
-            EXPECT_NEAR(batt->outBatteryPower[i], 0.947, 1e-3) << "timestep 5 battery SOC limits";
+            EXPECT_NEAR(batt->outBatteryPower[i], 0.92, 1e-3) << "timestep 5 battery SOC limits";
         else
             EXPECT_NEAR(batt->outBatteryPower[i], 0, 1e-3) << "timestep " << i << " battery at min SOC";
 

--- a/test/ssc_test/cmod_battery_test.cpp
+++ b/test/ssc_test/cmod_battery_test.cpp
@@ -23,7 +23,7 @@ TEST_F(CMBattery_cmod_battery, CommercialLifetimePeakShaving) {
 		// roundtrip efficiency test will ensure that the battery cycled
 		ssc_number_t roundtripEfficiency;
 		ssc_data_get_number(data, "average_battery_roundtrip_efficiency", &roundtripEfficiency);
-		EXPECT_NEAR(roundtripEfficiency, 82.75, 2);
+		EXPECT_NEAR(roundtripEfficiency, 94.42, 2);
 
 		// test that lifetime output is achieved
 		int n;


### PR DESCRIPTION
From bugs reported in NREL/sam#240 and NREL/sam#239, there were a few battery bugs:

1. the battery was discharging even when the state of charge had reached its minimum limit

- This was fixed by propagating changes to the current in `battery_t::run` so that the state of charge limits enforced

2. the pv + battery system output wasn't properly accounting for the energy pulled from the grid, which would reduce the system output (making it negative), which resulted in utility rate not accounting for this purchased energy

- This was fixed by re-adding the (negative) battery charge power into the `gen` output. Tests were written for `BatteryPowerFlow` which revealed some operational differences between AC and DC connected batteries. 

- For instance, when the battery is told to charge, in AC systems the battery will charge only after load has been met, but in DC systems, the battery will prefer to charge first from PV then grid and meeting the load from the grid.
