### PR TITLE
SAM 358: add exception for time series and net metering

### DIFF
--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -740,6 +740,11 @@ public:
 		bool two_meter = (metering_option == 4 );
 		bool timestep_reconciliation = (metering_option == 2 || metering_option == 3 || metering_option == 4);
 
+		bool time_series_rates = as_boolean("ur_en_ts_sell_rate") || as_boolean("ur_en_ts_buy_rate");
+		if (time_series_rates && !timestep_reconciliation)
+		{
+			throw exec_error("utilityrate5", "Time series rates are not compatible with net metering. Please disable time series rates or change to net billing / buy all - sell all");
+		}
 
 		idx = 0;
 		for (i=0;i<nyears;i++)


### PR DESCRIPTION
As discussed in https://github.com/NREL/SAM/issues/358, time series buy and sell rates don't run when net metering is chosen as a metering/billing option. Add an exception in case a user tries to enable both in PySAM/the SDK. 

To trigger this exception with the GUI:
* Build this branch with patch
* Switch to net billing and enable time series rates
* Switch back to net metering
* Run the simulation

This exception will not be encountered from the GUI when the parallel SAM PR is complete.