### PR TITLE
Add check for dt_hour > 1 and step_per_hour == 0

### DIFF
--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -29,6 +29,13 @@ void single_year_to_lifetime_interpolated(
 	// Parse lifetime properties
 	n_rec_single_year = n_rec_lifetime;
 
+	if (is_lifetime) {
+		n_rec_single_year = n_rec_lifetime / n_years;
+	}
+	else {
+		n_years = 1;
+	}
+
 	lifetime_from_singleyear_vector.reserve(n_rec_lifetime);
 
     if (singleyear_vector.empty() ) {
@@ -36,13 +43,6 @@ void single_year_to_lifetime_interpolated(
             lifetime_from_singleyear_vector.emplace_back(0);
         return;
     }
-
-	if (is_lifetime) {
-		n_rec_single_year = n_rec_lifetime / n_years;
-	}
-	else {
-		n_years = 1;
-	}
 	dt_hour = (double)(util::hours_per_year * n_years) / n_rec_lifetime;
 	size_t step_per_hour = (size_t)(1 / dt_hour);
 	if (step_per_hour == 0)

--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -29,6 +29,14 @@ void single_year_to_lifetime_interpolated(
 	// Parse lifetime properties
 	n_rec_single_year = n_rec_lifetime;
 
+	lifetime_from_singleyear_vector.reserve(n_rec_lifetime);
+
+    if (singleyear_vector.empty() ) {
+        for (size_t i = 0; i < n_rec_lifetime; i++)
+            lifetime_from_singleyear_vector.emplace_back(0);
+        return;
+    }
+
 	if (is_lifetime) {
 		n_rec_single_year = n_rec_lifetime / n_years;
 	}
@@ -39,14 +47,6 @@ void single_year_to_lifetime_interpolated(
 	size_t step_per_hour = (size_t)(1 / dt_hour);
 	if (step_per_hour == 0)
 	    throw std::runtime_error("single_year_to_lifetime_interpolated error: Calculated step_per_hour was 0.");
-
-	lifetime_from_singleyear_vector.reserve(n_rec_lifetime);
-
-    if (singleyear_vector.empty() ) {
-        for (size_t i = 0; i < n_rec_lifetime; i++)
-            lifetime_from_singleyear_vector.emplace_back(0);
-        return;
-    }
 
 	// Parse single year properties
 	double dt_hour_singleyear_input = (double)(util::hours_per_year) / (double)(singleyear_vector.size());

--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -1,8 +1,8 @@
 #include "lib_time.h"
 
 /**
-*  \function  single_year_to_lifetime_interpolated 
-*  
+*  \function  single_year_to_lifetime_interpolated
+*
 *  Takes information about the desired lifetime vector, a single-year vector, and returns the single-year vector
 *  as a lifetime length vector, interpolated as needed.  As an example, consider that solar generation is passed in
 *  as a 15-minute, 25 year vector, and the electric load is currently a single-year and hourly.  The function will
@@ -37,6 +37,9 @@ void single_year_to_lifetime_interpolated(
 	}
 	dt_hour = (double)(util::hours_per_year * n_years) / n_rec_lifetime;
 	size_t step_per_hour = (size_t)(1 / dt_hour);
+	if (step_per_hour == 0)
+	    throw std::runtime_error("single_year_to_lifetime_interpolated error: Calculated step_per_hour was 0.");
+
 	lifetime_from_singleyear_vector.reserve(n_rec_lifetime);
 
     if (singleyear_vector.empty() ) {
@@ -107,7 +110,7 @@ template void single_year_to_lifetime_interpolated<float>(bool, size_t, size_t, 
 * \param[in] steps_per_hour - Number of time steps per hour
 * \param[in] period_values - the value assigned to each period number
 * \param[in] multiplier - a multiplier on the period value
-* \param[out] flat_vector - The 8760*steps per hour values at each hour 
+* \param[out] flat_vector - The 8760*steps per hour values at each hour
 */
 template <class T>
 std::vector<T> flatten_diurnal(util::matrix_t<size_t> weekday_schedule, util::matrix_t<size_t> weekend_schedule, size_t steps_per_hour, std::vector<T> period_values, T multiplier)

--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -49,8 +49,8 @@ void single_year_to_lifetime_interpolated(
 
 	// Parse single year properties
 	double dt_hour_singleyear_input = (double)(util::hours_per_year) / (double)(singleyear_vector.size());
-	auto step_per_hour_singleyear_input = (size_t)(1 / dt_hour_singleyear_input);
-	T step_factor = (T)step_per_hour / (T)step_per_hour_singleyear_input;
+    size_t step_per_hour_singleyear_input = (size_t)(1 / dt_hour_singleyear_input);
+    T interpolation_factor = (T)step_per_hour / (T)step_per_hour_singleyear_input;
 
 	// Possible that there is no single year vector
 	if (singleyear_vector.size() > 1)

--- a/shared/lib_time.cpp
+++ b/shared/lib_time.cpp
@@ -28,30 +28,29 @@ void single_year_to_lifetime_interpolated(
 {
 	// Parse lifetime properties
 	n_rec_single_year = n_rec_lifetime;
-
 	if (is_lifetime) {
 		n_rec_single_year = n_rec_lifetime / n_years;
 	}
 	else {
 		n_years = 1;
 	}
+	dt_hour = (double)(util::hours_per_year * n_years) / n_rec_lifetime;
 
 	lifetime_from_singleyear_vector.reserve(n_rec_lifetime);
-
     if (singleyear_vector.empty() ) {
         for (size_t i = 0; i < n_rec_lifetime; i++)
             lifetime_from_singleyear_vector.emplace_back(0);
         return;
     }
-	dt_hour = (double)(util::hours_per_year * n_years) / n_rec_lifetime;
-	size_t step_per_hour = (size_t)(1 / dt_hour);
+
+	auto step_per_hour = (size_t)(1 / dt_hour);
 	if (step_per_hour == 0)
 	    throw std::runtime_error("single_year_to_lifetime_interpolated error: Calculated step_per_hour was 0.");
 
 	// Parse single year properties
 	double dt_hour_singleyear_input = (double)(util::hours_per_year) / (double)(singleyear_vector.size());
-	size_t step_per_hour_singleyear_input = (size_t)(1 / dt_hour_singleyear_input);
-	T interpolation_factor = (T)step_per_hour / (T)step_per_hour_singleyear_input;
+	auto step_per_hour_singleyear_input = (size_t)(1 / dt_hour_singleyear_input);
+	T step_factor = (T)step_per_hour / (T)step_per_hour_singleyear_input;
 
 	// Possible that there is no single year vector
 	if (singleyear_vector.size() > 1)

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -1619,6 +1619,12 @@ public:
             std::vector<ssc_number_t> power_input_lifetime = as_vector_ssc_number_t("gen");
             std::vector<ssc_number_t> load_lifetime, load_year_one;
             size_t n_rec_lifetime = power_input_lifetime.size();
+            bool use_lifetime = as_boolean("system_use_lifetime_output");
+            size_t analysis_period = (size_t)as_integer("analysis_period");
+
+            if (use_lifetime && (double)(util::hours_per_year * analysis_period) / n_rec_lifetime > 1)
+                throw exec_error("battery", "`gen` input must be lifetime when system_use_lifetime_output=1.");
+
             size_t n_rec_single_year;
             double dt_hour_gen;
             if (is_assigned("load")) {
@@ -1626,8 +1632,8 @@ public:
             }
 
             single_year_to_lifetime_interpolated<ssc_number_t>(
-                    (bool)as_integer("system_use_lifetime_output"),
-                    (size_t)as_integer("analysis_period"),
+                    use_lifetime,
+                    analysis_period,
                     n_rec_lifetime,
                     load_year_one,
                     load_lifetime,

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -740,6 +740,9 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NonAnnual)
 	ssc_data_unassign(data, "solar_resource_file");
 	ssc_data_set_table(data, "solar_resource_data", &weather_data->table);
 
+	std::vector<double> load(24, 1);
+	ssc_data_set_array(data, "load", &load[0], (int)load.size());
+
 	//run the tests
 	EXPECT_FALSE(run_module(data, "pvsamv1"));
 


### PR DESCRIPTION
In `cmod_battery`, adding an error check for when the `gen` input is single year rather than lifetime. This leads to `dt_hour > 1` and `step_per_hour = 0` which caused a segfault in `single_year_to_lifetime_interpolated`.

This won't happen in SAM but can be a mysterious hard crash in PySAM.