### PR TITLE
Include <cmath> for fabs, fmod, fmax, etc.

### DIFF
--- a/test/shared_test/lib_battery_test.cpp
+++ b/test/shared_test/lib_battery_test.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <gtest/gtest.h>
 
 #include "logger.h"


### PR DESCRIPTION
I'm not sure how this ever worked :smile:

Maybe it works on Visual Studio, but it doesn't work on G++ without <cmath> to declare `fabs`, `fmax`, `fmod`, etc.
