### PR TITLE
CMake Options Prepend with "SAM"

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -14,9 +14,9 @@ extraction:
     configure:
       command:
         - mkdir ${GTEST}/build; cd ${GTEST}/build; cmake -DCMAKE_CXX_FLAGS=-std=c++11 ..;
-        - mkdir ${SSCDIR}/build; cd ${SSCDIR}/build; cmake .. -DCMAKE_BUILD_TYPE=Release -Dskip_tools=1
+        - mkdir ${SSCDIR}/build; cd ${SSCDIR}/build; cmake .. -DCMAKE_BUILD_TYPE=Release -DSAM_SKIP_TOOLS=1
     before_index:
       - cd ${GTEST}/build; make;
-    index:    
+    index:
       build_command:
         - cd ${SSCDIR}/build; make -j4

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ script:
  # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -j4 -C $WEXDIR/build_linux; fi
  # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -j4 -C $SSCDIR/build_linux; fi
   - mkdir ${SSCDIR}/build && cd ${SSCDIR}/build
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake .. -DCMAKE_BUILD_TYPE=Release -Dskip_tools=1  && make; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake .. -DCMAKE_BUILD_TYPE=Release -Dskip_tools=1  && make; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake .. -DCMAKE_BUILD_TYPE=Release -DSAM_SKIP_TOOLS=1  && make; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake .. -DCMAKE_BUILD_TYPE=Release -DSAM_SKIP_TOOLS=1  && make; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test/Test; fi
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,14 @@ if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif()
 
-option(skip_tools "Skips the sdktool and tcsconsole builds" OFF)
+option(SAM_SKIP_TOOLS "Skips the sdktool and tcsconsole builds" OFF)
 
-option(SAMAPI_EXPORT "For Unix, compile ssc libraries for SAM_api" OFF)
+option(SAM_SKIP_TESTS "Skips building tests" OFF)
 
-option(skip_api "Skips the export of ssc binaries to the SAM_api directory" OFF)
-
-option(skip_tests "Skips building tests" OFF)
+option(SAMAPI_EXPORT "Export of ssc binaries to the SAM_api directory; for Unix, compile ssc libraries for SAM_api" ON)
 
 #
-# If project isn't system_advisor_model and skip_tools=1,
+# If project isn't system_advisor_model and SAM_SKIP_TOOLS=1,
 #   environment vars LK_LIB and LKD_LIB can be used to specify where to find those libraries
 #
 
@@ -157,11 +155,11 @@ add_subdirectory(solarpilot)
 add_subdirectory(tcs)
 add_subdirectory(ssc)
 
-if (NOT skip_tools)
+if (NOT SAM_SKIP_TOOLS)
 	add_subdirectory(sdktool)
 	add_subdirectory(tcsconsole)
 endif()
 
-if (NOT skip_tests)
+if (NOT SAM_SKIP_TESTS)
 	add_subdirectory(test)
 endif()

--- a/ssc/CMakeLists.txt
+++ b/ssc/CMakeLists.txt
@@ -282,7 +282,7 @@ if (MSVC)
 			)
 	endif()
 
-	if (NOT skip_api)
+	if (SAMAPI_EXPORT)
 		if (${CMAKE_PROJECT_NAME} STREQUAL system_advisor_model)
 			set(APIGENDIR ${CMAKE_CURRENT_BINARY_DIR}/../../sam/api/api_autogen/$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>)
 			add_custom_command(


### PR DESCRIPTION
CMake option names should be prepended to avoid potential name collisions when SAM source code is included in other projects.