### PR TITLE
Sam 315 energy accumulation fuel cell

### DIFF
--- a/ssc/cmod_pvwattsv7.cpp
+++ b/ssc/cmod_pvwattsv7.cpp
@@ -1217,11 +1217,10 @@ public:
 			}
 
 			wdprov->rewind();
-			if (y == 0) {
-				accumulate_monthly("gen", "monthly_energy", ts_hour);
-				accumulate_annual("gen", "annual_energy", ts_hour);
-			}
 		}
+
+		accumulate_monthly_for_year("gen", "monthly_energy", ts_hour, step_per_hour);
+		accumulate_annual_for_year("gen", "annual_energy", ts_hour, step_per_hour);
 
 		accumulate_monthly("dc", "dc_monthly", 0.001*ts_hour);
 		accumulate_monthly("ac", "ac_monthly", 0.001*ts_hour);


### PR DESCRIPTION
pvwatts7 was throwing an error when run in a subhourly fuel cell configuration (see https://github.com/NREL/SAM/issues/315). Fix the error by migrating from accumulate_monthly to accumulate_monthly_for_year.

It looks like this solves a second bug, where even on an hourly fuel cell configuration, all of the energy was being placed in January. Before fix:

![fuel_cell_before](https://user-images.githubusercontent.com/5530592/82575143-4e7bb400-9b45-11ea-8389-b036ab5f4b9f.png)

After fix:

![fuel_cell_after](https://user-images.githubusercontent.com/5530592/82575290-8256d980-9b45-11ea-8467-61a64d1eb248.png)

Mysteries: why did pvwattsv7 work subhourly without the fuel cell?

Questions: do any additional instances of accumulate_monthly need to change?