### PR TITLE
Pvwattsv5 1ts

### DIFF
--- a/ssc/cmod_pvwattsv5.cpp
+++ b/ssc/cmod_pvwattsv5.cpp
@@ -627,8 +627,8 @@ DEFINE_MODULE_ENTRY(pvwattsv5, "PVWatts V5 - integrated hourly weather reader an
 
 static var_info _cm_vtab_pvwattsv5_1ts_outputs[] = {
 	/* input/output variable: tcell & poa from previous time must be given */
-	{ SSC_INOUT,        SSC_NUMBER,      "tcell",                    "Module temperature",                          "C",      "",                        "PVWatts",      "*",                       "",                          "" },
-	{ SSC_INOUT,        SSC_NUMBER,      "poa",                      "Plane of array irradiance",                   "W/m2",   "",                        "PVWatts",      "*",                       "",                          "" },
+	{ SSC_INOUT,        SSC_NUMBER,      "tcell",                    "Module temperature",                          "C",      "",                        "PVWatts",      "",                       "",                          "" },
+	{ SSC_INOUT,        SSC_NUMBER,      "poa",                      "Plane of array irradiance",                   "W/m2",   "",                        "PVWatts",      "",                       "",                          "" },
 
 	/* outputs */
 	{ SSC_OUTPUT,       SSC_NUMBER,      "dc",                      "DC array output",                             "Wdc",    "",                        "PVWatts",      "*",                       "",                          "" },
@@ -649,6 +649,8 @@ public:
 
 	void exec()
 	{
+        setup_system_inputs();
+        initialize_cell_temp(as_number("time_step"));
 		int year = as_integer("year");
 		int month = as_integer("month");
 		int day = as_integer("day");
@@ -662,7 +664,6 @@ public:
 		double tamb = as_double("tamb");
 		double wspd = as_double("wspd");
 		double alb = as_double("alb");
-		//double time_step = as_double("time_step");
 
 		//double last_tcell = as_double("tcell");
 		//double last_poa = as_double("poa");

--- a/ssc/cmod_pvwattsv5.cpp
+++ b/ssc/cmod_pvwattsv5.cpp
@@ -626,9 +626,9 @@ DEFINE_MODULE_ENTRY(pvwattsv5, "PVWatts V5 - integrated hourly weather reader an
 		var_info_invalid };
 
 static var_info _cm_vtab_pvwattsv5_1ts_outputs[] = {
-	/* input/output variable: tcell & poa from previous time must be given */
-	{ SSC_INOUT,        SSC_NUMBER,      "tcell",                    "Module temperature",                          "C",      "",                        "PVWatts",      "",                       "",                          "" },
-	{ SSC_INOUT,        SSC_NUMBER,      "poa",                      "Plane of array irradiance",                   "W/m2",   "",                        "PVWatts",      "",                       "",                          "" },
+	/* input/output variable: tcell & poa from previous time may be given */
+	{ SSC_INOUT,        SSC_NUMBER,      "tcell",                    "Module temperature",                         "C",      "Output from last time step may be used as input",                        "PVWatts",      "",                       "",                          "" },
+	{ SSC_INOUT,        SSC_NUMBER,      "poa",                      "Plane of array irradiance",                  "W/m2",   "Output from last time step may be used as input",                        "PVWatts",      "",                       "",                          "" },
 
 	/* outputs */
 	{ SSC_OUTPUT,       SSC_NUMBER,      "dc",                      "DC array output",                             "Wdc",    "",                        "PVWatts",      "*",                       "",                          "" },
@@ -650,7 +650,11 @@ public:
 	void exec()
 	{
         setup_system_inputs();
-        initialize_cell_temp(as_number("time_step"));
+        double ts = as_number("time_step");
+        if (is_assigned("tcell") && is_assigned("poa"))
+            initialize_cell_temp(ts, as_double("tcell"), as_double("poa"));
+        else
+            initialize_cell_temp(ts);
 		int year = as_integer("year");
 		int month = as_integer("month");
 		int day = as_integer("day");
@@ -664,9 +668,6 @@ public:
 		double tamb = as_double("tamb");
 		double wspd = as_double("wspd");
 		double alb = as_double("alb");
-
-		//double last_tcell = as_double("tcell");
-		//double last_poa = as_double("poa");
 
 		double shad_beam = 1.0;
 		powerout(0, 1.0, shad_beam, 1.0, beam, diff, alb, wspd, tamb);

--- a/test/ssc_test/cmod_pvwattsv5_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv5_test.cpp
@@ -123,3 +123,39 @@ TEST_F(CMPvwattsV5Integration_cmod_pvwattsv5, LargeSystem_cmod_pvwattsv5)
 		count++;
 	}
 }
+
+
+TEST_F(CMPvwattsV5Integration_cmod_pvwattsv5, singleTS) {
+    auto data = ssc_data_create();
+    ssc_data_set_number(data, "alb", .2);
+    ssc_data_set_number(data, "beam", 0.612);
+    ssc_data_set_number(data, "day", 6);
+    ssc_data_set_number(data, "diffuse", 162.91);
+    ssc_data_set_number(data, "hour", 13);
+    ssc_data_set_number(data, "lat", 39.744);
+    ssc_data_set_number(data, "lon", -105.1778);
+    ssc_data_set_number(data, "minute", 20);
+    ssc_data_set_number(data, "month", 1);
+    ssc_data_set_number(data, "tamb", 10.79);
+    ssc_data_set_number(data, "tz", -7);
+    ssc_data_set_number(data, "wspd", 1.4500);
+    ssc_data_set_number(data, "year", 2019);
+    ssc_data_set_number(data, "tcell", 30);
+    ssc_data_set_number(data, "poa", 10);
+
+    ssc_data_set_number(data, "array_type", 2);
+    ssc_data_set_number(data, "azimuth", 180);
+    ssc_data_set_number(data, "dc_ac_ratio", 1.2);
+    ssc_data_set_number(data, "gcr", 0.4);
+    ssc_data_set_number(data, "inv_eff", 96);
+    ssc_data_set_number(data, "losses", 0);
+    ssc_data_set_number(data, "module_type", 0);
+    ssc_data_set_number(data, "system_capacity", 720);
+    ssc_data_set_number(data, "tilt", 0);
+
+
+    auto mod = ssc_module_create("pvwattsv5_1ts");
+    EXPECT_TRUE(ssc_module_exec(mod, data));
+
+
+}

--- a/test/ssc_test/cmod_pvwattsv5_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv5_test.cpp
@@ -140,8 +140,8 @@ TEST_F(CMPvwattsV5Integration_cmod_pvwattsv5, singleTS) {
     ssc_data_set_number(data, "tz", -7);
     ssc_data_set_number(data, "wspd", 1.4500);
     ssc_data_set_number(data, "year", 2019);
-    ssc_data_set_number(data, "tcell", 30);
-    ssc_data_set_number(data, "poa", 10);
+//    ssc_data_set_number(data, "tcell", 30);
+//    ssc_data_set_number(data, "poa", 10);
 
     ssc_data_set_number(data, "array_type", 2);
     ssc_data_set_number(data, "azimuth", 180);
@@ -157,5 +157,11 @@ TEST_F(CMPvwattsV5Integration_cmod_pvwattsv5, singleTS) {
     auto mod = ssc_module_create("pvwattsv5_1ts");
     EXPECT_TRUE(ssc_module_exec(mod, data));
 
-
+    double val;
+    ssc_data_get_number(data, "poa", &val);
+    EXPECT_NEAR(val, 140.21, 1);
+    ssc_data_get_number(data, "tcell", &val);
+    EXPECT_NEAR(val, 12.77, 1);
+    ssc_data_get_number(data, "ac", &val);
+    EXPECT_NEAR(val, 100851.88, 1);
 }

--- a/test/ssc_test/cmod_pvwattsv5_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv5_test.cpp
@@ -140,8 +140,6 @@ TEST_F(CMPvwattsV5Integration_cmod_pvwattsv5, singleTS) {
     ssc_data_set_number(data, "tz", -7);
     ssc_data_set_number(data, "wspd", 1.4500);
     ssc_data_set_number(data, "year", 2019);
-//    ssc_data_set_number(data, "tcell", 30);
-//    ssc_data_set_number(data, "poa", 10);
 
     ssc_data_set_number(data, "array_type", 2);
     ssc_data_set_number(data, "azimuth", 180);
@@ -153,15 +151,31 @@ TEST_F(CMPvwattsV5Integration_cmod_pvwattsv5, singleTS) {
     ssc_data_set_number(data, "system_capacity", 720);
     ssc_data_set_number(data, "tilt", 0);
 
-
     auto mod = ssc_module_create("pvwattsv5_1ts");
+
+    // without previous tcell & poa
     EXPECT_TRUE(ssc_module_exec(mod, data));
 
     double val;
     ssc_data_get_number(data, "poa", &val);
-    EXPECT_NEAR(val, 140.21, 1);
+    EXPECT_NEAR(val, 140.21, .1);
     ssc_data_get_number(data, "tcell", &val);
-    EXPECT_NEAR(val, 12.77, 1);
+    EXPECT_NEAR(val, 12.77, .1);
+    ssc_data_get_number(data, "dc", &val);
+    EXPECT_NEAR(val, 106739, 1);
     ssc_data_get_number(data, "ac", &val);
-    EXPECT_NEAR(val, 100851.88, 1);
+    EXPECT_NEAR(val, 100851, 1);
+
+    EXPECT_TRUE(ssc_module_exec(mod, data));
+
+    // tcell & poa are assigned from above exec call
+    val;
+    ssc_data_get_number(data, "poa", &val);
+    EXPECT_NEAR(val, 140.21, .1);
+    ssc_data_get_number(data, "tcell", &val);
+    EXPECT_NEAR(val, 13.36, .1);
+    ssc_data_get_number(data, "dc", &val);
+    EXPECT_NEAR(val, 106459, 1);
+    ssc_data_get_number(data, "ac", &val);
+    EXPECT_NEAR(val, 100579, 1);
 }


### PR DESCRIPTION
Copying comment over from #385 :

It looks like the Pvwattsv5 single time step model wasn’t correctly updated with some recent refactoring.

I fixed this by calling initializing functions from base pvwattsv5 class in the pvwattsv5_1ts: 4ef0b09

Regarding poa and tcell, a comment says 
>/* input/output variable: tcell & poa from previous time must be given */

but these values are not used in the code.

It looks like they could be used as part of `initialize_cell_temp`, which can use `poa` and `tcell` from the last time step.

Question for @janinefreeman, should `poa` and `tcell` of the last time step be required/used? If not, should they not be "required inputs", since users may not have these values to start?