### PR TITLE
Fix SAM issue #291, calendar degradaton specified in a table

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -1432,8 +1432,8 @@ double lifetime_calendar_t::runLifetimeCalendarModel(size_t idx, double T, doubl
 		// only run once per iteration (need to make the last iteration)
 		if (idx > _last_idx)
 		{
-
-			if (idx % util::hours_per_day / _dt_hour == 0)
+			int steps_per_day = (int) std::round(util::hours_per_day / _dt_hour);
+			if (idx % steps_per_day == 0)
 				_day_age_of_battery++;
 
 			if (_calendar_choice == lifetime_calendar_t::LITHIUM_ION_CALENDAR_MODEL)

--- a/test/shared_test/lib_battery_test.cpp
+++ b/test/shared_test/lib_battery_test.cpp
@@ -117,3 +117,27 @@ TEST_F(BatteryTest, AugmentCapacity)
 
 
 }
+
+TEST_F(BatteryTest, TestLifetimeDegradation) {
+	double vals[] = { 0, 100, 365, 50 };
+	util::matrix_t<double> lifetime_matrix;
+	lifetime_matrix.assign(vals, 2, 2);
+
+	double dt_hour = 1;
+	lifetime_calendar_t hourly_lifetime(lifetime_calendar_t::CALENDAR_LOSS_OPTIONS::CALENDAR_LOSS_TABLE, lifetime_matrix, dt_hour);
+
+	for (int idx = 0; idx < 8760; idx++) {
+		hourly_lifetime.runLifetimeCalendarModel(idx, 20, 80);
+	}
+
+	EXPECT_NEAR(hourly_lifetime.capacity_percent(), 50, 1);
+
+	dt_hour = 1.0 / 12.0; // Every 5 mins
+	lifetime_calendar_t subhourly_lifetime(lifetime_calendar_t::CALENDAR_LOSS_OPTIONS::CALENDAR_LOSS_TABLE, lifetime_matrix, dt_hour);
+
+	for (int idx = 0; idx < 8760 * 12; idx++) {
+		subhourly_lifetime.runLifetimeCalendarModel(idx, 20, 80);
+	}
+
+	EXPECT_NEAR(subhourly_lifetime.capacity_percent(), 50, 1);
+}


### PR DESCRIPTION
Due to an operator precedence error (% occuring before /) subhourly table based simulations were degrading faster than specified. Fix this issue and add a test.

To test: run SAM with the files from https://github.com/NREL/SAM/issues/291. Hourly degradation should match subhourly.