### PR TITLE
Remove unused variables

### DIFF
--- a/ssc/cmod_fuelcell.cpp
+++ b/ssc/cmod_fuelcell.cpp
@@ -139,7 +139,7 @@ void cm_fuelcell::exec()
 	double annual_fuel = 0.0;
 	float percent_complete = 0.0;
 	float percent = 0.0;
-	size_t nStatusUpdates = 50;
+	// size_t nStatusUpdates = 50;
 
 	if (is_assigned("percent_complete")) {
 		percent_complete = as_float("percent_complete");

--- a/ssc/cmod_pvsamv1_eqns.cpp
+++ b/ssc/cmod_pvsamv1_eqns.cpp
@@ -34,7 +34,7 @@ void map_optional_input(var_table* vt, const std::string& sam_name, var_table* r
     catch (std::runtime_error&) {
         sam_input = def_val;
     }
-    if (var_data* vd = reopt_table->lookup(reopt_name)){
+    if (reopt_table->lookup(reopt_name)){
         throw std::runtime_error(reopt_name + " variable already exists in 'reopt_table'.");
     }
     reopt_table->assign(reopt_name, sam_input);

--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -1402,8 +1402,6 @@ public:
                         throw exec_error("sco2_csp_system", csp_exception.m_error_message);
                     }
 
-                    size_t ncols = T_htf_parametrics.ncols();
-
                     log("sCO2 off-design performance calculations for lookup tables complete.", SSC_WARNING);
                     update("sCO2 preprocess complete", 100.0);
 

--- a/ssc/cmod_test_ud_power_cycle.cpp
+++ b/ssc/cmod_test_ud_power_cycle.cpp
@@ -101,9 +101,6 @@ public:
 				}
 			}
 		}
-
-		double blah = 1.2345;
-
 	}
 
 	double three_var_eqn(double a, double b, double c)

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -2747,7 +2747,6 @@ public:
 		//int metering_option = as_integer("ur_metering_option");
 		bool excess_monthly_dollars = (as_integer("ur_metering_option") == 3);
 		int excess_dollars_credit_month = (int)as_number("ur_nm_credit_month");
-		bool rollover_credit = as_boolean("ur_nm_credit_rollover");
 
 		bool tou_demand_single_peak = (as_integer("TOU_demand_single_peak") == 1);
 


### PR DESCRIPTION
Picked up by G++ once I locally disabled `-Wunused-variables`.
