### PR TITLE
Subminute thermal model

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -117,14 +117,15 @@ void thermal_t::updateTemperature(double I, size_t lifetimeIndex) {
     }
 
     // the battery temp is the average temp over that step, starting with temp from end of last timestep
-    double source = I * I * params->resistance / (params->surface_area * params->h) + state->T_room;
+    
+    double T_steady_state = I * I * params->resistance / (params->surface_area * params->h) + state->T_room;
     double diffusion = exp(-params->surface_area * params->h * dt_sec / params->mass / params->Cp);
     double coeff_avg = params->mass * params->Cp / params->surface_area / params->h / dt_sec;
-    state->T_batt = (state->T_batt_prev - state->T_room) * coeff_avg * (1 - diffusion) + source;
-    state->heat_dissipated = (state->T_batt - state->T_room) * params->surface_area * params->h;
+    state->T_batt = (state->T_batt_prev - T_steady_state) * coeff_avg * (1 - diffusion) + T_steady_state;
+    state->heat_dissipated = (state->T_batt - state->T_room) * params->surface_area * params->h; // needs m Cp & t
 
     // update temp for use in next timestep
-    state->T_batt_prev = (state->T_batt_prev - state->T_room) * diffusion + source;
+    state->T_batt_prev = (state->T_batt_prev - T_steady_state) * diffusion + T_steady_state;
 
     calc_capacity();
 }

