### PR TITLE
Include <cmath> for fabs()

### DIFF
--- a/test/shared_test/lib_battery_voltage_test.cpp
+++ b/test/shared_test/lib_battery_voltage_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 
 //#include "lib_battery_capacity.h"
 #include "lib_battery.h"


### PR DESCRIPTION
Not sure why this header isn't needed on other platforms. For a C++11 compiler, the standard says `<cmath>` must be included.