### PR TITLE
Battery Calendar Model set to None results in Cap % > 100

### DIFF
--- a/shared/lib_battery_lifetime.cpp
+++ b/shared/lib_battery_lifetime.cpp
@@ -418,6 +418,8 @@ double lifetime_calendar_t::runLifetimeCalendarModel(size_t lifetimeIndex, doubl
         runLithiumIonModel(T, SOC);
     else if (params->calendar_choice == lifetime_params::CALENDAR_CHOICE::TABLE)
         runTableModel();
+    else
+        state->q_relative_calendar = 100;
 
     return state->q_relative_calendar;
 }


### PR DESCRIPTION
-Add initialization for relative capacity when Calendar setting is set to None
-Closes #478 
