### PR TITLE
Remove interpolation factor from single_year_to_lifetime_interpolated

### DIFF
--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -62,7 +62,7 @@ void single_year_to_lifetime_interpolated(
 			for (size_t h = 0; h < util::hours_per_year; h++) {
 				for (size_t sy = 0; sy < step_per_hour_singleyear_input; sy++) {
 					for (size_t i = 0; i < (size_t)interpolation_factor; i++) {
-						singleyear_sampled.push_back(singleyear_vector[sy_idx] / interpolation_factor);
+						singleyear_sampled.push_back(singleyear_vector[sy_idx]);
 					}
 					sy_idx++;
 				}
@@ -74,7 +74,7 @@ void single_year_to_lifetime_interpolated(
 			for (size_t h = 0; h < util::hours_per_year; h++) {
 				for (size_t sy = 0; sy < step_per_hour; sy++) {
 					// eventually add more sophisticated downsampling, ignoring information
-					singleyear_sampled.push_back(singleyear_vector[(size_t)(sy_idx/interpolation_factor)] / interpolation_factor);
+					singleyear_sampled.push_back(singleyear_vector[(size_t)(sy_idx/interpolation_factor)]);
 					sy_idx++;
 				}
 			}

--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -76,7 +76,7 @@ void single_year_to_lifetime_interpolated(
 			for (size_t h = 0; h < util::hours_per_year; h++) {
 				for (size_t sy = 0; sy < step_per_hour; sy++) {
 					// eventually add more sophisticated downsampling, ignoring information
-					singleyear_sampled.push_back(singleyear_vector[(size_t)(sy_idx/step_factor) / interpolation_factor]);
+					singleyear_sampled.push_back(singleyear_vector[(size_t)(sy_idx/step_factor)] / interpolation_factor);
 					sy_idx++;
 				}
 			}

--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -13,6 +13,7 @@
 * \param[in] n_lifetime (length of desired lifetime vector)
 * \param[in] singleyear_vector (the single year vector to scale to lifetime and interpolate)
 * \param[in] scale_factor (scaling factors for years 2 through n, must be length n prior to calling this function)
+* \param[in] interpolation_factor (scaling as needed between single year records and the interpolated records. Given annual data, should be 1 for power, and 1/dt_hour for energy)
 * \param[out] lifetime_from_singleyear_vector (the lifetime, interpolated vector)
 * \param[out] n_rec_single_year (the length of a single year vector, interpolated at the lifetime vector timescale)
 * \param[out] dt_hour (the time step in hours)
@@ -24,6 +25,7 @@ void single_year_to_lifetime_interpolated(
 	size_t n_rec_lifetime,
 	std::vector<T> singleyear_vector,
 	std::vector<T> scale_factor,
+    double interpolation_factor,
 	std::vector<T> &lifetime_from_singleyear_vector,
 	size_t &n_rec_single_year,
 	double &dt_hour)
@@ -50,7 +52,7 @@ void single_year_to_lifetime_interpolated(
 	// Parse single year properties
 	double dt_hour_singleyear_input = (double)(util::hours_per_year) / (double)(singleyear_vector.size());
 	size_t step_per_hour_singleyear_input = (size_t)(1 / dt_hour_singleyear_input);
-	T interpolation_factor = (T)step_per_hour / (T)step_per_hour_singleyear_input;
+	T step_factor = (T)step_per_hour / (T)step_per_hour_singleyear_input;
 
 	// Possible that there is no single year vector
 	if (singleyear_vector.size() > 1)
@@ -61,8 +63,8 @@ void single_year_to_lifetime_interpolated(
 			size_t sy_idx = 0;
 			for (size_t h = 0; h < util::hours_per_year; h++) {
 				for (size_t sy = 0; sy < step_per_hour_singleyear_input; sy++) {
-					for (size_t i = 0; i < (size_t)interpolation_factor; i++) {
-						singleyear_sampled.push_back(singleyear_vector[sy_idx]);
+					for (size_t i = 0; i < (size_t)step_factor; i++) {
+						singleyear_sampled.push_back(singleyear_vector[sy_idx] / interpolation_factor);
 					}
 					sy_idx++;
 				}
@@ -74,7 +76,7 @@ void single_year_to_lifetime_interpolated(
 			for (size_t h = 0; h < util::hours_per_year; h++) {
 				for (size_t sy = 0; sy < step_per_hour; sy++) {
 					// eventually add more sophisticated downsampling, ignoring information
-					singleyear_sampled.push_back(singleyear_vector[(size_t)(sy_idx/interpolation_factor)]);
+					singleyear_sampled.push_back(singleyear_vector[(size_t)(sy_idx/step_factor) / interpolation_factor]);
 					sy_idx++;
 				}
 			}
@@ -96,8 +98,8 @@ void single_year_to_lifetime_interpolated(
 	}
 }
 
-template void single_year_to_lifetime_interpolated<double>(bool, size_t, size_t,std::vector<double>, std::vector<double>, std::vector<double> &, size_t &, double &);
-template void single_year_to_lifetime_interpolated<float>(bool, size_t, size_t, std::vector<float>, std::vector<float>, std::vector<float> &, size_t &, double &);
+template void single_year_to_lifetime_interpolated<double>(bool, size_t, size_t,std::vector<double>, std::vector<double>, double, std::vector<double> &, size_t &, double &);
+template void single_year_to_lifetime_interpolated<float>(bool, size_t, size_t, std::vector<float>, std::vector<float>, double, std::vector<float> &, size_t &, double &);
 
 
 

--- a/shared/lib_time.h
+++ b/shared/lib_time.h
@@ -17,6 +17,7 @@ void single_year_to_lifetime_interpolated(
 	size_t n_lifetime,
 	std::vector<T> singleyear_vector,
     std::vector<T> scale_factor,
+    double interpolation_factor,
 	std::vector<T> &lifetime_from_singleyear_vector,
 	size_t &n_rec_single_year,
 	double &dt_hour);

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -1524,12 +1524,14 @@ public:
             // compute load (electric demand) annual escalation multipliers
             std::vector<ssc_number_t> load_scale = scale_calculator.get_factors("load_escalation");
 
+            double interpolation_factor = 1.0;
             single_year_to_lifetime_interpolated<ssc_number_t>(
                     (bool)as_integer("system_use_lifetime_output"),
                     analysis_period,
                     n_rec_lifetime,
                     load_year_one,
                     load_scale,
+                    interpolation_factor,
                     load_lifetime,
                     n_rec_single_year,
                     dt_hour_gen);

--- a/ssc/cmod_battwatts.cpp
+++ b/ssc/cmod_battwatts.cpp
@@ -313,12 +313,14 @@ void cm_battwatts::exec()
         std::vector<ssc_number_t> load_lifetime;
         size_t n_rec_single_year;
         double dt_hour_gen;
+        double interpolation_factor = 1.0;
         single_year_to_lifetime_interpolated<ssc_number_t>(
                 (bool)as_integer("system_use_lifetime_output"),
                 analysis_period,
                 n_rec_lifetime,
                 p_load,
                 load_scale,
+                interpolation_factor,
                 load_lifetime,
                 n_rec_single_year,
                 dt_hour_gen);

--- a/ssc/cmod_grid.cpp
+++ b/ssc/cmod_grid.cpp
@@ -105,12 +105,14 @@ void cm_grid::exec()
     if (is_assigned("grid_curtailment")) {
         curtailment_year_one = as_vector_double("grid_curtailment");
     }
+    double interpolation_factor = 1.0;
     single_year_to_lifetime_interpolated<double>(
         system_use_lifetime_output,
         (size_t)analysis_period,
         n_rec_lifetime,
         curtailment_year_one,
         scaleFactors,
+        interpolation_factor,
         gridVars->gridCurtailmentLifetime_MW,
         n_rec_single_year,
         gridVars->dt_hour_gen);
@@ -137,12 +139,14 @@ void cm_grid::exec()
         load_scale = scale_calculator.get_factors("load_escalation");
     }
 
+    interpolation_factor = 1.0;
     single_year_to_lifetime_interpolated<double>(
         system_use_lifetime_output,
         analysis_period,
         n_rec_lifetime,
         load_year_one,
         load_scale,
+        interpolation_factor,
         gridVars->loadLifetime_kW,
         n_rec_single_year,
         gridVars->dt_hour_gen);

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1104,12 +1104,14 @@ void cm_pvsamv1::exec( )
     // compute load (electric demand) annual escalation multipliers
     std::vector<ssc_number_t> load_scale = scale_calculator.get_factors("load_escalation");
 
+    double interpolation_factor = 1.0;
     single_year_to_lifetime_interpolated<ssc_number_t>(
         (bool)as_integer("system_use_lifetime_output"),
         nyears,
         nlifetime,
         p_load_in,
         load_scale,
+        interpolation_factor,
         p_load_full,
         nrec,
         ts_hour);

--- a/ssc/cmod_swh.cpp
+++ b/ssc/cmod_swh.cpp
@@ -814,8 +814,9 @@ public:
             std::vector<double> scaleFactors(analysis_period, 1.0);
 			size_t n_rec_single_year = 0;
 			double dt_hour_gen = 0.0;
+            double interpolation_factor = 1.0;
 			single_year_to_lifetime_interpolated<ssc_number_t>(false, analysis_period, (size_t)wdprov->nrecords(),
-				load_year_one, scaleFactors, load_lifetime, n_rec_single_year, dt_hour_gen);
+				load_year_one, scaleFactors, interpolation_factor, load_lifetime, n_rec_single_year, dt_hour_gen);
 
 			for (size_t i = 0; i < load_lifetime.size(); i++) {
 				if (out_energy[i] > load_lifetime[i]) {

--- a/test/shared_test/lib_time_test.cpp
+++ b/test/shared_test/lib_time_test.cpp
@@ -20,7 +20,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_Lifetime)
 	for (size_t y = 0; y < n_years; y++) {
 		size_t idx = y * singleyear60min.size();
 		for (size_t i = 0; i < singleyear60min.size(); i+=increment) {
-			EXPECT_EQ(lifetime_from_single[idx*2], singleyear60min[i]/2);
+			EXPECT_EQ(lifetime_from_single[idx*2], singleyear60min[i]);
 			idx += increment;
 		}
 	}
@@ -158,7 +158,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleLife
 	for (size_t y = 0; y < n_years; y++) {
 		size_t idx = y * singleyear60min.size();
 		for (size_t i = 0; i < n_rec_singleyear; i += increment) {
-			EXPECT_EQ(lifetime_from_single[idx], singleyear30min[i*2] * 2);
+			EXPECT_EQ(lifetime_from_single[idx], singleyear30min[i*2]);
 			idx += increment;
 		}
 	}
@@ -181,7 +181,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleSing
 	EXPECT_EQ(lifetime_from_single.size(), n_rec_lifetime);
 
 	for (size_t i = 0; i < n_rec_singleyear; i+=increment) {
-		EXPECT_EQ(lifetime_from_single[i], singleyear30min[i*2]*2);
+		EXPECT_EQ(lifetime_from_single[i], singleyear30min[i*2]);
 	}
 }
 

--- a/test/shared_test/lib_time_test.cpp
+++ b/test/shared_test/lib_time_test.cpp
@@ -10,7 +10,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_Lifetime)
 	size_t n_rec_singleyear;
 	double dt_hour;
 	single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-		singleyear60min, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+		singleyear60min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
 	EXPECT_EQ(n_rec_lifetime, util::hours_per_year * 2 * n_years);
 	EXPECT_EQ(n_rec_singleyear, util::hours_per_year * 2);
@@ -34,7 +34,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_SingleYear)
 	size_t n_rec_singleyear;
 	double dt_hour;
 	single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-		singleyear60min, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+		singleyear60min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
 	EXPECT_EQ(n_rec_lifetime, util::hours_per_year);
 	EXPECT_EQ(n_rec_singleyear, util::hours_per_year);
@@ -60,7 +60,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_with_escalation)
     }
     double dt_hour;
     single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-        singleyear60min, load_scale, lifetime_from_single, n_rec_singleyear, dt_hour);
+        singleyear60min, load_scale, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
     EXPECT_EQ(n_rec_lifetime, util::hours_per_year * n_years);
     EXPECT_EQ(n_rec_singleyear, util::hours_per_year);
@@ -82,7 +82,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_SingleValue)
     std::vector<float> single_val = {1.};
     double dt_hour;
     single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-                                                single_val, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+                                                single_val, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
     EXPECT_EQ(n_rec_lifetime, util::hours_per_year);
     EXPECT_EQ(n_rec_singleyear, util::hours_per_year);
