### PR TITLE
Fix dc_adjust issue SAM_335

### DIFF
--- a/ssc/cmod_generic_system.cpp
+++ b/ssc/cmod_generic_system.cpp
@@ -69,7 +69,6 @@ public:
 		add_var_info( _cm_vtab_generic_system );
 
 		// performance adjustment factors
-		add_var_info(vtab_dc_adjustment_factors);
 		add_var_info(vtab_adjustment_factors);
 		add_var_info(vtab_technology_outputs);
 	}

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1008,7 +1008,7 @@ void cm_pvsamv1::exec( ) throw (general_error)
 	// hourly adjustment factors
 	adjustment_factors haf(this, "adjust");
 	if (!haf.setup())
-		throw exec_error("pvsamv1", "failed to setup adjustment factors: " + haf.error());
+		throw exec_error("pvsamv1", "failed to setup AC adjustment factors: " + haf.error());
 
     // clipping losses for battery dispatch
 	std::vector<ssc_number_t> p_invcliploss_full;

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -486,9 +486,9 @@ var_info vtab_adjustment_factors[] = {
 var_info_invalid };
 
 var_info vtab_dc_adjustment_factors[] = {
-{ SSC_INPUT,SSC_NUMBER  , "dc_adjust:constant"                   , "DC Constant loss adjustment"                                    , "%"                                      , ""                                      , "Adjustment Factors"   , ""               , "MAX=100"               , ""},
-{ SSC_INPUT,SSC_ARRAY   , "dc_adjust:hourly"                     , "DC Hourly Adjustment Factors"                                   , "%"                                      , ""                                      , "Adjustment Factors"   , ""               , "LENGTH=8760"           , ""},
-{ SSC_INPUT,SSC_MATRIX  , "dc_adjust:periods"                    , "DC Period-based Adjustment Factors"                             , "%"                                      , "n x 3 matrix [ start, end, loss ]"     , "Adjustment Factors"   , ""               , "COLS=3"                , ""},
+{ SSC_INPUT,SSC_NUMBER  , "dc_adjust:constant"                   , "DC Constant loss adjustment"                                    , "%"                                      , ""                                      , "Adjustment Factors"   , "*"               , "MAX=100"               , ""},
+{ SSC_INPUT,SSC_ARRAY   , "dc_adjust:hourly"                     , "DC Hourly Adjustment Factors"                                   , "%"                                      , ""                                      , "Adjustment Factors"   , "?"               , "LENGTH=8760"           , ""},
+{ SSC_INPUT,SSC_MATRIX  , "dc_adjust:periods"                    , "DC Period-based Adjustment Factors"                             , "%"                                      , "n x 3 matrix [ start, end, loss ]"     , "Adjustment Factors"   , "?"               , "COLS=3"                , ""},
 var_info_invalid };
 
 var_info vtab_sf_adjustment_factors[] = {


### PR DESCRIPTION
https://github.com/NREL/SAM/issues/335

In common.cpp, make dc_adjust:constant required, and :hourly and :periods optional. This is consistent with the adjustment_factors setup() function that requires :constant.

Remove dc_adjust from generic_system. SAM UI does not assign a value to dc_adjust for the generic system configurations. Maybe this was added for some internal testing of DC losses for a generic system / battery configuration.

Change pvsamv1 label for adjust to "AC adjustment".