### PR TITLE
Pvwatts bifacial

### DIFF
--- a/ssc/cmod_pvwattsv7.cpp
+++ b/ssc/cmod_pvwattsv7.cpp
@@ -807,7 +807,7 @@ public:
 
 					if (module.bifaciality > 0)
 					{
-						irr.calc_rear_side(0.013, 1, module.length * pv.nmody);
+						irr.calc_rear_side(bifacialTransmissionFactor, 1, module.length * pv.nmody);
 						irear = irr.get_poa_rear() * module.bifaciality; //total rear irradiance is returned, so must multiply module bifaciality
 					}
 
@@ -1046,7 +1046,8 @@ public:
 							if (y == 0) ld("poa_loss_soiling") = 0;
 
 						// now add up total effective POA, accounting for external and self shading
-						poa = ibeam + iskydiff + ignddiff + irear; //irear is zero if not bifacial
+						double poa_front = ibeam + iskydiff + ignddiff;
+						poa = poa_front + irear; //irear is zero if not bifacial
 
 						// dc power nominal before any losses
 						double dc_nom = pv.dc_nameplate*poa / 1000; // Watts_DC * (POA W/m2 / 1000 W/m2 STC value );
@@ -1054,17 +1055,17 @@ public:
 
 						// module cover module to handle transmitted POA
 						double f_cover = 1.0;
-						if (aoi > AOI_MIN && aoi < AOI_MAX && poa > 0)
+						if (aoi > AOI_MIN && aoi < AOI_MAX && poa_front > 0)
 						{
 							/*double modifier = iam( aoi, module.ar_glass );
 							double tpoa = poa - ( 1.0 - modifier )*wf.dn*cosd(aoi); */ // previous PVWatts method, skips diffuse calc
 
-							double tpoa = calculateIrradianceThroughCoverDeSoto(
+							tpoa = calculateIrradianceThroughCoverDeSoto(
 								aoi, solzen, stilt, ibeam, iskydiff, ignddiff, en_sdm == 0 && module.ar_glass);
 							if (tpoa < 0.0) tpoa = 0.0;
-							if (tpoa > poa) tpoa = poa;
+							if (tpoa > poa) tpoa = poa_front;
 
-							f_cover = tpoa / poa;
+							f_cover = tpoa / poa_front;
 						}
 
 						if (y == 0) ld("dc_loss_cover") += (1 - f_cover)*dc_nom * ts_hour; //ts_hour required to correctly convert to Wh for subhourly data

--- a/test/input_cases/pvwattsv7_cases.h
+++ b/test/input_cases/pvwattsv7_cases.h
@@ -6,8 +6,8 @@
 #include "code_generator_utilities.h"
 
 /**
-*   Data for high-level integration test that verifies whether results for a no-financials
-*	PVWatts case matches expected results.
+*   Data for high-level integration test that verifies whether results for a no-financials 
+*	PVWatts case matches expected results.  
 *	Data generated from code-generator (Shift+F5) within SAM UI.
 *   Test uses SSCAPI interfaces (similiar to SDK usage) to pass and receive data to PVWattsV7
 */
@@ -31,20 +31,20 @@ int pvwattsv7_nofinancial_testfile(ssc_data_t &data)
 
 	//set the variables for the PVWatts default case
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	ssc_data_set_number(data, "analysis_period", 1);
+	ssc_data_set_number(data, "analysis_period", 25);
 	ssc_data_set_string(data, "solar_resource_file", hourly); //file set above
-	ssc_data_set_number(data, "system_capacity", 4.692);
-	ssc_data_set_number(data, "module_type", 1);
+	ssc_data_set_number(data, "system_capacity", 4);
+	ssc_data_set_number(data, "module_type", 0);
 	ssc_data_set_number(data, "dc_ac_ratio", 1.2000000476837158);
 	ssc_data_set_number(data, "bifaciality", 0);
 
 	ssc_data_set_number(data, "array_type", 0);
 	ssc_data_set_number(data, "tilt", 20);
 	ssc_data_set_number(data, "azimuth", 180);
-	ssc_data_set_number(data, "gcr", 0.3);
+	ssc_data_set_number(data, "gcr", 0.40000000596046448);
 
 	ssc_data_set_number(data, "losses", 14.075660705566406);
-	ssc_data_set_number(data, "enable_wind_stow", 0);
+	//ssc_data_set_number(data, "enable_wind_stow", 0);
 	ssc_data_set_number(data, "inv_eff", 96);
 
 	ssc_data_set_number(data, "adjust:constant", 0);

--- a/test/input_cases/pvwattsv7_cases.h
+++ b/test/input_cases/pvwattsv7_cases.h
@@ -6,8 +6,8 @@
 #include "code_generator_utilities.h"
 
 /**
-*   Data for high-level integration test that verifies whether results for a no-financials 
-*	PVWatts case matches expected results.  
+*   Data for high-level integration test that verifies whether results for a no-financials
+*	PVWatts case matches expected results.
 *	Data generated from code-generator (Shift+F5) within SAM UI.
 *   Test uses SSCAPI interfaces (similiar to SDK usage) to pass and receive data to PVWattsV7
 */
@@ -31,20 +31,20 @@ int pvwattsv7_nofinancial_testfile(ssc_data_t &data)
 
 	//set the variables for the PVWatts default case
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	ssc_data_set_number(data, "analysis_period", 25);
+	ssc_data_set_number(data, "analysis_period", 1);
 	ssc_data_set_string(data, "solar_resource_file", hourly); //file set above
-	ssc_data_set_number(data, "system_capacity", 4);
-	ssc_data_set_number(data, "module_type", 0);
+	ssc_data_set_number(data, "system_capacity", 4.692);
+	ssc_data_set_number(data, "module_type", 1);
 	ssc_data_set_number(data, "dc_ac_ratio", 1.2000000476837158);
 	ssc_data_set_number(data, "bifaciality", 0);
 
 	ssc_data_set_number(data, "array_type", 0);
 	ssc_data_set_number(data, "tilt", 20);
 	ssc_data_set_number(data, "azimuth", 180);
-	ssc_data_set_number(data, "gcr", 0.40000000596046448);
+	ssc_data_set_number(data, "gcr", 0.3);
 
 	ssc_data_set_number(data, "losses", 14.075660705566406);
-	//ssc_data_set_number(data, "enable_wind_stow", 0);
+	ssc_data_set_number(data, "enable_wind_stow", 0);
 	ssc_data_set_number(data, "inv_eff", 96);
 
 	ssc_data_set_number(data, "adjust:constant", 0);

--- a/test/ssc_test/cmod_pvwattsv7_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv7_test.cpp
@@ -19,9 +19,9 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, DefaultNoFinancialModel_cmod_pvwat
 
 	for (size_t i = 0; i < 12; i++)
 		tmp += (double)monthly_energy[i];
-	//v5 is 6909.79, decrease of 2.4%: decreases due to shading, module cover losses, and spectral losses 
+	//v5 is 6909.79, decrease of 2.4%: decreases due to shading, module cover losses, and spectral losses
 	//v7 prior to module coeff changes is 6750.4236, increase of 3.7% due to improved tempco for standard module
-	EXPECT_NEAR(tmp, 7003.1477, error_tolerance) << "Annual energy."; 
+	EXPECT_NEAR(tmp, 7003.1477, error_tolerance) << "Annual energy.";
 
 
 	EXPECT_NEAR((double)monthly_energy[0], 439.755, error_tolerance) << "Monthly energy of January";
@@ -75,7 +75,7 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, DifferentTechnologyInputs_cmod_pvw
 
 	// Array types: Fixed open rack, fixed roof mount, 1-axis tracking, 1-axis backtracking, 2-axis tracking
 	for (int array_type = 0; array_type < 5; array_type++)
-	{		
+	{
 		pairs["array_type"] = array_type;
 		int pvwatts_errors = modify_ssc_data_and_run_module(data, "pvwattsv7", pairs);
 		EXPECT_FALSE(pvwatts_errors);
@@ -123,7 +123,7 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, LargeSystem_cmod_pvwattsv7)
 	}
 }
 
