### PR TITLE
add "gen" as output to PVWatts

### DIFF
--- a/ssc/cmod_pvwattsv5.cpp
+++ b/ssc/cmod_pvwattsv5.cpp
@@ -85,7 +85,7 @@ static var_info _cm_vtab_pvwattsv5_part2[] = {
 
         { SSC_OUTPUT,       SSC_ARRAY,       "dc",                             "DC array power",                              "W",     "",                         "Time Series",      "*",                       "",                          "" },
         { SSC_OUTPUT,       SSC_ARRAY,       "ac",                             "AC inverter power",                           "W",     "",                         "Time Series",      "*",                       "",                          "" },
-
+        { SSC_OUTPUT,       SSC_ARRAY,       "gen",                            "AC system power (lifetime)",                  "kWh",       "",                                             "Time Series",      "*",                       "",                          "" },
 
         { SSC_OUTPUT,       SSC_ARRAY,       "poa_monthly",                    "Plane of array irradiance",                   "kWh/m2",    "",                     "Monthly",          "*",                       "LENGTH=12",                          "" },
         { SSC_OUTPUT,       SSC_ARRAY,       "solrad_monthly",                 "Daily average solar irradiance",              "kWh/m2/day","",                     "Monthly",          "*",                       "LENGTH=12",                          "" },

--- a/ssc/cmod_pvwattsv7.cpp
+++ b/ssc/cmod_pvwattsv7.cpp
@@ -167,7 +167,8 @@ static var_info _cm_vtab_pvwattsv7[] = {
 		{ SSC_OUTPUT,       SSC_ARRAY,       "dcsnowderate",                   "Array DC power loss due to snow",            "%",         "",                                             "Time Series",      "*",                       "",                          "" },
 
 		{ SSC_OUTPUT,       SSC_ARRAY,       "dc",                             "DC array power",                              "W",         "",                                             "Time Series",      "*",                       "",                          "" },
-		{ SSC_OUTPUT,       SSC_ARRAY,       "ac",                             "AC inverter power",                           "W",         "",                                             "Time Series",      "*",                       "",                          "" },
+        { SSC_OUTPUT,       SSC_ARRAY,       "ac",                             "AC inverter power",                           "W",         "",                                             "Time Series",      "*",                       "",                          "" },
+        { SSC_OUTPUT,       SSC_ARRAY,       "gen",                            "AC system power (lifetime)",                  "kWh",       "",                                             "Time Series",      "*",                       "",                          "" },
 
 		{ SSC_OUTPUT,       SSC_ARRAY,       "poa_monthly",                    "Plane of array irradiance",                   "kWh/m2",    "",                                             "Monthly",          "*",                       "LENGTH=12",                          "" },
 		{ SSC_OUTPUT,       SSC_ARRAY,       "solrad_monthly",                 "Daily average solar irradiance",              "kWh/m2/day","",                                             "Monthly",          "*",                       "LENGTH=12",                          "" },

--- a/ssc/cmod_pvwattsv7.cpp
+++ b/ssc/cmod_pvwattsv7.cpp
@@ -168,7 +168,6 @@ static var_info _cm_vtab_pvwattsv7[] = {
 
 		{ SSC_OUTPUT,       SSC_ARRAY,       "dc",                             "DC array power",                              "W",         "",                                             "Time Series",      "*",                       "",                          "" },
         { SSC_OUTPUT,       SSC_ARRAY,       "ac",                             "AC inverter power",                           "W",         "",                                             "Time Series",      "*",                       "",                          "" },
-        { SSC_OUTPUT,       SSC_ARRAY,       "gen",                            "AC system power (lifetime)",                  "kWh",       "",                                             "Time Series",      "*",                       "",                          "" },
 
 		{ SSC_OUTPUT,       SSC_ARRAY,       "poa_monthly",                    "Plane of array irradiance",                   "kWh/m2",    "",                                             "Monthly",          "*",                       "LENGTH=12",                          "" },
 		{ SSC_OUTPUT,       SSC_ARRAY,       "solrad_monthly",                 "Daily average solar irradiance",              "kWh/m2/day","",                                             "Monthly",          "*",                       "LENGTH=12",                          "" },
@@ -275,6 +274,7 @@ protected:
 public:
 	cm_pvwattsv7()
 	{
+        add_var_info(vtab_technology_outputs);
 		add_var_info(_cm_vtab_pvwattsv7);
 		add_var_info(vtab_adjustment_factors);
 
@@ -342,10 +342,6 @@ public:
 
 	void exec() throw(general_error)
 	{
-		// don't add "gen" output if battery enabled, gets added later
-		if (!as_boolean("batt_simple_enable"))
-			add_var_info(vtab_technology_outputs);
-
 		std::unique_ptr<weather_data_provider> wdprov;
 
 		if (is_assigned("solar_resource_file"))

--- a/ssc/vartab.h
+++ b/ssc/vartab.h
@@ -44,7 +44,7 @@ typedef unordered_map< std::string, var_data* > var_hash;
 class var_table
 {
 public:
-	explicit var_table();
+	var_table();
     var_table(const var_table &rhs);
     virtual ~var_table();
 	var_table &operator=( const var_table &rhs );


### PR DESCRIPTION
Expose "gen" in var table as lifetime system power output. Originally hidden since lifetime PVWatts was not used in GUI since the degradation isn't explicitly simulated, but now that it is being used in the GUI, the variable should be listed for export.

Addresses issue NREL/pysam#31. Also see #371 