### PR TITLE
Batt subminute

### DIFF
--- a/shared/lib_battery_voltage.cpp
+++ b/shared/lib_battery_voltage.cpp
@@ -36,8 +36,6 @@ bool voltage_state::operator==(const voltage_state &p) {
 void voltage_t::initialize() {
     state = std::make_shared<voltage_state>();
     state->cell_voltage = params->Vnom_default;
-    if (params->dt_hr < 1 / 60.)
-        throw std::runtime_error("Battery time step size must be greater than 1/60th of hour.");
 }
 
 voltage_t::voltage_t(int mode, int num_cells_series, int num_strings, double voltage, double dt_hour) {

--- a/shared/lib_battery_voltage.cpp
+++ b/shared/lib_battery_voltage.cpp
@@ -412,7 +412,8 @@ double voltage_dynamic_t::calculate_current_for_target_w(double P_watts, double 
     }
 
     double x[1], resid[1];
-    x[0] = solver_power / state->cell_voltage / 10;     // initial guess is important
+    double initial_guess_factor = 0.1;       // trial and error, this gave correct results for a variety of timescales
+    x[0] = solver_power / state->cell_voltage * initial_guess_factor;
     bool check = false;
 
     newton<double, std::function<void(const double *, double *)>, 1>(x, resid, check, f,
@@ -538,7 +539,8 @@ double voltage_vanadium_redox_t::calculate_current_for_target_w(double P_watts, 
                                                                 this, _1, _2);
 
     double x[1], resid[1];
-    x[0] = solver_power / state->cell_voltage / 10;
+    double initial_guess_factor = 0.1;       // trial and error, this gave correct results for a variety of timescales
+    x[0] = solver_power / state->cell_voltage * initial_guess_factor;
     bool check = false;
 
     newton<double, std::function<void(const double *, double *)>, 1>(x, resid, check, f,

--- a/shared/lib_battery_voltage.cpp
+++ b/shared/lib_battery_voltage.cpp
@@ -414,7 +414,7 @@ double voltage_dynamic_t::calculate_current_for_target_w(double P_watts, double 
     }
 
     double x[1], resid[1];
-    x[0] = solver_power / state->cell_voltage;
+    x[0] = solver_power / state->cell_voltage / 10;     // initial guess is important
     bool check = false;
 
     newton<double, std::function<void(const double *, double *)>, 1>(x, resid, check, f,
@@ -439,8 +439,6 @@ void voltage_dynamic_t::solve_current_for_discharge_power(const double *x, doubl
 // Vanadium redox flow model
 void voltage_vanadium_redox_t::initialize() {
     m_RCF = 8.314 * 1.38 / (26.801 * 3600);
-    if (params->dt_hr < 1 / 60.)
-        throw std::runtime_error("Battery time step size must be greater than 1/60th of hour.");
 }
 
 voltage_vanadium_redox_t::voltage_vanadium_redox_t(int num_cells_series, int num_strings, double Vnom_default, double R,
@@ -511,7 +509,7 @@ double voltage_vanadium_redox_t::calculate_max_discharge_w(double q, double qmax
                                                                 this, _1, _2);
 
     double x[1], resid[1];
-    x[0] = solver_q - tolerance;
+    x[0] = (solver_q - tolerance) / params->dt_hr;
     bool check = false;
 
     newton<double, std::function<void(const double *, double *)>, 1>(x, resid, check, f,
@@ -542,7 +540,7 @@ double voltage_vanadium_redox_t::calculate_current_for_target_w(double P_watts, 
                                                                 this, _1, _2);
 
     double x[1], resid[1];
-    x[0] = solver_power / state->cell_voltage;
+    x[0] = solver_power / state->cell_voltage / 10;
     bool check = false;
 
     newton<double, std::function<void(const double *, double *)>, 1>(x, resid, check, f,

--- a/shared/lib_battery_voltage.h
+++ b/shared/lib_battery_voltage.h
@@ -121,7 +121,7 @@ private:
 class voltage_table_t : public voltage_t {
 public:
     voltage_table_t(int num_cells_series, int num_strings, double voltage, util::matrix_t<double> &voltage_table,
-                    double R, double dt_hour);
+                    double R, double dt_hour, double init_soc);
 
     voltage_table_t(std::shared_ptr<voltage_params> p);
 
@@ -158,9 +158,8 @@ private:
 // Shepard + Tremblay Model
 class voltage_dynamic_t : public voltage_t {
 public:
-    voltage_dynamic_t(int num_cells_series, int num_strings, double voltage, double Vfull,
-                      double Vexp, double Vnom, double Qfull, double Qexp, double Qnom,
-                      double C_rate, double R, double dt_hr);
+    voltage_dynamic_t(int num_cells_series, int num_strings, double voltage, double Vfull, double Vexp, double Vnom,
+                      double Qfull, double Qexp, double Qnom, double C_rate, double R, double dt_hr, double init_soc);
 
     voltage_dynamic_t(std::shared_ptr<voltage_params> p);
 
@@ -212,8 +211,8 @@ private:
 // D'Agostino Vanadium Redox Flow Model
 class voltage_vanadium_redox_t : public voltage_t {
 public:
-    voltage_vanadium_redox_t(int num_cells_series, int num_strings, double Vnom_default, double R,
-                             double dt_hour = 1.);
+    voltage_vanadium_redox_t(int num_cells_series, int num_strings, double Vnom_default, double R, double dt_hour,
+                             double init_soc);
 
     explicit voltage_vanadium_redox_t(std::shared_ptr<voltage_params> p);
 

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -767,13 +767,16 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
                                               batt_vars->batt_Vnom_default, batt_vars->batt_Vfull, batt_vars->batt_Vexp,
                                               batt_vars->batt_Vnom, batt_vars->batt_Qfull, batt_vars->batt_Qexp,
                                               batt_vars->batt_Qnom, batt_vars->batt_C_rate, batt_vars->batt_resistance,
-                                              dt_hr);
+                                              dt_hr, batt_vars->batt_initial_SOC);
     else if ((chem == battery_params::VANADIUM_REDOX) && batt_vars->batt_voltage_choice == voltage_params::MODEL)
         voltage_model = new voltage_vanadium_redox_t(batt_vars->batt_computed_series, batt_vars->batt_computed_strings,
-                                                     batt_vars->batt_Vnom_default, batt_vars->batt_resistance, dt_hr);
+                                                     batt_vars->batt_Vnom_default, batt_vars->batt_resistance,
+                                                     dt_hr,batt_vars->batt_initial_SOC);
     else
-        voltage_model = new voltage_table_t(batt_vars->batt_computed_series, batt_vars->batt_computed_strings, batt_vars->batt_Vnom_default,
-                                            batt_vars->batt_voltage_matrix, batt_vars->batt_resistance, dt_hr);
+        voltage_model = new voltage_table_t(batt_vars->batt_computed_series, batt_vars->batt_computed_strings,
+                                            batt_vars->batt_Vnom_default,
+                                            batt_vars->batt_voltage_matrix, batt_vars->batt_resistance,
+                                            dt_hr, batt_vars->batt_initial_SOC);
 
     if (batt_vars->batt_calendar_choice == lifetime_params::CALENDAR_CHOICE::MODEL) {
         lifetime_model = new lifetime_t(batt_vars->batt_lifetime_matrix, dt_hr,

--- a/test/shared_test/lib_battery_dispatch_automatic_btm_test.h
+++ b/test/shared_test/lib_battery_dispatch_automatic_btm_test.h
@@ -45,7 +45,7 @@ public:
 
         capacityModel = new capacity_lithium_ion_t(q * n_strings, SOC_init, SOC_max, SOC_min, dtHour);
         voltageModel = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
-                                             C_rate, resistance, dtHour);
+                                             C_rate, resistance, dtHour, SOC_init);
         lifetimeModel = new lifetime_t(cycleLifeMatrix, dtHour, calendar_q0, calendar_a, calendar_b, calendar_c);
         thermalModel = new thermal_t(1.0, mass, surface_area, resistance, Cp, h, capacityVsTemperature, T_room);
         lossModel = new losses_t();

--- a/test/shared_test/lib_battery_dispatch_automatic_fom_test.h
+++ b/test/shared_test/lib_battery_dispatch_automatic_fom_test.h
@@ -41,7 +41,8 @@ public:
         BatteryProperties::SetUp();
 
         capacityModel = new capacity_lithium_ion_t(2.25 * 133227, 50, 100, 10, dtHour);
-        voltageModel = new voltage_dynamic_t(139, 133227, 3.6, 4.10, 4.05, 3.4, 2.25, 0.04, 2.00, 0.2, 0.2, dtHour);
+        voltageModel = new voltage_dynamic_t(139, 133227, 3.6, 4.10, 4.05, 3.4,
+                2.25, 0.04, 2.00, 0.2, 0.2, dtHour, 50);
         lifetimeModel = new lifetime_t(cycleLifeMatrix, dtHour, calendar_q0, calendar_a, calendar_b, calendar_c);
         thermalModel = new thermal_t(1.0, mass, surface_area, resistance, Cp, h, capacityVsTemperature, T_room);
         lossModel = new losses_t();

--- a/test/shared_test/lib_battery_dispatch_manual_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_manual_test.cpp
@@ -468,8 +468,8 @@ TEST_F(ManualTest_lib_battery_dispatch, InverterEfficiencyCutoffDC)
     // Test discharge constraints. First constraint does not hit backoff
     batteryPower->powerPV = 0; batteryPower->voltageSystem = 600; batteryPower->powerGridToBattery = 0; batteryPower->powerLoad = 7;
     dispatchManual->dispatch(year, 0, step_of_hour);
-    EXPECT_NEAR(batteryPower->sharedInverter->efficiencyAC, 37.69, 0.1); // Not enforced becasue no PV
-    EXPECT_NEAR(batteryPower->powerBatteryDC, 4.55, 0.1);
+    EXPECT_NEAR(batteryPower->sharedInverter->efficiencyAC, 36.05, 0.1); // Not enforced becasue no PV
+    EXPECT_NEAR(batteryPower->powerBatteryDC, 4.43, 0.1);
 
     batteryPower->powerPV = 770; batteryPower->voltageSystem = 600; batteryPower->powerGridToBattery = 0; batteryPower->powerLoad = 1000;
     dispatchManual->dispatch(year, 12, step_of_hour);

--- a/test/shared_test/lib_battery_dispatch_manual_test.h
+++ b/test/shared_test/lib_battery_dispatch_manual_test.h
@@ -51,7 +51,7 @@ public:
 
         capacityModel = new capacity_lithium_ion_t(q * n_strings, SOC_init, SOC_max, SOC_min, 1.0);
         voltageModel = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
-                                             C_rate, resistance, dtHour);
+                                             C_rate, resistance, dtHour, SOC_init);
         lifetimeModel = new lifetime_t(cycleLifeMatrix, dtHour, calendar_q0, calendar_a, calendar_b, calendar_c);
         thermalModel = new thermal_t(1.0, mass, surface_area, resistance, Cp, h, capacityVsTemperature, T_room);
         lossModel = new losses_t();

--- a/test/shared_test/lib_battery_test.cpp
+++ b/test/shared_test/lib_battery_test.cpp
@@ -348,7 +348,7 @@ TEST_F(lib_battery_test, RoundtripEffTable){
     util::matrix_t<double> table(4, 2, &vals);
 
     auto capacityModel = new capacity_lithium_ion_t(q, SOC_init, SOC_max, SOC_min, dtHour);
-    auto voltageModel = new voltage_table_t(n_series, n_strings, Vnom_default, table, resistance, 1);
+    auto voltageModel = new voltage_table_t(n_series, n_strings, Vnom_default, table, resistance, 1, SOC_init);
     capacityModel->change_SOC_limits(0, 100);
 
     double full_current = 1000;
@@ -397,7 +397,7 @@ TEST_F(lib_battery_test, RoundtripEffTable){
 }
 
 TEST_F(lib_battery_test, RoundtripEffVanadiumFlow){
-    auto vol = new voltage_vanadium_redox_t(1, 1, 1.41, 0.001, dtHour);
+    auto vol = new voltage_vanadium_redox_t(1, 1, 1.41, 0.001, dtHour, SOC_init);
     auto cap = new capacity_lithium_ion_t(11, 30, 100, 0, dtHour);
 
     cap->change_SOC_limits(0, 100);
@@ -449,10 +449,12 @@ TEST_F(lib_battery_test, RoundtripEffVanadiumFlow){
 TEST_F(lib_battery_test, HourlyVsSubHourly)
 {
     auto cap_hourly = new capacity_lithium_ion_t(q, SOC_init, SOC_max, SOC_min, dtHour);
-    auto volt_hourly = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom, C_rate, resistance, 1);
+    auto volt_hourly = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
+                                             C_rate, resistance, 1, SOC_init);
 
     auto cap_subhourly = new capacity_lithium_ion_t(q, SOC_init, SOC_max, SOC_min, dtHour);
-    auto volt_subhourly = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom, C_rate, resistance, .5);
+    auto volt_subhourly = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
+                                                C_rate, resistance, .5, SOC_init);
 
     EXPECT_EQ(cap_hourly->q0(), cap_subhourly->q0());
     EXPECT_EQ(volt_hourly->battery_voltage(), volt_subhourly->battery_voltage());

--- a/test/shared_test/lib_battery_test.h
+++ b/test/shared_test/lib_battery_test.h
@@ -252,7 +252,8 @@ public:
         dtHour = 1.0;
 
         capacityModel = new capacity_lithium_ion_t(q, SOC_init, SOC_max, SOC_min, dtHour);
-        voltageModel = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom, C_rate, resistance, dtHour);
+        voltageModel = new voltage_dynamic_t(n_series, n_strings, Vnom_default, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
+                                             C_rate, resistance, dtHour, SOC_init);
         lifetimeModel = new lifetime_t(cycleLifeMatrix, dtHour, 1.02, 2.66e-3, -7280, 930);
         thermalModel = new thermal_t(1.0, mass, surface_area, resistance, Cp, h, capacityVsTemperature, T_room);
         lossModel = new losses_t(monthlyLosses, monthlyLosses, monthlyLosses);

--- a/test/shared_test/lib_battery_voltage_test.cpp
+++ b/test/shared_test/lib_battery_voltage_test.cpp
@@ -820,19 +820,19 @@ TEST_F(voltage_vanadium_lib_battery_voltage_test, updateCapacitySubMinute){
     cap->updateCapacity(I, dt_hour); // qmx = 10, q0 = 3
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 293, dt_hour);
     EXPECT_NEAR(model->cell_voltage(), 3.644, tol);
-    EXPECT_NEAR(cap->q0(), 4.99, tol);
+    EXPECT_NEAR(cap->q0(), 4.99, 1e-3);
 
     I = -2;
     cap->updateCapacity(I, dt_hour); // qmx = 10, q0 = 5
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 293, dt_hour);
     EXPECT_NEAR(model->cell_voltage(), 3.64, tol);
-    EXPECT_NEAR(cap->q0(), 5, tol);
+    EXPECT_NEAR(cap->q0(), 5, 1e-3);
 
     I = 5;
     cap->updateCapacity(I, dt_hour); // qmx = 10, I = 4.5, q0 = 0.5
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 293, dt_hour);
     EXPECT_NEAR(model->cell_voltage(), 3.71, tol);
-    EXPECT_NEAR(cap->q0(), 4.975, tol);
+    EXPECT_NEAR(cap->q0(), 4.975, 1e-3);
 }
 
 TEST_F(voltage_vanadium_lib_battery_voltage_test, calculateMaxChargeHourly){

--- a/test/shared_test/lib_battery_voltage_test.cpp
+++ b/test/shared_test/lib_battery_voltage_test.cpp
@@ -84,20 +84,20 @@ TEST_F(voltage_dynamic_lib_battery_voltage_test, updateCapacitySubMinute){
     double I = 2;
     cap->updateCapacity(I, dt_hour); // qmx = 10, q0 = 3
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 0, dt_hour);
-    EXPECT_NEAR(model->cell_voltage(), 4.01, tol);
-    EXPECT_NEAR(cap->q0(), 5, tol);
+    EXPECT_NEAR(model->cell_voltage(), 4.014, 1e-3);
+    EXPECT_NEAR(cap->q0(), 4.99, 1e-3);
 
     I = -2;
     cap->updateCapacity(I, dt_hour); // qmx = 10, q0 = 5
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 0, dt_hour);
-    EXPECT_NEAR(model->cell_voltage(), 4.1, tol);
-    EXPECT_NEAR(cap->q0(), 5, tol);
+    EXPECT_NEAR(model->cell_voltage(), 4.103, 1e-3);
+    EXPECT_NEAR(cap->q0(), 5, 1e-3);
 
     I = 5;
     cap->updateCapacity(I, dt_hour); // qmx = 10, I = 4.5, q0 = 0.5
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 0, dt_hour);
-    EXPECT_NEAR(model->cell_voltage(), 3.95, tol);
-    EXPECT_NEAR(cap->q0(), 4.97, tol);
+    EXPECT_NEAR(model->cell_voltage(), 3.947, 1e-3);
+    EXPECT_NEAR(cap->q0(), 4.975, 1e-3);
 }
 
 TEST_F(voltage_dynamic_lib_battery_voltage_test, calculateMaxChargeHourly){
@@ -374,19 +374,19 @@ TEST_F(voltage_table_lib_battery_voltage_test, updateCapacitySubMinute){
     cap->updateCapacity(I, dt_hour); // qmx = 10, q0 = 3
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 0, dt_hour);
     EXPECT_NEAR(model->cell_voltage(), 3.689, tol);
-    EXPECT_NEAR(cap->q0(), 5, tol);
+    EXPECT_NEAR(cap->q0(), 4.99, 1e-3);
 
     I = -2;
     cap->updateCapacity(I, dt_hour); // qmx = 10, q0 = 5
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 0, dt_hour);
     EXPECT_NEAR(model->cell_voltage(), 3.69, tol);