-/// Test pvwattsv7 with default inputs and a 15-minute weather file 
+/// Test pvwattsv7 with default inputs and a 15-minute weather file
 TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, SubhourlyWeather_cmod_pvwattsv7) {
 
 	char subhourly[256];
@@ -201,18 +201,26 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, BifacialTest_cmod_pvwattsv7) {
 
 	// set bifacial inputs
 	std::map<std::string, double> pairs;
-	pairs["bifaciality"] = 0.65;
+	pairs["bifaciality"] = 0.0;
+    ssc_number_t annual_energy_mono = 0, annual_energy_bi = 0;
 
 	int pvwatts_errors = modify_ssc_data_and_run_module(data, "pvwattsv7", pairs);
 	EXPECT_FALSE(pvwatts_errors);
 	if (!pvwatts_errors)
 	{
-		ssc_number_t annual_energy;
-		ssc_data_get_number(data, "annual_energy", &annual_energy);
-		EXPECT_NEAR(annual_energy, 7033.87, 0.1) << "System with bifaciality";
+		ssc_data_get_number(data, "annual_energy", &annual_energy_mono);
+		EXPECT_NEAR(annual_energy_mono, 8265, 1) << "System with bifaciality";
 	}
 
+    pairs["bifaciality"] = 0.65;
+    pvwatts_errors = modify_ssc_data_and_run_module(data, "pvwattsv7", pairs);
+    EXPECT_FALSE(pvwatts_errors);
+    if (!pvwatts_errors)
+    {
+        ssc_data_get_number(data, "annual_energy", &annual_energy_bi);
+    }
 
+    EXPECT_GT(annual_energy_bi/annual_energy_mono, 1.04);
 }
 
 /* this test isn't passing currently even though it's working in the UI, so commenting out for now

--- a/test/ssc_test/cmod_pvwattsv7_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv7_test.cpp
@@ -209,7 +209,7 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, BifacialTest_cmod_pvwattsv7) {
 	if (!pvwatts_errors)
 	{
 		ssc_data_get_number(data, "annual_energy", &annual_energy_mono);
-		EXPECT_NEAR(annual_energy_mono, 8265, 1) << "System with bifaciality";
+		EXPECT_NEAR(annual_energy_mono, 7003, 1) << "System with bifaciality";
 	}
 
     pairs["bifaciality"] = 0.65;


### PR DESCRIPTION
Thanks to detailed error reporting in NREL/SAM#295, the lack of bifaciality effect on the power was found to be due to bifacial simulations decreasing total POA, thereby reducing gains.

The total POA was reduced since the module cover loss was accurately calculated using just front side irradiance, but then a multiplier `f_cover` to the `poa_for_power` value was calculated incorrectly. 

With bifacials, `f_cover`, the ratio between the post-module cover `tpoa` and the original `poa`, was lowered since the denominator was front + rear rather than just front. 

This led to smaller gains in power as calculated by `poa_for_power *= f_cover * f_AM;`

Updated test to show `annual_energy_bi/annual_energy_mono` > 1.04