### PR TITLE
Fix time series buy rates

### DIFF
--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -292,8 +292,6 @@ void rate_setup::setup(var_table* vt, int num_recs_yearly, int nyears, rate_data
         }
         else
         { // hourly or sub hourly loads for single year
-            size_t cnt;
-            ssc_number_t* ts_br;
             ts_br = vt->as_array("ur_ts_buy_rate", &cnt);
             size_t ts_step_per_hour = cnt / 8760;
             if (ts_step_per_hour < 1 || ts_step_per_hour > 60 || ts_step_per_hour * 8760 != cnt)


### PR DESCRIPTION
The if statement for time series buy rates re-initialized the variables cnt and ts_br, such that the values read out of the vartable never make it to the setup_rate_data function. Thus, the length of rate.m_ec_ts_buy_rate was always 0, and the flat rates were used instead.

Can be tested with the SAM file attached to https://github.com/NREL/SAM/issues/494, closes https://github.com/NREL/SAM/issues/494