-    EXPECT_NEAR(cap->q0(), 5, tol);
+    EXPECT_NEAR(cap->q0(), 5, 1e-3);
 
     I = 5;
     cap->updateCapacity(I, dt_hour); // qmx = 10, I = 4.5, q0 = 0.5
     model->updateVoltage(cap->q0(), cap->qmax(), cap->I(), 0, dt_hour);
     EXPECT_NEAR(model->cell_voltage(), 3.689, tol);
-    EXPECT_NEAR(cap->q0(), 4.97, tol);
+    EXPECT_NEAR(cap->q0(), 4.975, 1e-3);
 }
 
 TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeHourly1){

--- a/test/shared_test/lib_battery_voltage_test.cpp
+++ b/test/shared_test/lib_battery_voltage_test.cpp
@@ -7,7 +7,7 @@
 TEST_F(voltage_dynamic_lib_battery_voltage_test, SetUpTest) {
     CreateModel(1);
 
-    EXPECT_EQ(model->cell_voltage(), 4.1);
+    EXPECT_NEAR(model->cell_voltage(), 4.058, 1e-3);
 }
 
 TEST_F(voltage_dynamic_lib_battery_voltage_test, NickelMetalHydrideFromPaperTest){
@@ -16,8 +16,8 @@ TEST_F(voltage_dynamic_lib_battery_voltage_test, NickelMetalHydrideFromPaperTest
     // Figure 3 from A Generic Battery Model for the Dynamic Simulation of Hybrid Electric Vehicles
     cap = std::unique_ptr<capacity_lithium_ion_t>(new capacity_lithium_ion_t(6.5, 100, 100, 0, 1));
 
-    model = std::unique_ptr<voltage_t>(new voltage_dynamic_t(1, 1,1.2, 1.4,
-            1.25, 1.2, 6.5, 1.3, 5.2, 0.2, 0.0046, 1));
+    model = std::unique_ptr<voltage_t>(new voltage_dynamic_t(1, 1, 1.2, 1.4,
+                                                             1.25, 1.2, 6.5, 1.3, 5.2, 0.2, 0.0046, 1, 100));
     std::vector<double> dt_hr = {1./6., 1./3., 1./3.};
     // testing with 1lt curve
     std::vector<double> voltages = {1.25, 1.22, 1.17};
@@ -414,7 +414,7 @@ TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeHourly1){
     EXPECT_NEAR(max_current_calc, -4.99, 1e-2);
     cap->updateCapacity(max_current_calc, dt_hour);
     EXPECT_NEAR(cap->SOC(), 99.99, 1e-2);
-    EXPECT_NEAR(cap->I() * model->battery_voltage(), -2501, 1);
+    EXPECT_NEAR(cap->I() * model->battery_voltage(), -2564, 1);
 }
 
 TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeHourly2){
@@ -449,7 +449,7 @@ TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeHourly2){
     // max current reduced to enforce SOC
     cap->updateCapacity(max_current_calc, dt_hour);
     EXPECT_NEAR(cap->SOC(), 99.984, 1e-3);
-    EXPECT_NEAR(cap->I() * model->battery_voltage(), -500, 1);
+    EXPECT_NEAR(cap->I() * model->battery_voltage(), -512, 1);
 
     // start at empty SOC
     double I = 2;
@@ -496,7 +496,7 @@ TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeHourly3){
     // max current reduced to enforce SOC
     cap->updateCapacity(max_current_calc, dt_hour);
     EXPECT_NEAR(cap->SOC(), 99.99, 1e-2);
-    EXPECT_NEAR(cap->I() * model->battery_voltage(), -4503, 1);
+    EXPECT_NEAR(cap->I() * model->battery_voltage(), -4615, 1);
 }
 
 TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeSubHourly1){
@@ -526,7 +526,7 @@ TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeSubHourly1){
     // max current reduced to enforce SOC
     cap->updateCapacity(max_current_calc, dt_hour);
     EXPECT_NEAR(cap->SOC(), 99.99, 1e-2);
-    EXPECT_NEAR(cap->I() * model->battery_voltage(), -5003, 1);
+    EXPECT_NEAR(cap->I() * model->battery_voltage(), -5128, 1);
 }
 
 TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeSubHourly2){
@@ -560,7 +560,7 @@ TEST_F(voltage_table_lib_battery_voltage_test, calculateMaxChargeSubHourly2){
 
     cap->updateCapacity(max_current_calc, dt_hour);
     EXPECT_NEAR(cap->SOC(), 99.99, 1e-2);
-    EXPECT_NEAR(cap->I() * model->battery_voltage(), -1000, 1);
+    EXPECT_NEAR(cap->I() * model->battery_voltage(), -1025, 1);
 
     // start at empty SOC
     double I = 2;

--- a/test/shared_test/lib_battery_voltage_test.h
+++ b/test/shared_test/lib_battery_voltage_test.h
@@ -45,7 +45,8 @@ protected:
         cap = std::unique_ptr<capacity_lithium_ion_t>(new capacity_lithium_ion_t(10, 50, 95, 5, dt_hr));
 
         model = std::unique_ptr<voltage_t>(new voltage_dynamic_t(n_cells_series, n_strings,
-                voltage_nom, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom, C_rate, R, dt_hr));
+                                                                 voltage_nom, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
+                                                                 C_rate, R, dt_hr, 50));
     }
 };
 
