### PR TITLE
Vanadium flow battery: voltage model fixes

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -868,7 +868,7 @@ double voltage_vanadium_redox_t::calculate_max_charge_w(double q, double qmax, d
     double max_I = (q - qmax) / dt_hr;
 
     if (max_current)
-        *max_current = -max_I;
+        *max_current = max_I;
 
     return voltage_model(qmax, qmax, max_I, kelvin) * max_I * _num_strings * _num_cells_series;
 }
@@ -932,15 +932,14 @@ double voltage_vanadium_redox_t::voltage_model(double q0, double qmax, double I_
 	    SOC_use = 1e-3;
 
 	double A = std::log(std::pow(SOC_use, 2) / std::pow(1 - SOC_use, 2));
-
-	return _V_ref_50 + m_RCF * T * A + I_string * _R;
+	return _V_ref_50 + m_RCF * T * A + fabs(I_string) * _R;
 }
 
 void voltage_vanadium_redox_t::solve_current_for_power(const double *x, double *f){
     double I = x[0];
     double SOC = (solver_q - I * dt_hr) / solver_Q;
     f[0] = I * (_V_ref_50 + m_RCF * solver_T_k * std::log(SOC * SOC / std::pow(1. - SOC, 2)) +
-                I * _R) - solver_power;
+                fabs(I) * _R) - solver_power;
 }
 
 void voltage_vanadium_redox_t::solve_max_discharge_power(const double *x, double *f){

--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -868,7 +868,7 @@ double voltage_vanadium_redox_t::calculate_max_charge_w(double q, double qmax, d
     double max_I = (q - qmax) / dt_hr;
 
     if (max_current)
-        *max_current = max_I;
+        *max_current = max_I * _num_strings;
 
     return voltage_model(qmax, qmax, max_I, kelvin) * max_I * _num_strings * _num_cells_series;
 }

--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -923,6 +923,8 @@ double voltage_vanadium_redox_t::calculate_current_for_target_w(double P_watts, 
 }
 
 // I, Q, q0 are on a per-string basis since adding cells in series does not change current or charge
+// In constrast to the V_stack + I_stack * R_specific in the paper which follows the convention of negative voltages,
+// here the abs(I_stack) is used to allow both terms to move in same direction (https://github.com/NREL/ssc/issues/404)
 double voltage_vanadium_redox_t::voltage_model(double q0, double qmax, double I_string, double T)
 {
 	double SOC_use = q0 / qmax;

--- a/shared/lib_battery.h
+++ b/shared/lib_battery.h
@@ -385,7 +385,7 @@ protected:
 
 private:
 
-    // RC/F: R is Molar gas constant [J/mol/K]^M, R is Faraday constant [As/mol]^M, C is model correction factor^M
+    // RC/F: R is Molar gas constant [J/mol/K]^M, R is Faraday constant [As/mol]^M, C is model correction factor^M 1.38
     double m_RCF;
 
     double _V_ref_50;				// Reference voltage at 50% SOC

--- a/test/shared_test/lib_resilience_test.cpp
+++ b/test/shared_test/lib_resilience_test.cpp
@@ -537,8 +537,7 @@ TEST_F(ResilienceTest_lib_resilience, RoundtripEffVanadiumFlow){
 //        for (size_t i = 0; i < inputs.size(); i++) {
 //            printf("%f, %f\n", inputs[i], outputs[i]);
 //        }
-
-        printf("current %f, eff %f, n %zd\n", current, -output_power/input_power, n_t);
+//        printf("current %f, eff %f, n %zd\n", current, -output_power/input_power, n_t);
 
         current += fabs(max_current) / 100.;
     }

--- a/test/shared_test/lib_resilience_test.cpp
+++ b/test/shared_test/lib_resilience_test.cpp
@@ -492,6 +492,51 @@ TEST_F(ResilienceTest_lib_resilience, RoundtripEffTable){
     }
 }
 
+TEST_F(ResilienceTest_lib_resilience, RoundtripEffVanadiumFlow){
+   auto vol = new voltage_vanadium_redox_t(1, 1, 1.41, 0.001, 1);
+    auto cap = new capacity_lithium_ion_t(11, 30, 100, 0);
+    auto temp = thermal_test();
+
+    cap->change_SOC_limits(0, 100);
+
+
+    double full_current = 1000;
+    double max_current;
+    vol->calculate_max_charge_w(cap->q0(), cap->qmax(), temp.T_battery(), &max_current);
+
+    double current = fabs(max_current) * 0.01;
+    while (current < fabs(max_current)){
+        cap->updateCapacity(full_current, 1);   //discharge to empty
+
+        size_t n_t = 0;
+        current *= -1;
+        double input_power = 0.;
+        while(cap->SOC() < 100 ){
+            double input_current = current;
+            cap->updateCapacity(input_current, 1);
+            vol->updateVoltage(cap, &temp, 1);
+            input_power += cap->I() * vol->battery_voltage();
+            n_t += 1;
+        }
+
+        current *= -1;
+        double output_power = 0.;
+        while(vol->calculate_max_discharge_w(cap->q0(), cap->qmax(), temp.T_battery(), nullptr) > 0 ){
+            double output_current = current;
+            cap->updateCapacity(output_current, 1);
+            vol->updateVoltage(cap, &temp, 1);
+            output_power += cap->I() * vol->battery_voltage();
+            if (output_power < -1000)
+                int x = 0;
+            n_t += 1;
+        }
+
+        printf("current %f, eff %f, n %zd\n", current, -output_power/input_power, n_t);
+
+        current += fabs(max_current) / 100.;
+    }
+}
+
 TEST_F(ResilienceTest_lib_resilience, HourlyVsSubHourly)
 {
     CreateBattery(false, 1, 0. ,1., 1.);

--- a/test/shared_test/lib_resilience_test.cpp
+++ b/test/shared_test/lib_resilience_test.cpp
@@ -377,17 +377,17 @@ TEST_F(ResilienceTest_lib_resilience, VoltageVanadium){
     double v = volt.cell_voltage();
 
 
-    double req_cur = volt.calculate_current_for_target_w(1.5, 3.3, 11, temp.T_battery());
+    double req_cur = volt.calculate_current_for_target_w(-5, 3.3, 11, temp.T_battery());
     cap.updateCapacity(req_cur, 1);
     volt.updateVoltage(&cap, &temp, 1);
     v = volt.cell_voltage();
-    EXPECT_NEAR(req_cur * v, 1.5, 1e-2);
+    EXPECT_NEAR(req_cur * v, -5, 1e-2);
 
-    req_cur = volt.calculate_current_for_target_w(-1.5, cap.q0(), cap.qmax(), temp.T_battery());
+    req_cur = volt.calculate_current_for_target_w(5, cap.q0(), cap.qmax(), temp.T_battery());
     cap.updateCapacity(req_cur, 1);
     volt.updateVoltage(&cap, &temp, 1);
     v = volt.cell_voltage();
-    EXPECT_NEAR(req_cur * v, -1.5, 1e-2);
+    EXPECT_NEAR(req_cur * v, 5, 1e-2);
 
     double max_p = volt.calculate_max_charge_w(cap.q0(), cap.qmax(), temp.T_battery(), &req_cur);
     cap.updateCapacity(req_cur, 1);
@@ -508,6 +508,8 @@ TEST_F(ResilienceTest_lib_resilience, RoundtripEffVanadiumFlow){
     while (current < fabs(max_current)){
         cap->updateCapacity(full_current, 1);   //discharge to empty
 
+        std::vector<double> inputs, outputs;
+
         size_t n_t = 0;
         current *= -1;
         double input_power = 0.;
@@ -517,6 +519,7 @@ TEST_F(ResilienceTest_lib_resilience, RoundtripEffVanadiumFlow){
             vol->updateVoltage(cap, &temp, 1);
             input_power += cap->I() * vol->battery_voltage();
             n_t += 1;
+            inputs.push_back(vol->battery_voltage());
         }
 
         current *= -1;
@@ -526,10 +529,14 @@ TEST_F(ResilienceTest_lib_resilience, RoundtripEffVanadiumFlow){
             cap->updateCapacity(output_current, 1);
             vol->updateVoltage(cap, &temp, 1);
             output_power += cap->I() * vol->battery_voltage();
-            if (output_power < -1000)
-                int x = 0;
             n_t += 1;
+            outputs.push_back(vol->battery_voltage());
         }
+
+//        std::reverse(outputs.begin(), outputs.end());
+//        for (size_t i = 0; i < inputs.size(); i++) {
+//            printf("%f, %f\n", inputs[i], outputs[i]);
+//        }
 
         printf("current %f, eff %f, n %zd\n", current, -output_power/input_power, n_t);
 


### PR DESCRIPTION
Fixes:
 - Copied over some fixes from `develop` on `calculate_max_charge_w` and `calculate_max_discharge_w`
 - fix `-inf` potential from `voltage_model`
 - voltage drop across aggregated stack the same for charge or discharge
 - adapt test to show catch difference in using abs(I_string)

With the thermal model turned off: this is the yearly battery charging & discharging table:
![image](https://user-images.githubusercontent.com/29387736/85171700-b993d580-b22c-11ea-98a6-0b8b736df2df.png)
