### PR TITLE
Resolve PVWatts issues by making scalefactors more flexible

### DIFF
--- a/ssc/cmod_grid.cpp
+++ b/ssc/cmod_grid.cpp
@@ -40,6 +40,7 @@ var_info vtab_grid_input[] = {
 	// external compute module inputs
 	{ SSC_INOUT,        SSC_ARRAY,       "gen",								  "System power generated",                "kW",        "Lifetime system generation",          "System Output",                  "",                        "",                              "" },
 	{ SSC_INPUT,		SSC_ARRAY,	     "load",			                  "Electricity load (year 1)",             "kW",	    "",                                    "Load",	                       "",	                      "",	                           "" },
+    { SSC_INPUT,        SSC_ARRAY,       "load_escalation",                   "Annual load escalation",                "%/year",    "",                                    "Load",                        "?=0",                      "",                            "" },
 
 var_info_invalid };
 
@@ -131,7 +132,7 @@ void cm_grid::exec() throw (general_error)
     scalefactors scale_calculator(m_vartab);
 
     // compute load (electric demand) annual escalation multipliers
-    std::vector<ssc_number_t> load_scale;
+    std::vector<ssc_number_t> load_scale(analysis_period, 1.0);
     if (is_assigned("load_escalation")) {
         load_scale = scale_calculator.get_factors("load_escalation");
     }

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1470,6 +1470,7 @@ scalefactors::scalefactors(var_table* v)
     vt = v;
 }
 
+// TODO: add a boolean for factoring in inflation when adding new financial models
 std::vector<double> scalefactors::get_factors(const char* name)
 {
     size_t nyears = 1;
@@ -1480,18 +1481,24 @@ std::vector<double> scalefactors::get_factors(const char* name)
     size_t count, i;
     std::vector<double> scale_factors(nyears);
     ssc_number_t* parr = vt->as_array(name, &count);
-    if (count == 1)
+    if (count < 1)
+    {
+        for (i = 0; i < nyears; i++)
+            scale_factors[i] = (ssc_number_t)1.0;
+    }
+    else if (count < 2)
     {
         for (i = 0; i < nyears; i++)
             scale_factors[i] = (ssc_number_t)pow((double)(1 + parr[0] * 0.01), (double)i);
     }
-    else if (count == 0)
-    {
-        for (i = 0; i < nyears; i++)
-            scale_factors[i] = (ssc_number_t) 1.0;
-    }
     else
     {
+        if (count != nyears)
+        {
+            std::ostringstream ss;
+            ss << "Expected length of " << name << " to be " << nyears << " found " << count << " entries";
+            throw general_error(ss.str());
+        }
         for (i = 0; i < nyears; i++)
             scale_factors[i] = (ssc_number_t)(1 + parr[i] * 0.01);
     }

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1472,14 +1472,23 @@ scalefactors::scalefactors(var_table* v)
 
 std::vector<double> scalefactors::get_factors(const char* name)
 {
-    size_t nyears = vt->as_integer("analysis_period");
+    size_t nyears = 1;
+    if (vt->is_assigned("analysis_period"))
+    {
+        nyears = vt->as_integer("analysis_period");
+    }
     size_t count, i;
-    std::vector<double> scale_factors(nyears); // TODO analysis period
+    std::vector<double> scale_factors(nyears);
     ssc_number_t* parr = vt->as_array(name, &count);
     if (count == 1)
     {
         for (i = 0; i < nyears; i++)
             scale_factors[i] = (ssc_number_t)pow((double)(1 + parr[0] * 0.01), (double)i);
+    }
+    else if (count == 0)
+    {
+        for (i = 0; i < nyears; i++)
+            scale_factors[i] = (ssc_number_t) 1.0;
     }
     else
     {

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1492,7 +1492,13 @@ std::vector<double> scalefactors::get_factors(const char* name)
                 scale_factors[i] = (ssc_number_t)pow((double)(1 + parr[0] * 0.01), (double)i);
         }
         else {
-            for (i = 0; i < nyears && i < count; i++)
+            if (count < nyears)
+            {
+                std::ostringstream ss;
+                ss << "Expected length of " << name << " to be " << nyears << " found " << count << " entries";
+                throw general_error(ss.str());
+            }
+            for (i = 0; i < nyears; i++)
                 scale_factors[i] = (ssc_number_t)(1 + parr[i] * 0.01);
         }
     }


### PR DESCRIPTION
An alternative solution to the issue in #416. Allows three options for load_escalation and other scaling factors:

* Length zero: no scaling (multiply by 1.0)
* Length 1: scale at a constant percent rate each year
* Length n_years/analysis_period: scale based on the custom vector

Defaults to analysis_period of 1 year if it is not defined, preventing the access errors.