@@ -64,7 +65,8 @@ protected:
         table = util::matrix_t<double>(4, 2, &vals);
 
         cap = std::unique_ptr<capacity_lithium_ion_t>(new capacity_lithium_ion_t(10, 50, 95, 5, dt_hr));
-        model = std::unique_ptr<voltage_t>(new voltage_table_t(n_cells_series, n_strings, voltage_nom, table, R, dt_hr));
+        model = std::unique_ptr<voltage_t>(new voltage_table_t(n_cells_series, n_strings, voltage_nom, table, R, dt_hr,
+                                                               50));
     }
 
     // Additional test case based on voltage table from a user. documented in SSC issue 412
@@ -73,7 +75,8 @@ protected:
         util::matrix_t<double> voltage_table(9, 2, &voltage_vals);
 
         cap = std::unique_ptr<capacity_lithium_ion_t>(new capacity_lithium_ion_t(10, 50, 95, 5, dt_hr));
-        model = std::unique_ptr<voltage_t>(new voltage_table_t(n_cells_series, n_strings, voltage_nom, voltage_table, R, dt_hr));
+        model = std::unique_ptr<voltage_t>(new voltage_table_t(n_cells_series, n_strings, voltage_nom, voltage_table, R,
+                                                               dt_hr, 50));
     }
 };
 
