### PR TITLE
core.cpp (compute_module::evaluate): Return true if all OK

### DIFF
--- a/ssc/core.cpp
+++ b/ssc/core.cpp
@@ -125,6 +125,7 @@ bool compute_module::evaluate()
                 return false;
             }
         }
+	return true;
     };
 
     CallSscEquations(table_indices);            // initial call populating outputs


### PR DESCRIPTION
This function returns `bool`, but falls off the bottom of the function without a return value.