### PR TITLE
Dependent inputs

### DIFF
--- a/ssc/core.cpp
+++ b/ssc/core.cpp
@@ -28,64 +28,57 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core.h"
 #include "ssc_equations.h"
 
-const var_info var_info_invalid = {	0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
+const var_info var_info_invalid = {0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
-compute_module::compute_module( )
-	:  m_handler(NULL), m_vartab(NULL), m_infomap(NULL)
-{
-	/* nothing to do */
+compute_module::compute_module()
+        : m_handler(NULL), m_vartab(NULL), m_infomap(NULL) {
+    /* nothing to do */
 }
 
-compute_module::~compute_module()
-{
-	if (m_infomap) delete m_infomap;
+compute_module::~compute_module() {
+    if (m_infomap) delete m_infomap;
 }
 
-bool compute_module::compute( handler_interface *handler, var_table *data )
-{
-	m_handler = NULL;
-	m_vartab = NULL;
+bool compute_module::compute(handler_interface *handler, var_table *data) {
+    m_handler = NULL;
+    m_vartab = NULL;
 
-	if (!handler)
-	{
-		log("no request handler assigned to computation engine", SSC_ERROR);
-		return false;
-	}
-	m_handler = handler;
+    if (!handler) {
+        log("no request handler assigned to computation engine", SSC_ERROR);
+        return false;
+    }
+    m_handler = handler;
 
-	if (!data)
-	{
-		log("no data object assigned to computation engine", SSC_ERROR);
-		return false;
-	}
-	m_vartab = data;
+    if (!data) {
+        log("no data object assigned to computation engine", SSC_ERROR);
+        return false;
+    }
+    m_vartab = data;
 
-	if (m_varlist.size() == 0)
-	{
-		log("no variables defined for computation engine", SSC_ERROR);
-		return false;
-	}
+    if (m_varlist.size() == 0) {
+        log("no variables defined for computation engine", SSC_ERROR);
+        return false;
+    }
 
-	try { // catch any 'general_error' that can be thrown during precheck, exec, and postcheck
+    try { // catch any 'general_error' that can be thrown during precheck, exec, and postcheck
 
         if (!evaluate()) return false;    // This can be enabled when we want automatic updating of interdependent-inputs
         if (!verify("precheck input", SSC_INPUT)) return false;
-		exec();
-		if (!verify("postcheck output", SSC_OUTPUT)) return false;
+        exec();
+        if (!verify("postcheck output", SSC_OUTPUT)) return false;
 
-	} catch ( general_error &e )	{
-		log( e.err_text, SSC_ERROR, e.time );
-		return false;
-	}
+    } catch (general_error &e) {
+        log(e.err_text, SSC_ERROR, e.time);
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
-bool compute_module::evaluate()
-{
+bool compute_module::evaluate() {
     // Find ssc_equations relevant to compute module
     std::vector<size_t> table_indices;
-    std::size_t table_length = sizeof(ssc_equation_table)/sizeof(*ssc_equation_table);
+    std::size_t table_length = sizeof(ssc_equation_table) / sizeof(*ssc_equation_table);
     for (std::size_t i = 0; i < table_length; i++) {
         if (ssc_equation_table[i].cmod == nullptr) continue;
         std::string row_compute_module_name = util::lower_case(ssc_equation_table[i].cmod);
@@ -99,17 +92,15 @@ bool compute_module::evaluate()
     if (table_indices.empty()) return true;      // no equations relevant to cmod
 
     // For calling all relevant ssc_equations
-    auto CallSscEquations = [this](const std::vector<size_t>& table_indices)
-    {
+    auto CallSscEquations = [this](const std::vector<size_t> &table_indices) {
         for (size_t table_row : table_indices) {
             ssc_equation_ptr ssc_equation = ssc_equation_table[table_row].func;
             auto var_table_data = static_cast<ssc_data_t>(this->m_vartab);
 
-            try
-            {
+            try {
                 (*ssc_equation)(var_table_data);
             }
-            catch (std::exception& e) {
+            catch (std::exception &e) {
                 float time = -1.;
                 log(e.what(), SSC_ERROR, time);
                 return false;
@@ -138,33 +129,31 @@ bool compute_module::evaluate()
         // Calculate convergence_error by comparing var_table values with previous
         double squared_error = 0.;
         int n_differences = 0;
-        const char* it;
+        const char *it;
         for (it = m_vartab->first(); it != nullptr; it = m_vartab->next()) {
-            auto AreSame = [](double a, double b) -> bool
-            {
+            auto AreSame = [](double a, double b) -> bool {
                 constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
                 return fabs(a - b) < kEpsilon;
             };
 
             std::string variable_name(it);
-            var_data* variable_data = m_vartab->lookup(variable_name);
+            var_data *variable_data = m_vartab->lookup(variable_name);
 
             switch (variable_data->type) {
-                case SSC_STRING:
-                {
+                case SSC_STRING: {
                     // if the strings change, throw an error
                     std::string string_cur = m_vartab->as_string(variable_name);
                     std::string string_prev = var_table_prev_iter.as_string(variable_name);
                     if (string_cur != string_prev) {
                         float time = -1.;
-                        log("Changing string variables in ssc_equations is not allowed.", SSC_ERROR, time);         // probably could add later
+                        log("Changing string variables in ssc_equations is not allowed.", SSC_ERROR,
+                            time);         // probably could add later
                         return false;
                     }
 
                     break;
                 }
-                case SSC_NUMBER:
-                {
+                case SSC_NUMBER: {
                     double number_cur = m_vartab->as_double(variable_name);
                     double number_prev = var_table_prev_iter.as_double(variable_name);
                     if (!AreSame(number_cur, number_prev)) {
@@ -174,15 +163,15 @@ bool compute_module::evaluate()
 
                     break;
                 }
-                case SSC_ARRAY:
-                {
+                case SSC_ARRAY: {
                     size_t n_elements_cur, n_elements_prev;
                     ssc_number_t *array_cur = m_vartab->as_array(variable_name, &n_elements_cur);
-                    ssc_number_t* array_prev = var_table_prev_iter.as_array(variable_name, &n_elements_prev);
+                    ssc_number_t *array_prev = var_table_prev_iter.as_array(variable_name, &n_elements_prev);
 
                     if (n_elements_cur != n_elements_prev) {
                         float time = -1.;
-                        log("Changing array variable length in ssc_equations is not allowed.", SSC_ERROR, time);       // probably could add later
+                        log("Changing array variable length in ssc_equations is not allowed.", SSC_ERROR,
+                            time);       // probably could add later
                         return false;
                     }
 
@@ -195,14 +184,14 @@ bool compute_module::evaluate()
 
                     break;
                 }
-                case SSC_MATRIX:
-                {
+                case SSC_MATRIX: {
                     util::matrix_t<double> matrix_cur = m_vartab->as_matrix(variable_name);
                     util::matrix_t<double> matrix_prev = var_table_prev_iter.as_matrix(variable_name);
 
                     if (matrix_cur.nrows() != matrix_prev.nrows() || matrix_cur.ncols() != matrix_prev.ncols()) {
                         float time = -1.;
-                        log("Changing matrix variable dimensions in ssc_equations is not allowed.", SSC_ERROR, time);       // probably could add later
+                        log("Changing matrix variable dimensions in ssc_equations is not allowed.", SSC_ERROR,
+                            time);       // probably could add later
                         return false;
                     }
 
@@ -215,10 +204,10 @@ bool compute_module::evaluate()
 
                     break;
                 }
-                default:
-                {
+                default: {
                     float time = -1.;
-                    log(variable_name + " of data type " + var_data::type_name(variable_data->type) + " is not supported for ssc_equations", SSC_ERROR, time);
+                    log(variable_name + " of data type " + var_data::type_name(variable_data->type) +
+                        " is not supported for ssc_equations", SSC_ERROR, time);
                     return false;
                 }
             }
@@ -226,8 +215,7 @@ bool compute_module::evaluate()
 
         if (n_differences == 0) {
             convergence_error = 0.;
-        }
-        else {
+        } else {
             convergence_error = sqrt(squared_error / static_cast<double>(n_differences));
         }
 
@@ -244,866 +232,762 @@ bool compute_module::evaluate()
     return true;
 }
 
-bool compute_module::verify(const std::string &phase, int check_var_type)
-{
-	std::vector< var_info* >::iterator it;
-	for (it=m_varlist.begin();it!=m_varlist.end();++it)
-	{
-		var_info *vi = *it;
-		if ( vi->var_type == check_var_type
-			|| vi->var_type == SSC_INOUT )
-		{
-			if ( check_required( vi->name ) )
-			{
-				// if the variable is required, make sure it exists (in the var_table)
-				// and that it is of the correct data type
-				var_data *dat = lookup( vi->name );
-				if (!dat)
-				{
-					log(phase + ": variable '" + std::string(vi->name) + "' (" + std::string(vi->label) + ") required but not assigned");
-					return false;
-				}
-				else if (dat->type != vi->data_type)
-				{
-					log(phase + ": variable '" + std::string(vi->name) + "' (" + var_data::type_name(dat->type) + ") of wrong type, " + var_data::type_name( vi->data_type ) + " required.");
-					return false;
-				}
+bool compute_module::verify(const std::string &phase, int check_var_type) {
+    std::vector<var_info *>::iterator it;
+    for (it = m_varlist.begin(); it != m_varlist.end(); ++it) {
+        var_info *vi = *it;
+        if (vi->var_type == check_var_type
+            || vi->var_type == SSC_INOUT) {
+            if (check_required(vi->name)) {
+                // if the variable is required, make sure it exists (in the var_table)
+                // and that it is of the correct data type
+                var_data *dat = lookup(vi->name);
+                if (!dat) {
+                    log(phase + ": variable '" + std::string(vi->name) + "' (" + std::string(vi->label) +
+                        ") required but not assigned");
+                    return false;
+                } else if (dat->type != vi->data_type) {
+                    log(phase + ": variable '" + std::string(vi->name) + "' (" + var_data::type_name(dat->type) +
+                        ") of wrong type, " + var_data::type_name(vi->data_type) + " required.");
+                    return false;
+                }
 
-				// now check constraints on it
-				std::string fail_text;
-				if (!check_constraints( vi->name, fail_text ))
-				{
-					log(fail_text, SSC_ERROR);
-					return false;
-				}
-			}
-		}
-	}
+                // now check constraints on it
+                std::string fail_text;
+                if (!check_constraints(vi->name, fail_text)) {
+                    log(fail_text, SSC_ERROR);
+                    return false;
+                }
+            }
+        }
+    }
 
-	return true;
+    return true;
 }
 
-void compute_module::add_var_info( var_info vi[] )
-{
-	int i=0;
-	while ( vi[i].data_type != SSC_INVALID
-		&& vi[i].name != NULL )
-	{
-		m_varlist.push_back( &vi[i] );
-		i++;
-	}
+void compute_module::add_var_info(var_info vi[]) {
+    int i = 0;
+    while (vi[i].data_type != SSC_INVALID
+           && vi[i].name != NULL) {
+        m_varlist.push_back(&vi[i]);
+        i++;
+    }
 }
 
-void compute_module::remove_var_info(var_info vi[])
-{
-	int i = 0;
-	while (vi[i].data_type != SSC_INVALID
-		&& vi[i].name != NULL)
-	{
-		m_varlist.erase(std::remove(m_varlist.begin(), m_varlist.end(), &vi[i]), m_varlist.end());
-		i++;
-	}
+void compute_module::remove_var_info(var_info vi[]) {
+    int i = 0;
+    while (vi[i].data_type != SSC_INVALID
+           && vi[i].name != NULL) {
+        m_varlist.erase(std::remove(m_varlist.begin(), m_varlist.end(), &vi[i]), m_varlist.end());
+        i++;
+    }
 }
 
-void compute_module::build_info_map()
-{
-	if (m_infomap) delete m_infomap;
+void compute_module::build_info_map() {
+    if (m_infomap) delete m_infomap;
 
-	m_infomap = new unordered_map<std::string, var_info*>;
+    m_infomap = new unordered_map<std::string, var_info *>;
 
-	std::vector<var_info*>::iterator it;
-	for (it = m_varlist.begin(); it != m_varlist.end(); ++it)
-		(*m_infomap)[ (*it)->name ] = *it;
+    std::vector<var_info *>::iterator it;
+    for (it = m_varlist.begin(); it != m_varlist.end(); ++it)
+        (*m_infomap)[(*it)->name] = *it;
 }
 
-bool compute_module::update( const std::string &current_action, float percent_done, float time )
-{
-	// forward to handler interface
-	if (m_handler) return m_handler->on_update( current_action, percent_done, time);
-	else return true;
+bool compute_module::update(const std::string &current_action, float percent_done, float time) {
+    // forward to handler interface
+    if (m_handler) return m_handler->on_update(current_action, percent_done, time);
+    else return true;
 }
 
-void compute_module::log( const std::string &msg, int type, float time )
-{
-	// forward to handler interface
-	if (m_handler) m_handler->on_log( msg, type, time );
+void compute_module::log(const std::string &msg, int type, float time) {
+    // forward to handler interface
+    if (m_handler) m_handler->on_log(msg, type, time);
 
-	// also save it in module object
-	m_loglist.push_back( log_item( type, msg, time ) );
+    // also save it in module object
+    m_loglist.push_back(log_item(type, msg, time));
 }
 
-void compute_module::clear_log()
-{
-	m_loglist.clear();
+void compute_module::clear_log() {
+    m_loglist.clear();
 }
 
-bool compute_module::extproc( const std::string &, const std::string & )
-{
+bool compute_module::extproc(const std::string &, const std::string &) {
 /*
 	if (m_handler) return m_handler->on_exec( command, workdir);
 	else return false;
 */
-	return false; // on_exec removed with rev 578
+    return false; // on_exec removed with rev 578
 }
 
-compute_module::log_item *compute_module::log(int index)
-{
-	if (index >= 0 && index < (int)m_loglist.size())
-		return &m_loglist[index];
-	else
-		return NULL;
+compute_module::log_item *compute_module::log(int index) {
+    if (index >= 0 && index < (int) m_loglist.size())
+        return &m_loglist[index];
+    else
+        return NULL;
 }
 
-var_info *compute_module::info(int index)
-{
-	if (index >= 0 && index < (int)m_varlist.size())
-		return m_varlist[index];
-	else
-		return NULL;
+var_info *compute_module::info(int index) {
+    if (index >= 0 && index < (int) m_varlist.size())
+        return m_varlist[index];
+    else
+        return NULL;
 }
 
-const var_info &compute_module::info( const std::string &name )
-{
-	// if there is an info lookup table, use it
-	if (m_infomap != NULL)
-	{
-		unordered_map<std::string, var_info*>::iterator pos = m_infomap->find(name);
-		if (pos != m_infomap->end())
-			return (*(pos->second));
-	}
+const var_info &compute_module::info(const std::string &name) {
+    // if there is an info lookup table, use it
+    if (m_infomap != NULL) {
+        unordered_map<std::string, var_info *>::iterator pos = m_infomap->find(name);
+        if (pos != m_infomap->end())
+            return (*(pos->second));
+    }
 
-	// otherwise search
-	std::vector< var_info* >::iterator it;
-	for (it = m_varlist.begin(); it != m_varlist.end(); ++it)
-	{
-		if ( (*it)->name == name )
-			return *(*it);
-	}
+    // otherwise search
+    std::vector<var_info *>::iterator it;
+    for (it = m_varlist.begin(); it != m_varlist.end(); ++it) {
+        if ((*it)->name == name)
+            return *(*it);
+    }
 
-	throw general_error("variable information lookup fail: '" + name + "'");
+    throw general_error("variable information lookup fail: '" + name + "'");
 }
 
-bool compute_module::is_ssc_array_output( const std::string &name )
-{
-	// if there is an info lookup table, use it
-	if (m_infomap != NULL)
-	{
-		unordered_map<std::string, var_info*>::iterator pos = m_infomap->find(name);
-		if (pos != m_infomap->end())
-		{
-			if ( ( ((pos->second)->var_type == SSC_OUTPUT) || ((pos->second)->var_type == SSC_INOUT) ) && (pos->second)->data_type == SSC_ARRAY )
-				return true;
-		}
-	}
+bool compute_module::is_ssc_array_output(const std::string &name) {
+    // if there is an info lookup table, use it
+    if (m_infomap != NULL) {
+        unordered_map<std::string, var_info *>::iterator pos = m_infomap->find(name);
+        if (pos != m_infomap->end()) {
+            if ((((pos->second)->var_type == SSC_OUTPUT) || ((pos->second)->var_type == SSC_INOUT)) &&
+                (pos->second)->data_type == SSC_ARRAY)
+                return true;
+        }
+    }
 
-	// otherwise search
-	std::vector< var_info* >::iterator it;
-	for (it = m_varlist.begin(); it != m_varlist.end(); ++it)
-	{
-		if ( ( ( (*it)->var_type == SSC_OUTPUT ) || ( (*it)->var_type == SSC_INOUT ) ) && (*it)->data_type == SSC_ARRAY )
-			if ( util::lower_case((*it)->name) == util::lower_case(name) ) return true;
-	}
+    // otherwise search
+    std::vector<var_info *>::iterator it;
+    for (it = m_varlist.begin(); it != m_varlist.end(); ++it) {
+        if ((((*it)->var_type == SSC_OUTPUT) || ((*it)->var_type == SSC_INOUT)) && (*it)->data_type == SSC_ARRAY)
+            if (util::lower_case((*it)->name) == util::lower_case(name)) return true;
+    }
 
-	return false;
+    return false;
 }
 
 
-var_data *compute_module::lookup( const std::string &name )
-{
-	if (!m_vartab) throw general_error("invalid data container object reference");
-	return m_vartab->lookup(name);
+var_data *compute_module::lookup(const std::string &name) {
+    if (!m_vartab) throw general_error("invalid data container object reference");
+    return m_vartab->lookup(name);
 }
 
-var_data *compute_module::assign( const std::string &name, const var_data &value )
-{
-	if (!m_vartab) throw general_error("invalid data container object reference");
-	return m_vartab->assign( name, value );
+var_data *compute_module::assign(const std::string &name, const var_data &value) {
+    if (!m_vartab) throw general_error("invalid data container object reference");
+    return m_vartab->assign(name, value);
 }
 
-ssc_number_t *compute_module::allocate( const std::string &name, size_t length )
-{
-	var_data *v = assign(name, var_data());
-	v->type = SSC_ARRAY;
-	v->num.resize_fill( length, 0.0 );
-	return v->num.data();
+ssc_number_t *compute_module::allocate(const std::string &name, size_t length) {
+    var_data *v = assign(name, var_data());
+    v->type = SSC_ARRAY;
+    v->num.resize_fill(length, 0.0);
+    return v->num.data();
 }
 
-ssc_number_t *compute_module::allocate( const std::string &name, size_t nrows, size_t ncols )
-{
-	var_data *v = assign(name, var_data());
-	v->type = SSC_MATRIX;
-	v->num.resize_fill(nrows, ncols, 0.0);
-	return v->num.data();
+ssc_number_t *compute_module::allocate(const std::string &name, size_t nrows, size_t ncols) {
+    var_data *v = assign(name, var_data());
+    v->type = SSC_MATRIX;
+    v->num.resize_fill(nrows, ncols, 0.0);
+    return v->num.data();
 }
 
-util::matrix_t<ssc_number_t>& compute_module::allocate_matrix( const std::string &name, size_t nrows, size_t ncols )
-{
-	var_data *v = assign(name, var_data());
-	v->type = SSC_MATRIX;
-	v->num.resize_fill(nrows, ncols, 0.0);
-	return v->num;
+util::matrix_t<ssc_number_t> &compute_module::allocate_matrix(const std::string &name, size_t nrows, size_t ncols) {
+    var_data *v = assign(name, var_data());
+    v->type = SSC_MATRIX;
+    v->num.resize_fill(nrows, ncols, 0.0);
+    return v->num;
 }
 
-var_data &compute_module::value( const std::string &name )
-{
-	var_data *v = lookup( name );
-	if (!v){
-		throw general_error("ssc variable does not exist: '" + name + "'");
-	}
-	return (*v);
+var_data &compute_module::value(const std::string &name) {
+    var_data *v = lookup(name);
+    if (!v) {
+        throw general_error("ssc variable does not exist: '" + name + "'");
+    }
+    return (*v);
 }
 
-bool compute_module::is_assigned( const std::string &name )
-{
-	if (m_vartab) return (m_vartab->is_assigned(name));
-	else return false;
+bool compute_module::is_assigned(const std::string &name) {
+    if (m_vartab) return (m_vartab->is_assigned(name));
+    else return false;
 }
 
-int compute_module::as_integer( const std::string &name )
-{
-	if (m_vartab) return m_vartab->as_integer(name);
-	else throw general_error("compute_module error: var_table does not exist.");
+int compute_module::as_integer(const std::string &name) {
+    if (m_vartab) return m_vartab->as_integer(name);
+    else throw general_error("compute_module error: var_table does not exist.");
 }
-size_t compute_module::as_unsigned_long(const std::string &name)
-{
+
+size_t compute_module::as_unsigned_long(const std::string &name) {
     if (m_vartab) return m_vartab->as_unsigned_long(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-bool compute_module::as_boolean( const std::string &name )
-{
+bool compute_module::as_boolean(const std::string &name) {
     if (m_vartab) return m_vartab->as_boolean(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-float compute_module::as_float( const std::string &name )
-{
+float compute_module::as_float(const std::string &name) {
     if (m_vartab) return m_vartab->as_float(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-ssc_number_t compute_module::as_number( const std::string &name )
-{
+ssc_number_t compute_module::as_number(const std::string &name) {
     if (m_vartab) return m_vartab->as_number(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-double compute_module::as_double( const std::string &name )
-{
+double compute_module::as_double(const std::string &name) {
     if (m_vartab) return m_vartab->as_double(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-const char *compute_module::as_string( const std::string &name )
-{
+const char *compute_module::as_string(const std::string &name) {
     if (m_vartab) return m_vartab->as_string(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-ssc_number_t *compute_module::as_array( const std::string &name, size_t *count )
-{
+ssc_number_t *compute_module::as_array(const std::string &name, size_t *count) {
     if (m_vartab) return m_vartab->as_array(name, count);
     else throw general_error("compute_module error: var_table does not exist.");
 }
+
 /**
 The obvious improvement would be to made this a template, but ran into trouble with
 "error: Access violation - no RTTI data!"
 */
-std::vector<int> compute_module::as_vector_integer(const std::string &name)
-{
+std::vector<int> compute_module::as_vector_integer(const std::string &name) {
     if (m_vartab) return m_vartab->as_vector_integer(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-std::vector<ssc_number_t> compute_module::as_vector_ssc_number_t(const std::string &name)
-{
+std::vector<ssc_number_t> compute_module::as_vector_ssc_number_t(const std::string &name) {
     if (m_vartab) return m_vartab->as_vector_ssc_number_t(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-std::vector<double> compute_module::as_vector_double(const std::string &name)
-{
+std::vector<double> compute_module::as_vector_double(const std::string &name) {
     if (m_vartab) return m_vartab->as_vector_double(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
-std::vector<float> compute_module::as_vector_float(const std::string &name)
-{
+
+std::vector<float> compute_module::as_vector_float(const std::string &name) {
     if (m_vartab) return m_vartab->as_vector_float(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
-std::vector<size_t> compute_module::as_vector_unsigned_long(const std::string &name)
-{
+
+std::vector<size_t> compute_module::as_vector_unsigned_long(const std::string &name) {
     if (m_vartab) return m_vartab->as_vector_unsigned_long(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
-std::vector<bool> compute_module::as_vector_bool(const std::string &name)
-{
+
+std::vector<bool> compute_module::as_vector_bool(const std::string &name) {
     if (m_vartab) return m_vartab->as_vector_bool(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-ssc_number_t *compute_module::as_matrix( const std::string &name, size_t *rows, size_t *cols )
-{
+ssc_number_t *compute_module::as_matrix(const std::string &name, size_t *rows, size_t *cols) {
     if (m_vartab) return m_vartab->as_matrix(name, rows, cols);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-util::matrix_t<double> compute_module::as_matrix(const std::string &name)
-{
+util::matrix_t<double> compute_module::as_matrix(const std::string &name) {
     if (m_vartab) return m_vartab->as_matrix(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-util::matrix_t<size_t> compute_module::as_matrix_unsigned_long(const std::string &name)
-{
+util::matrix_t<size_t> compute_module::as_matrix_unsigned_long(const std::string &name) {
     if (m_vartab) return m_vartab->as_matrix_unsigned_long(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
 
-util::matrix_t<double> compute_module::as_matrix_transpose(const std::string &name)
-{
+util::matrix_t<double> compute_module::as_matrix_transpose(const std::string &name) {
     if (m_vartab) return m_vartab->as_matrix_transpose(name);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
-bool compute_module::get_matrix(const std::string &name, util::matrix_t<ssc_number_t> &mat)
-{
+bool compute_module::get_matrix(const std::string &name, util::matrix_t<ssc_number_t> &mat) {
     if (m_vartab) return m_vartab->get_matrix(name, mat);
     else throw general_error("compute_module error: var_table does not exist.");
 }
 
 
+ssc_number_t compute_module::get_operand_value(const std::string &input, const std::string &cur_var_name) {
+    if (input.length() < 1) throw check_error(cur_var_name, "input is null to get_operand_value", input);
 
-ssc_number_t compute_module::get_operand_value( const std::string &input, const std::string &cur_var_name)
-{
-	if (input.length() < 1) throw check_error(cur_var_name, "input is null to get_operand_value", input);
-
-	if (isalpha(input[0]))
-	{
-		var_data *v = lookup(input);
-		if (!v)
-		    throw check_error(cur_var_name, "unassigned referenced",  input );
-		if (v->type != SSC_NUMBER) throw check_error(cur_var_name, "number type required", input );
-		return v->num;
-	}
-	else
-	{
-		double x = 0;
-		if (!util::to_double( input, &x )) throw check_error(cur_var_name, "number conversion", input );
-		return (ssc_number_t) x;
-	}
+    if (isalpha(input[0])) {
+        var_data *v = lookup(input);
+        if (!v)
+            throw check_error(cur_var_name, "unassigned referenced", input);
+        if (v->type != SSC_NUMBER) throw check_error(cur_var_name, "number type required", input);
+        return v->num;
+    } else {
+        double x = 0;
+        if (!util::to_double(input, &x)) throw check_error(cur_var_name, "number conversion", input);
+        return (ssc_number_t) x;
+    }
 }
 
-bool compute_module::check_required( const std::string &name )
-{
-	// only check if the variable is required as input to the simulation context
-	// if it is an input or an inout variable
+bool compute_module::check_required(const std::string &name) {
+    // only check if the variable is required as input to the simulation context
+    // if it is an input or an inout variable
 
-	const var_info &inf = info(name);
-	if (inf.required_if == NULL || strlen(inf.required_if)==0)
-		return false;
+    const var_info &inf = info(name);
+    if (inf.required_if == NULL || strlen(inf.required_if) == 0)
+        return false;
 
-	std::string reqexpr = inf.required_if;
+    std::string reqexpr = inf.required_if;
 
-	if (reqexpr == "*")
-	{
-		return true; // Always required
-	}
-	else if (reqexpr == "?")
-	{
-		return false; // Always optional
-	}
-	else if (reqexpr.length() > 2 && reqexpr[0] == '?' && reqexpr[1] == '=')
-	{
-		// optional but has a default value that is assigned if variable is unassigned
-		var_data *v = lookup(name);
-		if (!v)
-		{
-			v = assign(name, m_null_value );
+    if (reqexpr == "*") {
+        return true; // Always required
+    } else if (reqexpr == "?") {
+        return false; // Always optional
+    } else if (reqexpr.length() > 2 && reqexpr[0] == '?' && reqexpr[1] == '=') {
+        // optional but has a default value that is assigned if variable is unassigned
+        var_data *v = lookup(name);
+        if (!v) {
+            v = assign(name, m_null_value);
 
-			if ( !var_data::parse( inf.data_type, reqexpr.substr(2), *v ) )
-				throw check_error(name, "could not parse default value in required_if spec (" + var_data::type_name(inf.data_type) + ")", reqexpr);
-		}
+            if (!var_data::parse(inf.data_type, reqexpr.substr(2), *v))
+                throw check_error(name, "could not parse default value in required_if spec (" +
+                                        var_data::type_name(inf.data_type) + ")", reqexpr);
+        }
 
-		return true; // a default value has been assigned, so this variable is effectively always required
-	}
-	else
-	{
-		// run tests
-		std::string::size_type pos = std::string::npos;
-		std::vector< std::string > expr_list = util::split(util::lower_case(reqexpr), "&|", true, true );
+        return true; // a default value has been assigned, so this variable is effectively always required
+    } else {
+        // run tests
+        std::string::size_type pos = std::string::npos;
+        std::vector<std::string> expr_list = util::split(util::lower_case(reqexpr), "&|", true, true);
 
-		int cur_result = -1;
-		char cur_cond_oper = 0;
-		for ( std::vector< std::string >::iterator it = expr_list.begin(); it != expr_list.end(); ++it )
-		{
-			std::string expr = *it;
-			if (expr == "&")
-			{
-				if (cur_result == 0) // short circuit evaluation
-					break;
+        int cur_result = -1;
+        char cur_cond_oper = 0;
+        for (std::vector<std::string>::iterator it = expr_list.begin(); it != expr_list.end(); ++it) {
+            std::string expr = *it;
+            if (expr == "&") {
+                if (cur_result == 0) // short circuit evaluation
+                    break;
 
-				cur_cond_oper = '&';
-				continue;
-			}
-			else if (expr == "|")
-			{
-				if (cur_result > 0) // short circuit evaluation
-					break;
+                cur_cond_oper = '&';
+                continue;
+            } else if (expr == "|") {
+                if (cur_result > 0) // short circuit evaluation
+                    break;
 
-				cur_cond_oper = '|';
-				continue;
-			}
-			else
-			{
-				int expr_result = 0;
-				char op = 0;
-				if ( (pos=expr.find('=')) != std::string::npos ) op = '=';
-				else if ( (pos=expr.find('~')) != std::string::npos) op = '~';
-				else if ( (pos=expr.find('<')) != std::string::npos ) op = '<';
-				else if ( (pos=expr.find('>')) != std::string::npos ) op = '>';
-				else if ( (pos=expr.find(':')) != std::string::npos ) op = ':';
+                cur_cond_oper = '|';
+                continue;
+            } else {
+                int expr_result = 0;
+                char op = 0;
+                if ((pos = expr.find('=')) != std::string::npos) op = '=';
+                else if ((pos = expr.find('~')) != std::string::npos) op = '~';
+                else if ((pos = expr.find('<')) != std::string::npos) op = '<';
+                else if ((pos = expr.find('>')) != std::string::npos) op = '>';
+                else if ((pos = expr.find(':')) != std::string::npos) op = ':';
 
-				if (!op) throw check_error(name, "invalid operator", expr );
+                if (!op) throw check_error(name, "invalid operator", expr);
 
-				std::string lhs = expr.substr(0, pos);
-				std::string rhs = expr.substr(pos+1);
+                std::string lhs = expr.substr(0, pos);
+                std::string rhs = expr.substr(pos + 1);
 
-				if (lhs.length() < 1 || rhs.length() < 1) throw check_error(name, "null lhs or rhs in subexpr", expr);
+                if (lhs.length() < 1 || rhs.length() < 1) throw check_error(name, "null lhs or rhs in subexpr", expr);
 
-				if (op == ':')
-				{
-					/* handle built-in test operators */
+                if (op == ':') {
+                    /* handle built-in test operators */
 
-					if (lhs == "na") // check if variable name in 'rhs' is not assigned
-					{
-						expr_result = lookup(rhs)==NULL ? 1 : 0;
-					}
-					else if (lhs == "a") // check if variable name in 'rhs' is assigned
-					{
-						expr_result = lookup(rhs)!=NULL ? 1 : 0;
-					}
-					else if (lhs == "abt") // check if variable in 'rhs' is assigned, boolean type, and value true
-					{
-						var_data *v;
-						if ( ((v = lookup(rhs) ) != 0) && v->type == SSC_NUMBER &&  ((int)v->num) != 0)
-							return 1;
-						else
-							return 0;
-					}
-					else if (lhs == "abf") // check if variable in 'rhs' is assigned, boolean type, and value false
-					{
-						var_data *v;
-						if ( ((v = lookup(rhs)) !=0) && v->type == SSC_NUMBER &&  ((int)v->num) == 0)
-							return 1;
-						else
-							return 0;
-					}
-					else if (lhs == "naof") // check if variable is not assigned OR boolean value is 'false'
-					{
-						var_data *v;
-						if ( (v = lookup(rhs)) == 0 ) return 1;
-						if ( v->type == SSC_NUMBER && ((int)v->num)==0 ) return 1;
+                    if (lhs == "na") // check if variable name in 'rhs' is not assigned
+                    {
+                        expr_result = lookup(rhs) == NULL ? 1 : 0;
+                    } else if (lhs == "a") // check if variable name in 'rhs' is assigned
+                    {
+                        expr_result = lookup(rhs) != NULL ? 1 : 0;
+                    } else if (lhs == "abt") // check if variable in 'rhs' is assigned, boolean type, and value true
+                    {
+                        var_data *v;
+                        if (((v = lookup(rhs)) != 0) && v->type == SSC_NUMBER && ((int) v->num) != 0)
+                            return 1;
+                        else
+                            return 0;
+                    } else if (lhs == "abf") // check if variable in 'rhs' is assigned, boolean type, and value false
+                    {
+                        var_data *v;
+                        if (((v = lookup(rhs)) != 0) && v->type == SSC_NUMBER && ((int) v->num) == 0)
+                            return 1;
+                        else
+                            return 0;
+                    } else if (lhs == "naof") // check if variable is not assigned OR boolean value is 'false'
+                    {
+                        var_data *v;
+                        if ((v = lookup(rhs)) == 0) return 1;
+                        if (v->type == SSC_NUMBER && ((int) v->num) == 0) return 1;
 
-						return 0;
-					}
-					else
-					{
-						throw check_error(name, "invalid built-in test", expr);
-					}
-				}
-				else
-				{
-					ssc_number_t lhs_val = get_operand_value(lhs,name);
-					ssc_number_t rhs_val = get_operand_value(rhs,name);
+                        return 0;
+                    } else {
+                        throw check_error(name, "invalid built-in test", expr);
+                    }
+                } else {
+                    ssc_number_t lhs_val = get_operand_value(lhs, name);
+                    ssc_number_t rhs_val = get_operand_value(rhs, name);
 
-					switch(op)
-					{
-					case '=': expr_result = lhs_val == rhs_val ? 1 : 0 ; break;
-					case '~': expr_result = lhs_val != rhs_val ? 1 : 0; break;
-					case '<': expr_result = lhs_val < rhs_val ? 1 : 0 ; break;
-					case '>': expr_result = lhs_val > rhs_val ? 1 : 0 ; break;
-					default: throw check_error(name, "invalid numerical operator", expr);
-					}
-				}
+                    switch (op) {
+                        case '=':
+                            expr_result = lhs_val == rhs_val ? 1 : 0;
+                            break;
+                        case '~':
+                            expr_result = lhs_val != rhs_val ? 1 : 0;
+                            break;
+                        case '<':
+                            expr_result = lhs_val < rhs_val ? 1 : 0;
+                            break;
+                        case '>':
+                            expr_result = lhs_val > rhs_val ? 1 : 0;
+                            break;
+                        default:
+                            throw check_error(name, "invalid numerical operator", expr);
+                    }
+                }
 
-				if (cur_result < 0)
-				{
-					cur_result = expr_result;
-				}
-				else if (cur_cond_oper == '&')
-				{
-					cur_result = (cur_result && expr_result);
-				}
-				else if (cur_cond_oper == '|')
-				{
-					cur_result = (cur_result || expr_result);
-				}
+                if (cur_result < 0) {
+                    cur_result = expr_result;
+                } else if (cur_cond_oper == '&') {
+                    cur_result = (cur_result && expr_result);
+                } else if (cur_cond_oper == '|') {
+                    cur_result = (cur_result || expr_result);
+                } else
+                    throw check_error(name, "invalid evaluation sequence", reqexpr);
+            }
+        }
 
-				else
-					throw check_error(name, "invalid evaluation sequence", reqexpr);
-			}
-		}
+        return cur_result != 0 ? true : false;
+    }
 
-		return cur_result != 0 ? true : false;
-	}
-
-	return false;
+    return false;
 }
 
-bool compute_module::check_constraints( const std::string &name, std::string &fail_text)
-{
-#define fail_constraint( str ) { fail_text = "fail("+name+", "+expr+"): "+std::string(str); return false; }
+bool compute_module::check_constraints(const std::string &name, std::string &fail_text) {
+#define fail_constraint(str) { fail_text = "fail("+name+", "+expr+"): "+std::string(str); return false; }
 
-	const var_info &inf = info(name);
+    const var_info &inf = info(name);
 
-	if (inf.constraints == NULL) return true; // pass if no constraints defined
+    if (inf.constraints == NULL) return true; // pass if no constraints defined
 
-	var_data &dat = value(name);
+    var_data &dat = value(name);
 
-	std::vector< std::string > exprlist = util::split( inf.constraints, "," );
-	for ( std::vector<std::string>::iterator it=exprlist.begin(); it!=exprlist.end(); ++it )
-	{
-		std::string::size_type pos;
-		std::string expr = util::lower_case(*it);
-		if (expr == "tmyepw")
-		{
-			if (dat.type != SSC_STRING || dat.str.length() <= 4)
-				fail_constraint("string data type required with length greater than 4 chars: " + dat.str);
+    std::vector<std::string> exprlist = util::split(inf.constraints, ",");
+    for (std::vector<std::string>::iterator it = exprlist.begin(); it != exprlist.end(); ++it) {
+        std::string::size_type pos;
+        std::string expr = util::lower_case(*it);
+        if (expr == "tmyepw") {
+            if (dat.type != SSC_STRING || dat.str.length() <= 4) fail_constraint(
+                    "string data type required with length greater than 4 chars: " + dat.str);
 
-			std::string ext = util::lower_case( dat.str.substr( dat.str.length()-3 ) );
-			if (ext != "tm2" || ext != "tm3" || ext != "epw" || ext != "csv")
-				fail_constraint("file extension was not tm2,tm3,epw,csv: " + ext);
-		}
-		else if (expr == "local_file")
-		{
-			if (dat.type != SSC_STRING)
-				fail_constraint("string data type required");
+            std::string ext = util::lower_case(dat.str.substr(dat.str.length() - 3));
+            if (ext != "tm2" || ext != "tm3" || ext != "epw" || ext != "csv") fail_constraint(
+                    "file extension was not tm2,tm3,epw,csv: " + ext);
+        } else if (expr == "local_file") {
+            if (dat.type != SSC_STRING) fail_constraint("string data type required");
 
-			std::ifstream f_in( dat.str.c_str(), std::ios_base::in );
-			if (f_in.is_open())
-				f_in.close();
-			else
-				fail_constraint("could not open for read: '" + dat.str + "'");
-		}
-		else if (expr == "mxh_schedule")
-		{
-			if (dat.type != SSC_STRING)
-				fail_constraint("string data type required");
+            std::ifstream f_in(dat.str.c_str(), std::ios_base::in);
+            if (f_in.is_open())
+                f_in.close();
+            else fail_constraint("could not open for read: '" + dat.str + "'");
+        } else if (expr == "mxh_schedule") {
+            if (dat.type != SSC_STRING) fail_constraint("string data type required");
 
-			if (dat.str.length() != 288)
-				fail_constraint( "288 characters required (24x12) but " + util::to_string((int)dat.str.length()) + " found" );
+            if (dat.str.length() != 288) fail_constraint(
+                    "288 characters required (24x12) but " + util::to_string((int) dat.str.length()) + " found");
 
-			for ( std::string::size_type i=0;i<dat.str.length(); i++)
-				if ( dat.str[i] < '0' || dat.str[i] > '9' )
-					fail_constraint( util::format("invalid character %c at %d", (char)dat.str[i], (int)i) );
-		}
-		else if (expr == "boolean")
-		{
-			if (dat.type != SSC_NUMBER)
-				fail_constraint("number data type required");
+            for (std::string::size_type i = 0; i < dat.str.length(); i++)
+                if (dat.str[i] < '0' || dat.str[i] > '9') fail_constraint(
+                        util::format("invalid character %c at %d", (char) dat.str[i], (int) i));
+        } else if (expr == "boolean") {
+            if (dat.type != SSC_NUMBER) fail_constraint("number data type required");
 
-			int val = (int)dat.num;
-			if (val != 0 && val != 1)
-				fail_constraint("value was not 0 nor 1");
-		}
-		else if (expr == "integer")
-		{
-			if (dat.type != SSC_NUMBER)
-				fail_constraint("number data type required");
+            int val = (int) dat.num;
+            if (val != 0 && val != 1) fail_constraint("value was not 0 nor 1");
+        } else if (expr == "integer") {
+            if (dat.type != SSC_NUMBER) fail_constraint("number data type required");
 
-			if ( ((ssc_number_t)((int)dat.num)) != dat.num )
-				fail_constraint("number could not be interpreted as an integer: " + util::to_string( (double) dat.num ));
-		}
-		else if (expr == "tousched")
-		{
-			if (dat.type != SSC_STRING)
-				fail_constraint("string data type required");
+            if (((ssc_number_t) ((int) dat.num)) != dat.num) fail_constraint(
+                    "number could not be interpreted as an integer: " + util::to_string((double) dat.num));
+        } else if (expr == "tousched") {
+            if (dat.type != SSC_STRING) fail_constraint("string data type required");
 
-			if (dat.str.length() != 288)
-				fail_constraint("288 character string required (12x24 values)");
+            if (dat.str.length() != 288) fail_constraint("288 character string required (12x24 values)");
 
-			for (std::string::size_type i=0;i<dat.str.length();i++)
-			{
+            for (std::string::size_type i = 0; i < dat.str.length(); i++) {
 //				if ( dat.str[i] < '1' || dat.str[i] > '9' )
-				if ( util::schedule_char_to_int(dat.str[i]) == 0 )
-					fail_constraint("all digits must be between 1 and 9, inclusive");
-			}
-		}
-		else if (expr == "positive")
-		{
-			if (dat.type != SSC_NUMBER) throw constraint_error(name, "cannot test for positive with non-numeric type", expr);
-			if (dat.num <= 0.0)
-				fail_constraint( util::to_string( (double)dat.num ) );
-		}
-		else if (expr == "percent")
-		{
-			if (dat.type != SSC_NUMBER) throw constraint_error(name, "cannot test for percent (%) constraint with non-numeric type", expr);
-			if (dat.num < 0.0 || dat.num > 100.0)
-				fail_constraint( util::to_string( (double)dat.num ) );
-		}
-		else if (expr == "factor")
-		{
-			if (dat.type != SSC_NUMBER) throw constraint_error(name, "cannot test for factor (0..1) constraint with non-numeric type", expr);
-			if (dat.num < 0.0 || dat.num > 1.0)
-				fail_constraint( util::to_string( (double)dat.num ) );
-		}
-		else if (expr == "ts_m")
-		{
-			if (dat.type != SSC_NUMBER)
-				fail_constraint("number data type required");
+                if (util::schedule_char_to_int(dat.str[i]) == 0) fail_constraint(
+                        "all digits must be between 1 and 9, inclusive");
+            }
+        } else if (expr == "positive") {
+            if (dat.type != SSC_NUMBER)
+                throw constraint_error(name, "cannot test for positive with non-numeric type", expr);
+            if (dat.num <= 0.0) fail_constraint(util::to_string((double) dat.num));
+        } else if (expr == "percent") {
+            if (dat.type != SSC_NUMBER)
+                throw constraint_error(name, "cannot test for percent (%) constraint with non-numeric type", expr);
+            if (dat.num < 0.0 || dat.num > 100.0) fail_constraint(util::to_string((double) dat.num));
+        } else if (expr == "factor") {
+            if (dat.type != SSC_NUMBER)
+                throw constraint_error(name, "cannot test for factor (0..1) constraint with non-numeric type", expr);
+            if (dat.num < 0.0 || dat.num > 1.0) fail_constraint(util::to_string((double) dat.num));
+        } else if (expr == "ts_m") {
+            if (dat.type != SSC_NUMBER) fail_constraint("number data type required");
 
-			int val = (int) dat.num;
-			if (   val != 1
-				&& val != 5
-				&& val != 10
-				&& val != 15
-				&& val != 30
-				&& val != 60
-				)
-			{
-				fail_constraint("time step must be 1,5,10,15,30,60 minutes");
-			}
-		}
-		else if ( (pos=expr.find('=')) != std::string::npos )
-		{
-			std::string test = expr.substr(0, pos);
-			std::string rhs = expr.substr(pos+1);
+            int val = (int) dat.num;
+            if (val != 1
+                && val != 5
+                && val != 10
+                && val != 15
+                && val != 30
+                && val != 60
+                    ) {
+                fail_constraint("time step must be 1,5,10,15,30,60 minutes");
+            }
+        } else if ((pos = expr.find('=')) != std::string::npos) {
+            std::string test = expr.substr(0, pos);
+            std::string rhs = expr.substr(pos + 1);
 
-			if (test == "min")
-			{
-				if (dat.type != SSC_NUMBER) throw constraint_error(name, "cannot test for min with non-numeric type", expr);
-				double minval = 0;
-				if (!util::to_double( rhs, &minval )) throw constraint_error(name, "test for min requires a number value", expr);
-				if ( dat.num < (ssc_number_t)minval )
-					fail_constraint( util::to_string( (double)dat.num ) );
-			}
-			else if (test == "max")
-			{
-				if (dat.type != SSC_NUMBER) throw constraint_error(name, "cannot test for max with non-numeric type", expr);
-				double maxval = 0;
-				if (!util::to_double( rhs, &maxval )) throw constraint_error(name, "test for max requires a numeric value", expr);
-				if (dat.num > (ssc_number_t)maxval )
-					fail_constraint( util::to_string( (double)dat.num ) );
-			}
-			else if (test == "length")
-			{
-				if (dat.type != SSC_ARRAY) throw constraint_error(name, "cannot test for length with non-array type", expr);
-				int lenval = 0;
-				if (!util::to_integer( rhs, &lenval )) throw constraint_error(name, "test for length requires an integer value", expr);
-				size_t len = (size_t)lenval;
-				if (dat.num.length() != len)
-					fail_constraint( util::to_string( (int)dat.num.length() ) );
-			}
-			else if (test == "length_equal")
-			{
-				if (dat.type != SSC_ARRAY) throw constraint_error(name, "cannot test for length_equal with non-array type", expr);
-				var_data *other = lookup( rhs );
-				if (!other) throw constraint_error(name, "length_equal cannot find variable to test against", expr);
-				if (other->type == SSC_ARRAY)
-				{
-					if (dat.num.length() != other->num.length())
-						fail_constraint( util::to_string( (int) other->num.length() ) );
-				}
-				else if (other->type == SSC_NUMBER)
-				{
-					if (dat.num.length() != (size_t)(ssc_number_t)other->num)
-						fail_constraint( util::to_string( (int) other->num ) );
-				}
-				else throw constraint_error(name, "length_equal must specify a number or array variable to test against", expr);
-			}
-			else if (test == "length_multiple_of")
-			{
-				if (dat.type != SSC_ARRAY) throw constraint_error(name, "cannot test for length_multiple_of with non-array type", expr);
-				int lenval = 0;
-				if (!util::to_integer( rhs, &lenval ) || lenval < 1) throw constraint_error(name, "test for length_multiple_of requires a positive integer value", expr);
-				size_t len = (size_t)lenval;
-				size_t multiplier = dat.num.length() / len;
-				if ( dat.num.length() < len || len*multiplier != dat.num.length() )
-					fail_constraint( util::to_string( (int)dat.num.length() ) );
-			}
-			else if (test == "rows")
-			{
-				if (dat.type != SSC_MATRIX) throw constraint_error(name, "cannot test for rows with non-matrix type", expr);
-				int nrows = 0;
-				if (!util::to_integer( rhs, &nrows ) || nrows < 1) throw constraint_error(name, "test for rows requires a positive integer value", expr);
-				if ( dat.num.nrows() != (size_t)nrows )
-					fail_constraint( util::to_string( (int)dat.num.nrows() ) );
-			}
-			else if (test == "cols")
-			{
-				if (dat.type != SSC_MATRIX) throw constraint_error(name, "cannot test for cols with non-matrix type", expr);
-				int ncols = 0;
-				if (!util::to_integer( rhs, &ncols) || ncols < 1) throw constraint_error(name, "test for cols requires a positive integer value", expr);
-				if ( dat.num.ncols() != (size_t)ncols )
-					fail_constraint( util::to_string( (int)dat.num.ncols() ) );
-			}
-		}
-		else
-		{
-			throw constraint_error( name, "invalid test or expression", expr );
-		}
+            if (test == "min") {
+                if (dat.type != SSC_NUMBER)
+                    throw constraint_error(name, "cannot test for min with non-numeric type", expr);
+                double minval = 0;
+                if (!util::to_double(rhs, &minval))
+                    throw constraint_error(name, "test for min requires a number value", expr);
+                if (dat.num < (ssc_number_t) minval) fail_constraint(util::to_string((double) dat.num));
+            } else if (test == "max") {
+                if (dat.type != SSC_NUMBER)
+                    throw constraint_error(name, "cannot test for max with non-numeric type", expr);
+                double maxval = 0;
+                if (!util::to_double(rhs, &maxval))
+                    throw constraint_error(name, "test for max requires a numeric value", expr);
+                if (dat.num > (ssc_number_t) maxval) fail_constraint(util::to_string((double) dat.num));
+            } else if (test == "length") {
+                if (dat.type != SSC_ARRAY)
+                    throw constraint_error(name, "cannot test for length with non-array type", expr);
+                int lenval = 0;
+                if (!util::to_integer(rhs, &lenval))
+                    throw constraint_error(name, "test for length requires an integer value", expr);
+                size_t len = (size_t) lenval;
+                if (dat.num.length() != len) fail_constraint(util::to_string((int) dat.num.length()));
+            } else if (test == "length_equal") {
+                if (dat.type != SSC_ARRAY)
+                    throw constraint_error(name, "cannot test for length_equal with non-array type", expr);
+                var_data *other = lookup(rhs);
+                if (!other) throw constraint_error(name, "length_equal cannot find variable to test against", expr);
+                if (other->type == SSC_ARRAY) {
+                    if (dat.num.length() != other->num.length()) fail_constraint(
+                            util::to_string((int) other->num.length()));
+                } else if (other->type == SSC_NUMBER) {
+                    if (dat.num.length() != (size_t) (ssc_number_t) other->num) fail_constraint(
+                            util::to_string((int) other->num));
+                } else
+                    throw constraint_error(name, "length_equal must specify a number or array variable to test against",
+                                           expr);
+            } else if (test == "length_multiple_of") {
+                if (dat.type != SSC_ARRAY)
+                    throw constraint_error(name, "cannot test for length_multiple_of with non-array type", expr);
+                int lenval = 0;
+                if (!util::to_integer(rhs, &lenval) || lenval < 1)
+                    throw constraint_error(name, "test for length_multiple_of requires a positive integer value", expr);
+                size_t len = (size_t) lenval;
+                size_t multiplier = dat.num.length() / len;
+                if (dat.num.length() < len || len * multiplier != dat.num.length()) fail_constraint(
+                        util::to_string((int) dat.num.length()));
+            } else if (test == "rows") {
+                if (dat.type != SSC_MATRIX)
+                    throw constraint_error(name, "cannot test for rows with non-matrix type", expr);
+                int nrows = 0;
+                if (!util::to_integer(rhs, &nrows) || nrows < 1)
+                    throw constraint_error(name, "test for rows requires a positive integer value", expr);
+                if (dat.num.nrows() != (size_t) nrows) fail_constraint(util::to_string((int) dat.num.nrows()));
+            } else if (test == "cols") {
+                if (dat.type != SSC_MATRIX)
+                    throw constraint_error(name, "cannot test for cols with non-matrix type", expr);
+                int ncols = 0;
+                if (!util::to_integer(rhs, &ncols) || ncols < 1)
+                    throw constraint_error(name, "test for cols requires a positive integer value", expr);
+                if (dat.num.ncols() != (size_t) ncols) fail_constraint(util::to_string((int) dat.num.ncols()));
+            }
+        } else {
+            throw constraint_error(name, "invalid test or expression", expr);
+        }
 
-	}
+    }
 
-	// all constraints passed fine
-	return true;
+    // all constraints passed fine
+    return true;
 
 #undef fail_constraint
 }
 
-size_t compute_module::check_timestep_seconds( double t_start, double t_end, double t_step )
-{
-	if (t_start < 0.0) throw timestep_error(t_start,t_end,t_step, "start time must be 0 or greater");
-	if (t_end <= t_start) throw timestep_error(t_start,t_end,t_step, "end time must be greater than start time");
-	if (t_end > 8760.0*3600.0) throw timestep_error(t_start,t_end,t_step, "end time cannot be greater than 8760*3600");
-	if (t_step < 1.0) throw timestep_error(t_start,t_end,t_step, "time step must be greater or equal to than 1 sec");
-	if (t_step > 3600.0) throw timestep_error(t_start,t_end,t_step, "the maximum allowed time step is 3600 sec");
+size_t compute_module::check_timestep_seconds(double t_start, double t_end, double t_step) {
+    if (t_start < 0.0) throw timestep_error(t_start, t_end, t_step, "start time must be 0 or greater");
+    if (t_end <= t_start) throw timestep_error(t_start, t_end, t_step, "end time must be greater than start time");
+    if (t_end > 8760.0 * 3600.0)
+        throw timestep_error(t_start, t_end, t_step, "end time cannot be greater than 8760*3600");
+    if (t_step < 1.0) throw timestep_error(t_start, t_end, t_step, "time step must be greater or equal to than 1 sec");
+    if (t_step > 3600.0) throw timestep_error(t_start, t_end, t_step, "the maximum allowed time step is 3600 sec");
 
-	double duration = t_end - t_start;
-	size_t steps = (size_t)(ceil(duration / t_step));
+    double duration = t_end - t_start;
+    size_t steps = (size_t) (ceil(duration / t_step));
 
-	/* time step notes:
+    /* time step notes:
 
-	  The start and end times represent the time at the beginning of an hour.  For example:
+      The start and end times represent the time at the beginning of an hour.  For example:
 
-	    0 represents 12am on January 1st
-		8759 represents 11pm on December 31st
-		8760 represents 12am on January 1st of the next year
+        0 represents 12am on January 1st
+        8759 represents 11pm on December 31st
+        8760 represents 12am on January 1st of the next year
 
-		As a result, suppose you are simulating only the first twelve hours of January, at 1/2 hour steps.
-		The 'time'  will take values of
+        As a result, suppose you are simulating only the first twelve hours of January, at 1/2 hour steps.
+        The 'time'  will take values of
 
-		DataIndex: 0     1     2     3     4     5     6     7     8     9     10    11    12    13    14    15    16    17    18    19    20    21    22    23
-		Time:      0     0.5   1     1.5   2     2.5   3     3.5   4     4.5   5     5.5   6     6.5   7     7.5   8     8.5   9     9.5   10    10.5  11    11.5
+        DataIndex: 0     1     2     3     4     5     6     7     8     9     10    11    12    13    14    15    16    17    18    19    20    21    22    23
+        Time:      0     0.5   1     1.5   2     2.5   3     3.5   4     4.5   5     5.5   6     6.5   7     7.5   8     8.5   9     9.5   10    10.5  11    11.5
 
-		Therefore, there will be 24 data values needed.
+        Therefore, there will be 24 data values needed.
 
-		To specify this time range, use
-			t_start = 0
-			t_end = 12
-			t_step = 0.5
+        To specify this time range, use
+            t_start = 0
+            t_end = 12
+            t_step = 0.5
 
-		Pseudo-code for iteration control is done as follows:
+        Pseudo-code for iteration control is done as follows:
 
-		time = t_start
-		while ( time < t_end )
-		{
-			// do calculations for current time //
-			time = time + t_step
-		}
-	*/
+        time = t_start
+        while ( time < t_end )
+        {
+            // do calculations for current time //
+            time = time + t_step
+        }
+    */
 
-	size_t max0 = (size_t)( steps*t_step );
-	size_t max1 = (size_t)( duration );
+    size_t max0 = (size_t) (steps * t_step);
+    size_t max1 = (size_t) (duration);
 
-	if ( max0 != max1 ) throw timestep_error(t_start, t_end, t_step,
-		util::format("invalid time step, must represent an integer number of minutes steps(%u != %u)", max0, max1).c_str());
+    if (max0 != max1)
+        throw timestep_error(t_start, t_end, t_step,
+                             util::format(
+                                     "invalid time step, must represent an integer number of minutes steps(%u != %u)",
+                                     max0, max1).c_str());
 
-	return steps;
+    return steps;
 }
 
-ssc_number_t *compute_module::accumulate_monthly(const std::string &ts_var, const std::string &monthly_var, double scale)
-{
+ssc_number_t *
+compute_module::accumulate_monthly(const std::string &ts_var, const std::string &monthly_var, double scale) {
 
-	size_t count = 0;
-	ssc_number_t *ts = as_array(ts_var, &count);
+    size_t count = 0;
+    ssc_number_t *ts = as_array(ts_var, &count);
 
-	size_t step_per_hour = count/8760;
+    size_t step_per_hour = count / 8760;
 
-	if (!ts || step_per_hour < 1 || step_per_hour > 60 || step_per_hour*8760 != count)
-		throw exec_error("generic", "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to monthly: " + monthly_var);
+    if (!ts || step_per_hour < 1 || step_per_hour > 60 || step_per_hour * 8760 != count)
+        throw exec_error("generic",
+                         "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to monthly: " +
+                         monthly_var);
 
 
-	ssc_number_t *monthly = allocate( monthly_var, 12 );
+    ssc_number_t *monthly = allocate(monthly_var, 12);
 
-	size_t c = 0;
-	for (int m=0;m<12;m++) // each month
-	{
-		monthly[m] = 0;
-		for (size_t d=0;d<util::nday[m];d++) // for each day in each month
-			for (int h=0;h<24;h++) // for each hour in each day
-				for( size_t j=0;j<step_per_hour;j++ )
-					monthly[m] += ts[c++];
+    size_t c = 0;
+    for (int m = 0; m < 12; m++) // each month
+    {
+        monthly[m] = 0;
+        for (size_t d = 0; d < util::nday[m]; d++) // for each day in each month
+            for (int h = 0; h < 24; h++) // for each hour in each day
+                for (size_t j = 0; j < step_per_hour; j++)
+                    monthly[m] += ts[c++];
 
-		monthly[m] *= (ssc_number_t)scale;
-	}
+        monthly[m] *= (ssc_number_t) scale;
+    }
 
-	return monthly;
+    return monthly;
 }
 
-ssc_number_t *compute_module::accumulate_monthly_for_year(const std::string &ts_var, const std::string &monthly_var, double scale, size_t step_per_hour, size_t year)
-{
+ssc_number_t *
+compute_module::accumulate_monthly_for_year(const std::string &ts_var, const std::string &monthly_var, double scale,
+                                            size_t step_per_hour, size_t year) {
 
-	size_t count = 0;
-	ssc_number_t *ts = as_array(ts_var, &count);
+    size_t count = 0;
+    ssc_number_t *ts = as_array(ts_var, &count);
 
-	size_t annual_values = step_per_hour * 8760;
+    size_t annual_values = step_per_hour * 8760;
 
-	if (!ts || step_per_hour < 1 || step_per_hour > 60 || year*step_per_hour * 8760 > count)
-		throw exec_error("generic", "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to monthly: " + monthly_var);
+    if (!ts || step_per_hour < 1 || step_per_hour > 60 || year * step_per_hour * 8760 > count)
+        throw exec_error("generic",
+                         "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to monthly: " +
+                         monthly_var);
 
 
-	ssc_number_t *monthly = allocate(monthly_var, 12);
+    ssc_number_t *monthly = allocate(monthly_var, 12);
 
-	size_t c = (year-1)*annual_values;
-	for (int m = 0; m<12; m++) // each month
-	{
-		monthly[m] = 0;
-		for (size_t d = 0; d<util::nday[m]; d++) // for each day in each month
-			for (int h = 0; h<24; h++) // for each hour in each day
-				for (size_t j = 0; j<step_per_hour; j++)
-					monthly[m] += ts[c++];
+    size_t c = (year - 1) * annual_values;
+    for (int m = 0; m < 12; m++) // each month
+    {
+        monthly[m] = 0;
+        for (size_t d = 0; d < util::nday[m]; d++) // for each day in each month
+            for (int h = 0; h < 24; h++) // for each hour in each day
+                for (size_t j = 0; j < step_per_hour; j++)
+                    monthly[m] += ts[c++];
 
-		monthly[m] *= (ssc_number_t)scale;
-	}
+        monthly[m] *= (ssc_number_t) scale;
+    }
 
-	return monthly;
+    return monthly;
 }
 
-ssc_number_t compute_module::accumulate_annual(const std::string &ts_var, const std::string &annual_var, double scale)
-{
-	size_t count = 0;
-	ssc_number_t *ts = as_array(ts_var, &count);
+ssc_number_t compute_module::accumulate_annual(const std::string &ts_var, const std::string &annual_var, double scale) {
+    size_t count = 0;
+    ssc_number_t *ts = as_array(ts_var, &count);
 
-	size_t step_per_hour = count/8760;
+    size_t step_per_hour = count / 8760;
 
-	if (!ts || step_per_hour < 1 || step_per_hour > 60 || step_per_hour*8760 != count)
-		throw exec_error("generic", "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to annual: " + annual_var);
+    if (!ts || step_per_hour < 1 || step_per_hour > 60 || step_per_hour * 8760 != count)
+        throw exec_error("generic",
+                         "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to annual: " +
+                         annual_var);
 
-	double annual = 0;
-	for ( size_t i=0;i<count;i++ )
-		annual += ts[i];
+    double annual = 0;
+    for (size_t i = 0; i < count; i++)
+        annual += ts[i];
 
-	assign( annual_var, var_data( (ssc_number_t) (annual*scale) ) );
+    assign(annual_var, var_data((ssc_number_t) (annual * scale)));
 
-	return (ssc_number_t)(annual*scale);
+    return (ssc_number_t) (annual * scale);
 }
 
-ssc_number_t compute_module::accumulate_annual_for_year( const std::string &ts_var,
-	const std::string &annual_var,
-	double scale,
-	size_t step_per_hour,
-	size_t year,
-    size_t steps)
-{
-	size_t count = 0;
-	ssc_number_t *ts = as_array(ts_var, &count);
+ssc_number_t compute_module::accumulate_annual_for_year(const std::string &ts_var,
+                                                        const std::string &annual_var,
+                                                        double scale,
+                                                        size_t step_per_hour,
+                                                        size_t year,
+                                                        size_t steps) {
+    size_t count = 0;
+    ssc_number_t *ts = as_array(ts_var, &count);
 
-	size_t annual_values = step_per_hour * steps;
+    size_t annual_values = step_per_hour * steps;
 
-	if (!ts || step_per_hour < 1 || step_per_hour > 60 || year*step_per_hour * steps > count)
-		throw exec_error("generic", "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to annual: " + annual_var);
+    if (!ts || step_per_hour < 1 || step_per_hour > 60 || year * step_per_hour * steps > count)
+        throw exec_error("generic",
+                         "Failed to accumulate time series (hourly or subhourly): " + ts_var + " to annual: " +
+                         annual_var);
 
-	size_t istart = (year-1)*annual_values;
-	size_t iend  = year*annual_values;
+    size_t istart = (year - 1) * annual_values;
+    size_t iend = year * annual_values;
 
-	double sum = 0;
-	for (size_t i = istart; i < iend; i++)
-		sum += ts[i];
+    double sum = 0;
+    for (size_t i = istart; i < iend; i++)
+        sum += ts[i];
 
-	assign( annual_var, var_data((ssc_number_t)( sum * scale )));
+    assign(annual_var, var_data((ssc_number_t) (sum * scale)));
 
-	return (ssc_number_t)( sum*scale );
+    return (ssc_number_t) (sum * scale);
 }

--- a/ssc/core.cpp
+++ b/ssc/core.cpp
@@ -68,7 +68,7 @@ bool compute_module::compute( handler_interface *handler, var_table *data )
 
 	try { // catch any 'general_error' that can be thrown during precheck, exec, and postcheck
 
-        //if (!evaluate()) return false;    // This can be enabled when we want automatic updating of interdependent-inputs
+        if (!evaluate()) return false;    // This can be enabled when we want automatic updating of interdependent-inputs
         if (!verify("precheck input", SSC_INPUT)) return false;
 		exec();
 		if (!verify("postcheck output", SSC_OUTPUT)) return false;

--- a/ssc/core.cpp
+++ b/ssc/core.cpp
@@ -83,22 +83,13 @@ bool compute_module::compute( handler_interface *handler, var_table *data )
 
 bool compute_module::evaluate()
 {
-    // Get compute module name (e.g., cm_tcsmolten_salt)
-    const std::string kTypeIdClassPrefix("class ");
-    std::string compute_module_name(typeid(*this).name());
-    std::size_t prefix_position = compute_module_name.find(kTypeIdClassPrefix);
-    if (prefix_position != std::string::npos) {
-        compute_module_name.erase(prefix_position, kTypeIdClassPrefix.length());
-    }
-
     // Find ssc_equations relevant to compute module
     std::vector<size_t> table_indices;
-    compute_module_name = util::lower_case(compute_module_name);    // make lowercase for later matching
     std::size_t table_length = sizeof(ssc_equation_table)/sizeof(*ssc_equation_table);
     for (std::size_t i = 0; i < table_length; i++) {
         if (ssc_equation_table[i].cmod == nullptr) continue;
         std::string row_compute_module_name = util::lower_case(ssc_equation_table[i].cmod);
-        std::size_t match = compute_module_name.find(row_compute_module_name);
+        std::size_t match = name.find(row_compute_module_name);
 
         if (match != std::string::npos) {
             table_indices.push_back(i);

--- a/ssc/core.cpp
+++ b/ssc/core.cpp
@@ -24,6 +24,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <cstring>
 #include <algorithm>
+#include <functional>
 
 #include "core.h"
 #include "ssc_equations.h"

--- a/ssc/core.h
+++ b/ssc/core.h
@@ -170,6 +170,7 @@ public:
 	compute_module( ); // cannot be created directly - has a pure virtual function
 	virtual ~compute_module();
 
+	void set_name(const std::string &n) { name = n; }
 	bool update( const std::string &current_action, float percent_done, float time=-1.0 );
 	void log( const std::string &msg, int type=SSC_NOTICE, float time=-1.0 );
 	bool extproc( const std::string &command, const std::string &workdir );
@@ -195,6 +196,9 @@ public:
 	virtual bool on_extproc_output( const std::string & ) { return false; }
 
 protected:
+
+    std::string name;
+
     /* these members are take values only during a call to 'compute(..)'
   and are NULL otherwise */
     handler_interface   *m_handler;
@@ -203,7 +207,6 @@ protected:
 	/* must be implemented to perform calculations
 	   note: can throw exceptions of type 'compute_module::error' */
 	virtual void exec( ) = 0;
-
 
 	/* can be called in constructors to build up the variable table references */
 	void add_var_info( var_info vi[] );
@@ -297,18 +300,20 @@ public:
 
 
 #define DEFINE_MODULE_ENTRY( name, desc, ver ) \
-	static compute_module *_create_ ## name () { return new cm_ ## name; } \
+	static compute_module *_create_ ## name () { auto x = new cm_ ## name; x->set_name(#name); return x; } \
 	module_entry_info cm_entry_ ## name = { \
 		#name, desc, ver, _create_ ## name, nullptr }; \
 
 #define DEFINE_TCS_MODULE_ENTRY( name, desc, ver ) \
-	static compute_module *_create_ ## name() { extern tcstypeprovider sg_tcsTypeProvider; return new cm_ ## name(&sg_tcsTypeProvider); } \
+	static compute_module *_create_ ## name() { extern tcstypeprovider sg_tcsTypeProvider; \
+	    auto x = new cm_ ## name(&sg_tcsTypeProvider); x->set_name(#name); return x; } \
 	module_entry_info cm_entry_ ## name = { \
 		#name, desc, ver, _create_ ## name, nullptr }; \
 
 #define DEFINE_STATEFUL_MODULE_ENTRY(name, desc, ver) \
-    static compute_module *_create_ ## name () { return new cm_ ## name; } \
-    static compute_module *_create_stateful_ ## name (var_table* vt) { return new cm_ ## name (vt); } \
+    static compute_module *_create_ ## name () { throw std::runtime_error("stateful modules must be called with ssc_stateful_module_create"); } \
+    static compute_module *_create_stateful_ ## name (var_table* vt) { auto x = new cm_ ## name (vt); \
+        x->set_name(#name); return x; } \
 	module_entry_info cm_entry_ ## name = { \
 		#name, desc, ver, _create_ ## name, _create_stateful_ ## name }; \
 

--- a/ssc/ssc_equations.h
+++ b/ssc/ssc_equations.h
@@ -30,6 +30,7 @@ struct ssc_equation_entry{
     ssc_equation_ptr func;
     const char* cmod;
     const char* doc;
+    bool auto_eval;
     bool PySAM_export;
 };
 
@@ -42,46 +43,61 @@ struct ssc_equation_entry{
 static ssc_equation_entry ssc_equation_table [] = {
         // Marine energy
 		{"me_array_cable_length", me_array_cable_length,
-            "Marine energy", me_array_cable_length_doc, true},
+            "Marine energy", me_array_cable_length_doc,
+            false, true},
 		{"mp_ancillary_services", mp_ancillary_services,
-            "Merchant plant", mp_ancillary_services_doc, true},
+            "Merchant plant", mp_ancillary_services_doc,
+            false, true},
 
         // PV
         {"Reopt_size_battery_post", Reopt_size_battery_params,
-            "Pvsamv1", Reopt_size_battery_params_doc, true},
+            "Pvsamv1", Reopt_size_battery_params_doc,
+            false, true},
         {"Reopt_size_battery_post", Reopt_size_battery_params,
-            "Pvwattsv7", Reopt_size_battery_params_doc, true},
+            "Pvwattsv7", Reopt_size_battery_params_doc,
+            false, true},
 
         // Wind
         {"Turbine_calculate_powercurve", Turbine_calculate_powercurve,
-            "Windpower", Turbine_calculate_powercurve_doc, true},
+            "Windpower", Turbine_calculate_powercurve_doc,
+            false, true},
 
         // CSP
         {"MSPT_System_Design_Equations", MSPT_System_Design_Equations,
-            "Tcsmolten_salt", MSPT_System_Design_Equations_doc, false},
+            "Tcsmolten_salt", MSPT_System_Design_Equations_doc,
+            true, false},
         {"Tower_SolarPilot_Solar_Field_Equations", Tower_SolarPilot_Solar_Field_Equations,
-            "Tcsmolten_salt", Tower_SolarPilot_Solar_Field_Equations_doc, false},
+            "Tcsmolten_salt", Tower_SolarPilot_Solar_Field_Equations_doc,
+            true, false},
         {"MSPT_Receiver_Equations", MSPT_Receiver_Equations,
-            "Tcsmolten_salt", MSPT_Receiver_Equations_doc, false},
+            "Tcsmolten_salt", MSPT_Receiver_Equations_doc,
+            true, false},
         {"MSPT_System_Control_Equations", MSPT_System_Control_Equations,
-            "Tcsmolten_salt", MSPT_System_Control_Equations_doc, false},
+            "Tcsmolten_salt", MSPT_System_Control_Equations_doc,
+            true, false},
         {"Tower_SolarPilot_Capital_Costs_MSPT_Equations", Tower_SolarPilot_Capital_Costs_MSPT_Equations,
-            "Tcsmolten_salt", Tower_SolarPilot_Capital_Costs_MSPT_Equations_doc, false},
+            "Tcsmolten_salt", Tower_SolarPilot_Capital_Costs_MSPT_Equations_doc,
+            true, false},
         {"Tower_SolarPilot_Capital_Costs_DSPT_Equations", Tower_SolarPilot_Capital_Costs_DSPT_Equations,
-            "Tcsdirect_steam", Tower_SolarPilot_Capital_Costs_DSPT_Equations_doc, false},
+            "Tcsdirect_steam", Tower_SolarPilot_Capital_Costs_DSPT_Equations_doc,
+            true, false},
         {"Tower_SolarPilot_Capital_Costs_ISCC_Equations", Tower_SolarPilot_Capital_Costs_ISCC_Equations,
-            "Tcsiscc", Tower_SolarPilot_Capital_Costs_ISCC_Equations_doc, false},
+            "Tcsiscc", Tower_SolarPilot_Capital_Costs_ISCC_Equations_doc,
+            true, false},
 
         // Single owner
         {"Financial_Construction_Financing_Equations", Financial_Construction_Financing_Equations,
-            "Tcsmolten_salt", Financial_Construction_Financing_Equations_doc, false},
+            "Tcsmolten_salt", Financial_Construction_Financing_Equations_doc,
+            true, false},
         {"Financial_Capacity_Payments_Equations", Financial_Capacity_Payments_Equations,
-            "Singleowner", Financial_Capacity_Payments_Equations_doc, false},
+            "Singleowner", Financial_Capacity_Payments_Equations_doc,
+            true, false},
 
         // Utility Rate
         {"ElectricityRates_format_as_URDBv7", ElectricityRates_format_as_URDBv7,
-            "UtilityRate5", ElectricityRates_format_as_URDBv7_doc, true},
-        {nullptr, nullptr, nullptr, nullptr, false}
+            "UtilityRate5", ElectricityRates_format_as_URDBv7_doc,
+            false, true},
+        {nullptr, nullptr, nullptr, nullptr, false, false}
 };
 
 


### PR DESCRIPTION
Enabling & reviewing @Matthew-Boyd's `compute_module::exec()`'s call to new `evaluate` function that calls `ssc_equations` so that all interdependent inputs are correctly modified. Nice job!

This is part of the push to migrate equations and callbacks that modify SSC inputs from the GUI. This allows SDK and PySAM users to modify compute_module inputs without worrying that they are missing variable updates and logic in the GUI.

This works by looking up all ssc_equations that apply to a given cmod by matching the name-- hence a new name field to `compute_module`.

Added a field to `ssc_equation_entry` called `auto_eval` for equations that should be run in the `evaluate` loop. https://github.com/NREL/ssc/blob/1c065b2e53e99391e906c90e6ab2d8194378fff1/ssc/ssc_equations.h#L42

@Matthew-Boyd, could you retest these for all the CSP cmods which have associated equations?

@sjanzou @janinefreeman @brtietz FYI