@@ -82,7 +85,8 @@ class voltage_vanadium_lib_battery_voltage_test : public lib_battery_voltage_tes
 protected:
     void CreateModel(double dt_hr){
         cap = std::unique_ptr<capacity_lithium_ion_t>(new capacity_lithium_ion_t(10, 50, 95, 5, dt_hr));
-        model = std::unique_ptr<voltage_t>(new voltage_vanadium_redox_t(n_cells_series, n_strings, voltage_nom, R, dt_hr));
+        model = std::unique_ptr<voltage_t>(new voltage_vanadium_redox_t(n_cells_series, n_strings, voltage_nom, R,
+                                                                        dt_hr, 50));
     }
 };
 

--- a/test/shared_test/lib_resilience_test.cpp
+++ b/test/shared_test/lib_resilience_test.cpp
@@ -20,8 +20,9 @@ TEST_F(ResilienceTest_lib_resilience, VoltageCutoffParameterSetup)
                                         char buf[300];
                                         sprintf(buf, "dtHour, %f, Vfull, %f, Vexp, %f, Vnom, %f, Qfull, %f, Qexp, %f, Qnom, %f, C rate, %f, res, %f",
                                                 dtHour, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom, C_rate, resistance);
-                                        auto voltageModel = new voltage_dynamic_t(n_series, n_strings, Vnom * 0.98, Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
-                                                                                  C_rate, resistance, dtHour);
+                                        auto voltageModel = new voltage_dynamic_t(n_series, n_strings, Vnom * 0.98,
+                                                                                  Vfull, Vexp, Vnom, Qfull, Qexp, Qnom,
+                                                                                  C_rate, resistance, dtHour, 100);
                                         try{
                                             double current1;
                                             for (auto q_ratio : {0.25, 0.5, 0.75}){
@@ -213,8 +214,9 @@ TEST_F(ResilienceTest_lib_resilience, VoltageTable)
 {
     std::vector<double> vals = {99, 0, 50, 2, 0, 3};
     util::matrix_t<double> table(3, 2, &vals);
-    auto volt = voltage_table_t(1, 1, 3, table, 0.1, 1);
-    auto cap = capacity_lithium_ion_t(2.25, 50, 100, 0, 1);
+    double soc_init = 50;
+    auto volt = voltage_table_t(1, 1, 3, table, 0.1, 1, soc_init);
+    auto cap = capacity_lithium_ion_t(2.25, soc_init, 100, 0, 1);
 
     volt.updateVoltage(cap.q0(), cap.qmax(), cap.I(), 0, 0.);
     EXPECT_NEAR(cap.SOC(), 50, 1e-3);
@@ -249,8 +251,9 @@ TEST_F(ResilienceTest_lib_resilience, VoltageTable)
 TEST_F(ResilienceTest_lib_resilience, DischargeVoltageTable){
     std::vector<double> vals = {99, 0, 50, 2, 0, 3};
     util::matrix_t<double> table(3, 2, &vals);
-    auto volt = voltage_table_t(1, 1, 3, table, 0.1, 1);
-    auto cap = capacity_lithium_ion_t(2.25, 50, 100, 0, 1);
+    double soc_init = 50;
+    auto volt = voltage_table_t(1, 1, 3, table, 0.1, 1, soc_init);
+    auto cap = capacity_lithium_ion_t(2.25, soc_init, 100, 0, 1);
 
     // test discharging
     double req_cur = volt.calculate_current_for_target_w(2.2386, 2.25, 2.25, 0);
@@ -293,8 +296,9 @@ TEST_F(ResilienceTest_lib_resilience, DischargeVoltageTable){
 TEST_F(ResilienceTest_lib_resilience, ChargeVoltageTable){
     std::vector<double> vals = {99, 0, 50, 2, 0, 3};
     util::matrix_t<double> table(3, 2, &vals);
-    auto volt = voltage_table_t(1, 1, 3, table, 0.1, 1);
-    auto cap = capacity_lithium_ion_t(2.25, 50, 100, 0, 1);
+    double soc_init = 50;
+    auto volt = voltage_table_t(1, 1, 3, table, 0.1, 1, soc_init);
+    auto cap = capacity_lithium_ion_t(2.25, soc_init, 100, 0, 1);
 
     // test charging
     double current = 10;
@@ -321,8 +325,9 @@ TEST_F(ResilienceTest_lib_resilience, ChargeVoltageTable){
 }
 
 TEST_F(ResilienceTest_lib_resilience, VoltageVanadium){
-    auto volt = voltage_vanadium_redox_t(1, 1, 1.41, 0.001, 1);
-    auto cap = capacity_lithium_ion_t(11, 30, 100, 0, 1);
+    double SOC_init = 30;
+    auto volt = voltage_vanadium_redox_t(1, 1, 1.41, 0.001, 1, SOC_init);
+    auto cap = capacity_lithium_ion_t(11, SOC_init, 100, 0, 1);
 
     volt.updateVoltage(cap.q0(), cap.qmax(), cap.I(), 33, 1);
     double v = volt.cell_voltage();

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -405,12 +405,12 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_ManualDispatchBatteryModelI
 	grid_and_rate_defaults(data);
 	singleowner_defaults(data);
 
-	ssc_number_t expectedEnergy = 37189640;
+	ssc_number_t expectedEnergy = 37188974;
 	ssc_number_t expectedBatteryChargeEnergy = 1297974;
-	ssc_number_t expectedBatteryDischargeEnergy = 1166766;
+	ssc_number_t expectedBatteryDischargeEnergy = 1166099;
 
 	ssc_number_t peakKwCharge = -1052.0;
-	ssc_number_t peakKwDischarge = 874.7;
+	ssc_number_t peakKwDischarge = 857.2;
 	ssc_number_t peakCycles = 1;
 	ssc_number_t avgCycles = 1;
 

--- a/test/ssc_test/cmod_battery_stateful_test.cpp
+++ b/test/ssc_test/cmod_battery_stateful_test.cpp
@@ -5,6 +5,7 @@
 typedef std::chrono::high_resolution_clock Clock;
 
 TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestStep) {
+    CreateModel(1);
     double last_idx, current, SOC, V, P;
 
     ssc_module_exec(mod, data);
@@ -47,4 +48,50 @@ TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestStep) {
     EXPECT_NEAR(P, 0.457, 1e-2);
     EXPECT_NEAR(V, 457.93, 1e-2);
     EXPECT_NEAR(SOC, 41.79, 1e-2);
+}
+
+TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, SubMinute) {
+    CreateModel(1. / 360);
+    double last_idx, current, SOC, V, P;
+
+    ssc_module_exec(mod, data);
+    ssc_data_get_number(data, "last_idx", &last_idx);
+    ssc_data_get_number(data, "I", &current);
+    ssc_data_get_number(data, "P", &P);
+    ssc_data_get_number(data, "V", &V);
+    ssc_data_get_number(data, "SOC", &SOC);
+    EXPECT_EQ(last_idx, 1);
+    EXPECT_NEAR(current, 1, 1e-2);
+    EXPECT_NEAR(P, 0.477, 0.02);
+    EXPECT_NEAR(V, 492.54, 1e-2);
+    EXPECT_NEAR(SOC, 52.07, 1e-2);
+
+    // make a copy
+    std::string js = ssc_data_to_json(data);
+    auto copy = json_to_ssc_data(js.c_str());
+
+    ssc_module_exec(mod, data);
+    ssc_data_get_number(data, "last_idx", &last_idx);
+    ssc_data_get_number(data, "I", &current);
+    ssc_data_get_number(data, "P", &P);
+    ssc_data_get_number(data, "V", &V);
+    ssc_data_get_number(data, "SOC", &SOC);
+    EXPECT_EQ(last_idx, 2);
+    EXPECT_NEAR(current, 1, 1e-2);
+    EXPECT_NEAR(P, 0.493, 1e-2);
+    EXPECT_NEAR(V, 492.504, 1e-2);
+    EXPECT_NEAR(SOC, 52.05, 1e-2);
+
+    // run the copy, should end up in same place
+    ssc_module_exec(mod, copy);
+    ssc_data_get_number(data, "last_idx", &last_idx);
+    ssc_data_get_number(data, "I", &current);
+    ssc_data_get_number(data, "P", &P);
+    ssc_data_get_number(data, "V", &V);
+    ssc_data_get_number(data, "SOC", &SOC);
+    EXPECT_EQ(last_idx, 2);
+    EXPECT_NEAR(current, 1, 1e-2);
+    EXPECT_NEAR(P, 0.493, 1e-2);
+    EXPECT_NEAR(V, 492.50, 1e-2);
+    EXPECT_NEAR(SOC, 52.05, 1e-2);
 }

--- a/test/ssc_test/cmod_battery_stateful_test.h
+++ b/test/ssc_test/cmod_battery_stateful_test.h
@@ -16,13 +16,14 @@ public:
     double m_error_tolerance_hi = 100;
     double m_error_tolerance_lo = 0.1;
 
-    void SetUp() override {
+    void CreateModel(double dt_hour = 1.) {
         params_str = R"({ "control_mode": 0, "input_current": 1, "chem": 1, "nominal_energy": 10, "nominal_voltage": 500, "qmax_init": 1000.000, "initial_SOC": 50.000, "maximum_SOC": 95.000, "minimum_SOC": 5.000, "dt_hr": 1.000, "leadacid_tn": 0.000, "leadacid_qn": 0.000, "leadacid_q10": 0.000, "leadacid_q20": 0.000, "voltage_choice": 0, "Vnom_default": 3.600, "resistance": 0.000, "Vfull": 4.100, "Vexp": 4.050, "Vnom": 3.400, "Qfull": 2.250, "Qexp": 0.040, "Qnom": 2.000, "C_rate": 0.200, "mass": 507.000, "surface_area": 2.018, "Cp": 1004.000, "h": 20.000, "cap_vs_temp": [ [ -10, 60 ], [ 0, 80 ], [ 25, 1E+2 ], [ 40, 1E+2 ] ], "option": 1, "T_room_init": 20, "cycling_matrix": [ [ 20, 0, 1E+2 ], [ 20, 5E+3, 80 ], [ 20, 1E+4, 60 ], [ 80, 0, 1E+2 ], [ 80, 1E+3, 80 ], [ 80, 2E+3, 60 ] ], "calendar_choice": 1, "calendar_q0": 1.020, "calendar_a": 0.003, "calendar_b": -7280.000, "calendar_c": 930.000, "calendar_matrix": [ [ -3.1E+231 ] ], "loss_choice": 0, "monthly_charge_loss": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], "monthly_discharge_loss": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], "monthly_idle_loss": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], "schedule_loss": [], "replacement_option": 0, "replacement_capacity": 0.000, "replacement_schedule": [], "replacement_schedule_percent": [], "analysis_period": 1, "load_escalation": [0]})";
-
         data = json_to_ssc_data(params_str.c_str());
+        ssc_data_set_number(data, "dt_hr", dt_hour);
         mod = ssc_stateful_module_create("battery_stateful", data);
         EXPECT_TRUE(mod);
     }
+
     void TearDown() override {
         ssc_data_free(data);
         ssc_module_free(mod);

--- a/test/ssc_test/cmod_battwatts_test.cpp
+++ b/test/ssc_test/cmod_battwatts_test.cpp
@@ -117,7 +117,7 @@ TEST_F(CMBattwatts_cmod_battwatts, ResidentialDefaultsLeadAcid) {
 
     auto cycles = data.as_vector_ssc_number_t("batt_cycles");
     ssc_number_t maxCycles = *std::max_element(cycles.begin(), cycles.end());
-    EXPECT_NEAR(maxCycles, 610, 0.1);
+    EXPECT_NEAR(maxCycles, 612, 0.1);
 }
 
 TEST_F(CMBattwatts_cmod_battwatts, NoPV) {

--- a/test/ssc_test/cmod_battwatts_test.cpp
+++ b/test/ssc_test/cmod_battwatts_test.cpp
@@ -117,7 +117,7 @@ TEST_F(CMBattwatts_cmod_battwatts, ResidentialDefaultsLeadAcid) {
 
     auto cycles = data.as_vector_ssc_number_t("batt_cycles");
     ssc_number_t maxCycles = *std::max_element(cycles.begin(), cycles.end());
-    EXPECT_NEAR(maxCycles, 612, 0.1);
+    EXPECT_NEAR(maxCycles, 610, 0.1);
 }
 
 TEST_F(CMBattwatts_cmod_battwatts, NoPV) {


### PR DESCRIPTION
Changes:
 - Remove error for battery timesteps less than a minute
 - Update initial guesses for `calculate_max_discharge_w`, `calculate_max_charge_w` and `calculate_current_for_target_w` for each voltage model when applicable
 - Add new `SubMinute` tests to dynamic voltage model, voltage table and vanadium voltage classes for 1/200 or 1/360 `dt_hr`
 - Modify a test result from `CMBattwatts_cmod_battwatts, ResidentialDefaultsLeadAcid`-- difference is due to change in initial guesses but not sure of the details

close #432 