### PR TITLE
Price signals dispatch feedback

### DIFF
--- a/shared/lib_battery_dispatch.h
+++ b/shared/lib_battery_dispatch.h
@@ -110,6 +110,7 @@ public:
 	virtual double power_grid_target(){	return 0;}
 	virtual double power_batt_target(){ return 0.;}
 	virtual double cost_to_cycle() { return 0.;}
+    virtual double cost_to_cycle_per_kwh() { return 0.; }
 
 	// control settings
 	double battery_power_to_fill();
@@ -283,6 +284,9 @@ public:
 	/// Return the battery power target set by the controller
 	double power_batt_target();
 
+    /*! Return the calculated cost to cycle ($/cycle-kWh for all dispatch)*/
+    double cost_to_cycle_per_kwh() { return cost_to_cycle(); }
+
 protected:
 
 	/*! Initialize with a pointer*/
@@ -291,7 +295,7 @@ protected:
 	/*! Return the dispatch mode */
 	int get_mode();
 
-    /*! Return the calculated cost to cycle ($/cycle for behind the meter, $/cycle-kWh for front of the meter)*/
+    /*! Return the calculated cost to cycle ($/cycle for behind the meter, $/cycle-kWh for front of the meter) - used internally*/
     double cost_to_cycle() { return m_cycleCost; }
 
 	/*! Full time-series of PV production [kW] */

--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -707,7 +707,6 @@ void dispatch_automatic_behind_the_meter_t::plan_dispatch_for_cost(dispatch_plan
             }
             else if (m_batteryPower->canSystemCharge)
             {
-                bool systemCharge = false;
                 // Powerflow considerations are different between AC and DC connected batteries for system charging
                 if (m_batteryPower->connectionMode == m_batteryPower->AC_CONNECTED) {
                     // AC connected assumes PV goes to load first. Need net generation in this case
@@ -716,7 +715,7 @@ void dispatch_automatic_behind_the_meter_t::plan_dispatch_for_cost(dispatch_plan
                     }
                 }
                 else {
-                    // DC connected can charge the battery before sending energy to load
+                    // DC connected can charge the battery before sending power to load
                     if (idx + index < _P_pv_ac.size() && _P_pv_ac[idx + index] > 0) {
                         requiredPower = -_P_pv_ac[idx + index];
                     }
@@ -863,4 +862,9 @@ void dispatch_automatic_behind_the_meter_t::costToCycle()
     {
         m_cycleCost = cycle_costs_by_year[curr_year] * _Battery->get_params().nominal_energy;
     }
+}
+
+double dispatch_automatic_behind_the_meter_t::cost_to_cycle_per_kwh()
+{
+    return m_cycleCost / _Battery->get_params().nominal_energy;
 }

--- a/shared/lib_battery_dispatch_automatic_btm.h
+++ b/shared/lib_battery_dispatch_automatic_btm.h
@@ -107,6 +107,9 @@ public:
 	/*! Grid target power */
 	double power_grid_target() override;
 
+    /*! Return the calculated cost to cycle for battery outputs */
+    double cost_to_cycle_per_kwh();
+
 	enum BTM_TARGET_MODES {TARGET_SINGLE_MONTHLY, TARGET_TIME_SERIES};
 
 protected:

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -212,7 +212,7 @@ var_info vtab_battery_outputs[] = {
         { SSC_OUTPUT,        SSC_ARRAY,      "batt_system_loss",                           "Electricity loss from battery ancillary equipment (kW DC for DC connected, AC for AC connected)",     "kW",      "",                       "Battery",       "",                           "",                              "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "grid_power_target",                          "Electricity grid power target for automated dispatch","kW","",                               "Battery",       "",                           "",                              "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "batt_power_target",                          "Electricity battery power target for automated dispatch","kW","",                            "Battery",       "",                           "",                              "" },
-        { SSC_OUTPUT,        SSC_ARRAY,      "batt_cost_to_cycle",                         "Battery computed cycle degradation penalty",            "$/cycle-kWh FOM, $/cycle BTM", "",                       "Battery",       "",                           "",                              "" },
+        { SSC_OUTPUT,        SSC_ARRAY,      "batt_cost_to_cycle",                         "Battery computed cycle degradation penalty",            "$/cycle-kWh", "",                       "Battery",       "",                           "",                              "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "market_sell_rate_series_yr1",                "Market sell rate (Year 1)",                             "$/MWh", "",                         "Battery",       "",                           "",                              "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "batt_revenue_gridcharge",					   "Revenue to charge from grid",                           "$/kWh", "",                         "Battery",       "",                           "",                              "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "batt_revenue_charge",                        "Revenue to charge from system",                         "$/kWh", "",                         "Battery",       "",                           "",                              "" },
@@ -1450,7 +1450,7 @@ void battstor::outputs_topology_dependent()
     bool cycleCostRelevant = (batt_vars->batt_meter_position == dispatch_t::BEHIND && batt_vars->batt_dispatch == dispatch_t::FORECAST) ||
         (batt_vars->batt_meter_position == dispatch_t::FRONT && (batt_vars->batt_dispatch != dispatch_t::FOM_MANUAL && batt_vars->batt_dispatch != dispatch_t::FOM_CUSTOM_DISPATCH));
     if (cycleCostRelevant && batt_vars->batt_cycle_cost_choice == dispatch_t::MODEL_CYCLE_COST) {
-        outCostToCycle[index] = (ssc_number_t)(dispatch_model->cost_to_cycle());
+        outCostToCycle[index] = (ssc_number_t)(dispatch_model->cost_to_cycle_per_kwh());
     }
 }
 

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -776,7 +776,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialDCBatteryModelPriceS
     ssc_number_t expectedBatteryChargeEnergy = 390.9;
     ssc_number_t expectedBatteryDischargeEnergy = 360.2;
 
-    ssc_number_t peakKwCharge = -3.537;
+    ssc_number_t peakKwCharge = -3.914;
     ssc_number_t peakKwDischarge = 1.99;
     ssc_number_t peakCycles = 2;
     ssc_number_t avgCycles = 0.4136;


### PR DESCRIPTION
Two tweaks to the price signals dispatch code based on feedback from our beta testers:

- Update the dispatch planner to better match the powerflow calculations. This allows DC connected systems to charge from PV even if the load is greater than generation at that timestep
- Return the cycle degradation cost in $/cycle-kWh such that the output and input have the same units.