@@ -103,7 +103,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_SingleYearSubh
 	size_t n_rec_singleyear;
 	double dt_hour;
 	single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-		singleyear30min, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+		singleyear30min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
 	EXPECT_EQ(n_rec_lifetime, util::hours_per_year * 2);
 	EXPECT_EQ(n_rec_singleyear, util::hours_per_year * 2);
@@ -123,7 +123,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_LifetimeSubhou
 	size_t n_rec_singleyear;
 	double dt_hour;
 	single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-		singleyear30min, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+		singleyear30min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
 	EXPECT_EQ(n_rec_lifetime, util::hours_per_year * 2 * n_years);
 	EXPECT_EQ(n_rec_singleyear, util::hours_per_year * 2);
@@ -148,7 +148,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleLife
 	size_t n_rec_singleyear;
 	double dt_hour;
 	single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-		singleyear30min, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+		singleyear30min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
 	EXPECT_EQ(n_rec_lifetime, util::hours_per_year * n_years);
 	EXPECT_EQ(n_rec_singleyear, util::hours_per_year);
@@ -165,6 +165,32 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleLife
 }
 
 // Test downsample
+TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleLifetime_w_interpolation)
+{
+    is_lifetime = true;
+    std::vector<float> lifetime_from_single;
+    size_t n_rec_lifetime = lifetime60min.size();
+    size_t n_rec_singleyear;
+    double dt_hour;
+    interpolation_factor = 2.0;
+    single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
+        singleyear30min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
+
+    EXPECT_EQ(n_rec_lifetime, util::hours_per_year * n_years);
+    EXPECT_EQ(n_rec_singleyear, util::hours_per_year);
+    EXPECT_EQ(dt_hour, 1.0);
+    EXPECT_EQ(lifetime_from_single.size(), n_rec_lifetime);
+
+    for (size_t y = 0; y < n_years; y++) {
+        size_t idx = y * singleyear60min.size();
+        for (size_t i = 0; i < n_rec_singleyear; i += increment) {
+            EXPECT_EQ(lifetime_from_single[idx], singleyear30min[i * 2] / interpolation_factor);
+            idx += increment;
+        }
+    }
+}
+
+// Test downsample
 TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleSingleYear)
 {
 	is_lifetime = false;
@@ -173,7 +199,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleSing
 	size_t n_rec_singleyear;
 	double dt_hour;
 	single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
-		singleyear30min, scaleFactors, lifetime_from_single, n_rec_singleyear, dt_hour);
+		singleyear30min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 
 	EXPECT_EQ(n_rec_lifetime, util::hours_per_year);
 	EXPECT_EQ(n_rec_singleyear, util::hours_per_year);

