### PR TITLE
Throw exception if weatherfile goes backwards in time

### DIFF
--- a/shared/lib_weatherfile.cpp
+++ b/shared/lib_weatherfile.cpp
@@ -1059,6 +1059,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 	// from 1-24 standard to 0-23
 	int tmy3_hour_shift = 1;
 	int n_leap_data_removed = 0;
+    bool subtract_hour = false;
 
 	for (int i = 0; i < (int)m_nRecords; i++)
 	{
@@ -1338,7 +1339,7 @@ bool weatherfile::open(const std::string &file, bool header_only)
 		}
 		else if (m_type == WFCSV)
 		{
-
+            
 			for (;;)
 			{
 				getline(ifs, buf);
@@ -1376,6 +1377,11 @@ bool weatherfile::open(const std::string &file, bool header_only)
 					continue;
 				}
 
+                if (m_columns[HOUR].data[i] > 23)
+                {
+                    subtract_hour = true;
+                }
+
 				if (m_columns[MINUTE].data[i] > 59)
 				{
 					m_message = "minute column must contain integers from 0-59";
@@ -1385,16 +1391,18 @@ bool weatherfile::open(const std::string &file, bool header_only)
 				else
 					break;
 			}
-
-
 		}
 
-        int hour_of_year = util::hour_of_year(m_columns[MONTH].data[i], m_columns[DAY].data[i], m_columns[HOUR].data[i]);
-        if (!check_hour_of_year(hour_of_year, i))
-        {
-            return false;
-        }
 	}
+
+    // Currently only used by WFCSV
+    if (subtract_hour)
+    {
+        for (size_t i = 0; i < m_nRecords; i++)
+        {
+            m_columns[HOUR].data[i] = ((float)m_columns[HOUR].data[i]) - 1;
+        }
+    }
 
 	//	if( n_leap_data_removed > 0 )
 	//		m_message = util::format("Skipped %d data lines for February 29th (leap day).", n_leap_data_removed );
@@ -1503,6 +1511,16 @@ bool weatherfile::open(const std::string &file, bool header_only)
 			return false;
 		}
 	}
+
+    // Need to check hours after adjustments like 1 - 24 to 0 - 23 for some file types above
+    for (size_t i = 0; i < m_nRecords; i++)
+    {
+        int hour_of_year = util::hour_of_year(m_columns[MONTH].data[i], m_columns[DAY].data[i], m_columns[HOUR].data[i]);
+        if (!check_hour_of_year(hour_of_year, i))
+        {
+            return false;
+        }
+    }
 
 	return true;
 }

--- a/shared/lib_weatherfile.cpp
+++ b/shared/lib_weatherfile.cpp
@@ -412,7 +412,7 @@ void weather_record::reset()
 bool weather_data_provider::check_hour_of_year(int hour, int line) {
     if (hour < m_hour_of_year) {
         std::ostringstream ss;
-        ss << "Hour " << hour << " occurs after " << m_hour_of_year << " on line " << line << " of weatherfile. If this is an interpolated subhourly file, please re-interpolate from hourly with the updated macro.";
+        ss << "Hour " << hour << " occurs after " << m_hour_of_year << " on line " << line << " of weather file. If this is subhourly data that was interpolated from hourly using the SAM Solar Resource Interpolation macro in SAM 2020.2.29 r3 or earlier, please run the macro again to correct the interpolation.";
         m_message = ss.str();
         return false;
     }

--- a/shared/lib_weatherfile.cpp
+++ b/shared/lib_weatherfile.cpp
@@ -409,7 +409,18 @@ void weather_record::reset()
 	tdry = twet = tdew = rhum = pres = snow = alb =  aod = std::numeric_limits<double>::quiet_NaN();
 }
 
-
+bool weather_data_provider::check_hour_of_year(int hour, int line) {
+    if (hour < m_hour_of_year) {
+        std::ostringstream ss;
+        ss << "Hour " << hour << " occurs after " << m_hour_of_year << " on line " << line << " of weatherfile. If this is an interpolated subhourly file, please re-interpolate from hourly with the updated macro.";
+        m_message = ss.str();
+        return false;
+    }
+    else {
+        m_hour_of_year = hour;
+        return true;
+    }
+}
 
 #define NBUF 2048
 
@@ -1378,6 +1389,11 @@ bool weatherfile::open(const std::string &file, bool header_only)
 
 		}
 
+        int hour_of_year = util::hour_of_year(m_columns[MONTH].data[i], m_columns[DAY].data[i], m_columns[HOUR].data[i]);
+        if (!check_hour_of_year(hour_of_year, i))
+        {
+            return false;
+        }
 	}
 
 	//	if( n_leap_data_removed > 0 )

--- a/shared/lib_weatherfile.h
+++ b/shared/lib_weatherfile.h
@@ -140,7 +140,8 @@ public:
 protected:
 	bool m_ok;
 	bool m_msg;
-	int m_startYear;
+    int m_startYear;
+    int m_hour_of_year = -1; // For error checking
 	double m_time;
 	// error messages
 	std::string m_message;
@@ -188,6 +189,8 @@ public:
 	double lon() { return header().lon; }
 	double tz() { return header().tz; }
 	double elev() { return header().elev; }
+
+    bool check_hour_of_year(int hour, int line);
 
 	// virtual functions specific to weather data source
 	/// check if the data is available from weather file


### PR DESCRIPTION
Throw an exception for any weatherfile subject to issue https://github.com/NREL/ssc/issues/447

The exception occurs when running a simulation with an old interpolated weather file for all relevant cases, and if https://github.com/NREL/SAM/pull/364 is checked out, it will appear when selecting interpolated weather file on the battery modules.

To test:
- Check out and build SAM on this branch
- Select an interpolated weather file from 2020.2.29 r3 (or develop prior to today) and try to run it
- An exception should be raised about hour 0 occurring after hour 23 (or similar)

Weather files interpolated with the code on https://github.com/NREL/SAM/pull/364 should not trigger the exception.