### PR TITLE
Use add_compile_options to set nlopt options correctly

### DIFF
--- a/nlopt/CMakeLists.txt
+++ b/nlopt/CMakeLists.txt
@@ -68,7 +68,7 @@ set_no_warnings()
 if(MSVC)
     add_compile_definitions( __WXMSW__ _MBCS )
 else(MSVC)
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
+    add_compile_options(-Wall -Wno-deprecated-declarations)
 endif(MSVC)
 
 


### PR DESCRIPTION
Use add_compile_options() in `nlopt/CMakeLists.txt` to set the options correctly on non-MSVC platforms. Appending to `CMAKE_CXX_FLAGS` is not appropriate for this directory as it contains C source files, not C++.
