### PR TITLE
add code to resize temperature array from length 1 to length nrec

### DIFF
--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -569,6 +569,12 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
             batt_vars->batt_h_to_ambient = vt.as_double("batt_h_to_ambient");
             batt_vars->T_room = vt.as_vector_double("batt_room_temperature_celsius");
 
+            // If only one variable was specified, use a fixed ambient temperature
+            if (batt_vars->T_room.size() == 1) {
+                double T_ambient = batt_vars->T_room[0];
+                batt_vars->T_room = std::vector<double>(T_ambient, nrec);
+            }
+
             // Inverter settings
             batt_vars->inverter_model = vt.as_integer("inverter_model");
             if (batt_vars->inverter_model < 4) //user has assigned an actual inverter model


### PR DESCRIPTION
Add code to cmod_battery to take a battery temperature array from length 1 and resize it to length nrec.

Note that this will not solve https://github.com/NREL/ssc/issues/472 by itself, since the UI is still providing an array of length nrec. See https://github.com/NREL/SAM/pull/418 for details. I'm open to changing things on the SAM side if desired, but figured this code would simplify PySAM inputs.