### PR TITLE
Re-indent var_table::lookup to eliminate G++ misleading-indentation warning

### DIFF
--- a/ssc/vartab.cpp
+++ b/ssc/vartab.cpp
@@ -318,13 +318,13 @@ bool var_table::rename_match_case( const std::string &oldname, const std::string
 
 var_data *var_table::lookup( const std::string &name )
 {
-    var_hash::iterator it = m_hash.find(name );
+    var_hash::iterator it = m_hash.find(name);
     if (it == m_hash.end())
-        it = m_hash.find( util::lower_case(name) );
-	if ( it != m_hash.end() )
-		return (*it).second;
-	else
-		return NULL;
+      it = m_hash.find( util::lower_case(name));
+    if ( it != m_hash.end() )
+      return (*it).second;
+    else
+      return NULL;
 }
 
 var_data *var_table::lookup_match_case( const std::string &name )


### PR DESCRIPTION
The code is correct, but the indenation makes it misleading (and G++ agrees!)

```
vartab.cpp: In member function ‘var_data* var_table::lookup(const string&)’:
vartab.cpp:322:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
  322 |     if (it == m_hash.end())
      |     ^~
vartab.cpp:324:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  324 |  if ( it != m_hash.end() )
      |  ^~
```