--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -122,7 +122,7 @@ void thermal_t::updateTemperature(double I, size_t lifetimeIndex) {
     double diffusion = exp(-params->surface_area * params->h * dt_sec / params->mass / params->Cp);
     double coeff_avg = params->mass * params->Cp / params->surface_area / params->h / dt_sec;
     state->T_batt = (state->T_batt_prev - T_steady_state) * coeff_avg * (1 - diffusion) + T_steady_state;
-    state->heat_dissipated = (state->T_batt - state->T_room) * params->surface_area * params->h; // needs m Cp & t
+    state->heat_dissipated = (state->T_batt - state->T_room) * params->surface_area * params->h;
 
     // update temp for use in next timestep
     state->T_batt_prev = (state->T_batt_prev - T_steady_state) * diffusion + T_steady_state;

--- a/test/shared_test/lib_battery_test.cpp
+++ b/test/shared_test/lib_battery_test.cpp
@@ -26,12 +26,12 @@ TEST_F(lib_battery_thermal_test, updateTemperatureTest) {
 
     I = 50;
     model->updateTemperature(I, idx++);
-    s = thermal_state({94.02, 17.53, 21.85});
+    s = thermal_state({94.02, 17.51, 21.85});
     compareState(model->get_state(), s, "updateTemperatureTest: 3");
 
     I = 10;
     model->updateTemperature(I, idx++);
-    s = thermal_state({94.88, 18.61, 21.85});
+    s = thermal_state({94.88, 18.58, 21.85});
     compareState(model->get_state(), s, "updateTemperatureTest: 4");
 
     I = 10;
@@ -46,10 +46,97 @@ TEST_F(lib_battery_thermal_test, updateTemperatureTest) {
 
     I = 100;
     model->updateTemperature(I, idx++);
-    s = thermal_state({88.85, 11.06, -3.15});
+    s = thermal_state({88.80, 11.01, -3.15});
     compareState(model->get_state(), s, "updateTemperatureTest: 7");
 }
 
+TEST_F(lib_battery_thermal_test, updateTemperatureTestSubMinute) {
+    CreateModelTenSecondStep(Cp);
+    // battery which adjusts quickly to temp {16.85, 16.85, 21.85, 21.85, 16.85, -3.15, -3.15};
+    double I = 50;
+    size_t idx = 0;
+    double avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    auto s = thermal_state({ 93.49, 16.86, 16.85 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 1";
+
+    I = -50;
+    idx++;
+    avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    s = thermal_state({ 93.49, 16.87, 16.85 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 2";
+
+    I = 50;
+    idx++;
+    avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    s = thermal_state({ 94.02, 17.51, 21.85 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 3";
+
+    I = 10;
+    idx++;
+    avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    s = thermal_state({ 94.88, 18.58, 21.85 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 4";
+
+    I = 10;
+    idx++;
+    avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    s = thermal_state({ 95.00, 18.76, 16.85 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 5";
+
+    I = 10;
+    idx++;
+    avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    s = thermal_state({ 92.55, 15.69, -3.15 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 6";
+
+    I = 100;
+    idx++;
+    avgTemp = 0;
+    for (size_t j = 0; j < 600; j++)
+    {
+        model->updateTemperature(I, idx);
+        avgTemp += model->get_state().T_batt;
+    }
+    avgTemp /= 600.0;
+    s = thermal_state({ 88.85, 11.01, -3.15 });
+    EXPECT_NEAR(avgTemp, s.T_batt, 0.02) << "updateTemperatureTest: 7";
+}
 
 TEST_F(lib_battery_losses_test, MonthlyLossesTest){
     model = std::unique_ptr<losses_t>(new losses_t(chargingLosses, dischargingLosses, chargingLosses));
@@ -131,7 +218,7 @@ TEST_F(lib_battery_test, runTestCycleAt1C){
     }
 //    std::cerr <<  idx << ": soc " << batteryModel->SOC() << ", cap " << capacity_passed << "\n";
     // the SOC isn't at 5 so it means the controller is not able to calculate a current/voltage at which to discharge to 5
-    s = battery_state_test({{54.5, 1000, 960.07, 20.25, 0, 5.67, 7.79, 2}, // cap
+    s = battery_state_test({{54.5, 1000, 960.01, 20.25, 0, 5.67, 7.79, 2}, // cap
                        366.96, // voltage
                        100, {100, 0, 0, 0, 0, 0, 1, std::vector<double>()}, // cycle
                         {101.976, 0, 0.0002}, // calendar
@@ -155,10 +242,10 @@ TEST_F(lib_battery_test, runTestCycleAt1C){
     }
 //    std::cerr <<  idx << ": soc " << batteryModel->SOC() << ", cap " << capacity_passed << "\n";
     // the SOC isn't at 5 so it means the controller is not able to calculate a current/voltage at which to discharge to 5
-    s = battery_state_test({{47.36, 920.55, 883.74, 8.93, 0, 5.35, 6.38, 2}, // cap
-                       354.71, // voltage
-                       93.08, {92.05, 398, 88.94, 89.05, 88.97, 89.65, 5, std::vector<double>()}, // cycle
-                        {98.01, 2754, 0.039}, // calendar
+    s = battery_state_test({{52.13, 921.15, 884.31, 9.04, 0, 5.90, 6.91, 2}, // cap
+                       374.68, // voltage
+                       93.08, {92.11, 395, 88.86, 89.10, 88.93, 89.15, 11, std::vector<double>()}, // cycle
+                        {98.06, 2669, 0.039}, // calendar
                        {96.0, 20.00, 20}, // thermal
                        32991});
     compareState(batteryModel, s, "runTestCycleAt1C: 3");
@@ -176,7 +263,7 @@ TEST_F(lib_battery_test, runTestCycleAt3C){
     capacity_passed += batteryModel->I() * batteryModel->V() / 1000.;
 //    std::cerr << "\n" << idx << ": " << capacity_passed << "\n";
 
-    auto s = battery_state_test({{439.25, 1000, 960.15, 60.75, 0, 45.74, 52.08, 2}, // cap
+    auto s = battery_state_test({{439.25, 1000, 960.02, 60.75, 0, 45.75, 52.08, 2}, // cap
                             548.35, // voltage
                             100, {100, 0, 0, 0, 0, 0, 1, std::vector<double>()}, // cycle
                              {102, 0}, // calendar
@@ -190,11 +277,11 @@ TEST_F(lib_battery_test, runTestCycleAt3C){
     }
 //    std::cerr <<  idx << ": soc " << batteryModel->SOC() << ", cap " << capacity_passed << "\n";
     // the SOC isn't at 5 so it means the controller is not able to calculate a current/voltage at which to discharge to 5
-    s = battery_state_test({{48.03, 1000, 960.47, 26.72, 0, 5.00, 7.78, 2}, // cap
-                       339.03, // voltage
+    s = battery_state_test({{48.01, 1000, 960.11, 26.74, 0, 5.00, 7.78, 2}, // cap
+                       338.91, // voltage
                        101.98, {100, 0, 0, 0, 0, 0, 1, std::vector<double>()}, // cycle
                         {101.98, 0}, // calendar
-                       {96.06, 20.07, 20}, // thermal
+                       {96.01, 20.01, 20}, // thermal
                        0});
     compareState(batteryModel, s, "runTest: 2");
 
@@ -214,16 +301,16 @@ TEST_F(lib_battery_test, runTestCycleAt3C){
     }
 //    std::cerr <<  idx << ": soc " << batteryModel->SOC() << ", cap " << capacity_passed << "\n";
     // the SOC isn't at 5 so it means the controller is not able to calculate a current/voltage at which to discharge to 5
-    s = battery_state_test({{48.84, 920.77, 883.95, 9.00, 0, 5.52, 6.55, 2}, // cap
-                       361.33, // voltage
-                       93.08, {92.07, 397, 88.62, 88.80, 88.65, 89.48, 7, std::vector<double>()}, // cycle
-                        {98.06, 2655, 0.0393}, // calendar
+    s = battery_state_test({{46.21, 920.97, 884.13, 8.97, 0, 5.23, 6.24, 2}, // cap
+                       349.15, // voltage
+                       93.08, {92.10, 396, 89.27, 89.19, 89.32, 89.80, 9, std::vector<double>()}, // cycle
+                        {98.11, 2609, 0.0393}, // calendar
                        {96.01, 20, 20}, // thermal
                        32991});
     compareState(batteryModel, s, "runTest: 3");
 
 
-    EXPECT_NEAR(capacity_passed, 352421, 100) << "Current passing through cell";
+    EXPECT_NEAR(capacity_passed, 353517, 100) << "Current passing through cell";
     double qmax = fmax(s.capacity.qmax_lifetime, s.capacity.qmax_thermal);
     EXPECT_NEAR(qmax/q, 0.9209, 0.01) << "capacity relative to max capacity";
 }
@@ -329,17 +416,17 @@ TEST_F(lib_battery_test, RoundtripEffModel){
         current += fabs(max_current) / 100.;
         eff_vs_current.emplace_back(fabs(output_power/input_power));
     }
-    std::vector<double> eff_expected = {0.99, 0.99, 0.98, 0.98, 0.97, 0.97, 0.96, 0.97, 0.95, 0.95, 0.94, 0.95, 0.93,
-                                        0.91, 0.93, 0.93, 0.92, 0.90, 0.93, 0.89, 0.92, 0.88, 0.91, 0.91, 0.87, 0.89,
-                                        0.90, 0.84, 0.87, 0.88, 0.89, 0.88, 0.82, 0.85, 0.86, 0.87, 0.88, 0.88, 0.82,
-                                        0.79, 0.81, 0.82, 0.84, 0.85, 0.86, 0.87, 0.87, 0.84, 0.73, 0.75, 0.75, 0.77,
-                                        0.78, 0.79, 0.80, 0.81, 0.82, 0.83, 0.84, 0.85, 0.85, 0.85, 0.83, 0.80, 0.71,
-                                        0.65, 0.67, 0.67, 0.68, 0.69, 0.69, 0.70, 0.71, 0.72, 0.73, 0.74, 0.75, 0.75,
-                                        0.76, 0.77, 0.78, 0.78, 0.79, 0.80, 0.80, 0.81, 0.81, 0.81, 0.82, 0.82, 0.81,
-                                        0.81, 0.80, 0.79, 0.76, 0.72, 0.65, 0.49, 0.49,
+    std::vector<double> eff_expected = {0.99, 0.99, 0.98, 0.98, 0.97, 0.97, 0.96, 0.97, 0.95, 0.95, 0.94, 0.95, 0.93, // i = 12
+                                        0.91, 0.93, 0.93, 0.92, 0.92, 0.90, 0.93, 0.88, 0.92, 0.90, 0.88, 0.91, 0.89, // i = 25
+                                        0.88, 0.90, 0.90, 0.84, 0.87, 0.88, 0.89, 0.89, 0.81, 0.85, 0.85, 0.86, 0.88, // i = 38
+                                        0.88, 0.87, 0.78, 0.81, 0.81, 0.83, 0.84, 0.85, 0.86, 0.87, 0.87, 0.85, 0.79, // i = 51
+                                        0.73, 0.75, 0.76, 0.77, 0.78, 0.79, 0.80, 0.81, 0.82, 0.83, 0.84, 0.85, 0.85, // i = 64
+                                        0.84, 0.84, 0.82, 0.76, 0.65, 0.66, 0.66, 0.67, 0.68, 0.69, 0.70, 0.70, 0.71, // i = 77
+                                        0.72, 0.73, 0.74, 0.74, 0.75, 0.76, 0.77, 0.77, 0.78, 0.78, 0.79, 0.80, 0.81, // i = 90
+                                        0.81, 0.81, 0.81, 0.81, 0.82, 0.82, 0.81, 0.81, // i = 98
     };
     for (size_t i = 0; i < eff_expected.size(); i++)
-        EXPECT_NEAR(eff_vs_current[i], eff_expected[i], .01);
+        EXPECT_NEAR(eff_vs_current[i], eff_expected[i], .01) << " i = " << i;
 }
 
 TEST_F(lib_battery_test, RoundtripEffTable){

--- a/test/shared_test/lib_battery_test.h
+++ b/test/shared_test/lib_battery_test.h
@@ -69,6 +69,10 @@ public:
     void CreateModel(double Cp){
         model = std::unique_ptr<thermal_t>(new thermal_t(dt_hour, mass, surface_area, batt_R, Cp, h, capacityVsTemperature, T_room));
     }
+    void CreateModelTenSecondStep(double Cp) {
+        dt_hour = 1.0 / 600.0;
+        model = std::unique_ptr<thermal_t>(new thermal_t(dt_hour, mass, surface_area, batt_R, Cp, h, capacityVsTemperature, T_room));
+    }
 };
 
 class lib_battery_losses_test : public ::testing::Test


### PR DESCRIPTION
The previous version of the thermal model could be numerically unstable at small timesteps and large currents, due to the current term not having an exponential to smooth it. This update includes the current term in the exponential, such that the battery will approach the same steady state temperature at large and small timesteps.

Old behavior, 10 second timesteps:

![batt_stateful_old_thermal_temp](https://user-images.githubusercontent.com/5530592/87986183-fce69b80-ca99-11ea-8bb8-ff6a186cb0a1.png)

New behavior:

![image](https://user-images.githubusercontent.com/5530592/87986212-0bcd4e00-ca9a-11ea-9969-134a602c6837.png)

Reference for converging to steady state temperature: https://web.mit.edu/16.unified/www/FALL/thermodynamics/notes/node129.html (the convection constants are different, but the underlying differential equations are the same)