--- a/test/shared_test/lib_time_test.cpp
+++ b/test/shared_test/lib_time_test.cpp
@@ -172,7 +172,7 @@ TEST_F(libTimeTest_lib_time, single_year_to_lifetime_interpolated_DownsampleLife
     size_t n_rec_lifetime = lifetime60min.size();
     size_t n_rec_singleyear;
     double dt_hour;
-    interpolation_factor = 2.0;
+    interpolation_factor = 1.0 / 2.0;
     single_year_to_lifetime_interpolated<float>(is_lifetime, n_years, n_rec_lifetime,
         singleyear30min, scaleFactors, interpolation_factor, lifetime_from_single, n_rec_singleyear, dt_hour);
 

--- a/test/shared_test/lib_time_test.h
+++ b/test/shared_test/lib_time_test.h
@@ -24,6 +24,7 @@ protected:
 	util::matrix_t<size_t> schedule;
 	std::vector<double> sched_values = { 0.1, 0.0, 0.3 };
 	double multiplier = 2.0;
+    double interpolation_factor = 1.0;
 
 
 	void SetUp()


### PR DESCRIPTION
See https://github.com/NREL/ssc/issues/426 for background. This was introduced to develop with https://github.com/NREL/ssc/issues/411, I haven't been able to reproduce it on patch because patch is strict about making sure load and gen are the same length, and pvsamv1 used a different method for load forecasting.

As far as I can tell, single_year_to_lifetime_interpolated is only used on data with units of power, therefore removing it the interpolation factor is appropriate for the current code. If we apply this to energy or other units, we may need to pass it in as a parameter in the future.