### PR TITLE
Price signals dispatch improved demand

### DIFF
--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -634,14 +634,23 @@ void dispatch_automatic_behind_the_meter_t::plan_dispatch_for_cost(dispatch_plan
             index = sorted_grid[i].Hour() * _steps_per_hour + sorted_grid[i].Step(); // Assumes we're always running this function on the hour
             plan.plannedDispatch[index] = desiredPower;
 
+            if (powerAtMaxCost == 0) {
+                powerAtMaxCost = desiredPower;
+            }
+        }
+    }
+
+    for (i = 0; i < _steps_per_hour && (i < sorted_grid.size()); i++)
+    {
+        if (sorted_grid[i].Cost() > 0)
+        {
             if (sorted_grid[i].MarginalCost() < plan.lowestMarginalCost)
             {
                 plan.lowestMarginalCost = sorted_grid[i].MarginalCost();
             }
-
-            if (powerAtMaxCost == 0) {
-                powerAtMaxCost = desiredPower;
-            }
+        }
+        else {
+            break;
         }
     }
 

--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -140,21 +140,21 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
     {
         // Process load and pv forecasts to get _monthly_ expected gen, load, and peak
         // Do we need new member variables, or can these just be passed off to UtilityRateForecast?
-        std::vector<double> monthly_peaks;
+        std::vector<double> monthly_gross_load;
         std::vector<double> monthly_gen;
-        std::vector<double> monthly_load;
+        std::vector<double> monthly_net_load;
 
         // Load here is every step for the full analysis period. Load escalation has already been applied (TODO in compute modules)
         size_t num_recs = util::hours_per_year * _steps_per_hour * _nyears;
         size_t step = 0; size_t hour_of_year = 0;
         int curr_month = 1;
-        double load_during_month = 0.0; double gen_during_month = 0.0; double peak_during_month = 0.0;
+        double load_during_month = 0.0; double gen_during_month = 0.0; double gross_load_during_month = 0.0;
         size_t array_size = std::min(_P_pv_ac.size(), _P_load_ac.size()); // Cover smaller arrays to make testing easier
         for (size_t idx = 0; idx < num_recs && idx < array_size; idx++)
         {
             double grid_power = _P_pv_ac[idx] - _P_load_ac[idx];
 
-            peak_during_month += _P_load_ac[idx] * _dt_hour;
+            gross_load_during_month += _P_load_ac[idx] * _dt_hour;
             
 
             if (grid_power < 0)
@@ -179,16 +179,16 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
             {
                 // Push back vectors
                 // Note: this is a net-billing approach. To be accurate for net metering, we'd have to invoke tou periods here, this overestimates costs for NM
-                monthly_peaks.push_back(peak_during_month / util::hours_in_month(curr_month));
-                monthly_load.push_back(-1.0 * load_during_month);
+                monthly_gross_load.push_back(gross_load_during_month / util::hours_in_month(curr_month));
+                monthly_net_load.push_back(-1.0 * load_during_month);
                 monthly_gen.push_back(gen_during_month);
 
-                peak_during_month = 0.0; load_during_month = 0.0; gen_during_month = 0.0;
+                gross_load_during_month = 0.0; load_during_month = 0.0; gen_during_month = 0.0;
                 curr_month < 12 ? curr_month++ : curr_month = 1;
             }
         }
 
-        rate_forecast = std::shared_ptr<UtilityRateForecast>(new UtilityRateForecast(rate.get(), _steps_per_hour, monthly_load, monthly_gen, monthly_peaks, _nyears));
+        rate_forecast = std::shared_ptr<UtilityRateForecast>(new UtilityRateForecast(rate.get(), _steps_per_hour, monthly_net_load, monthly_gen, monthly_gross_load, _nyears));
         rate_forecast->initializeMonth(0, 0);
         rate_forecast->copyTOUForecast();
     }

--- a/shared/lib_utility_rate.cpp
+++ b/shared/lib_utility_rate.cpp
@@ -130,7 +130,7 @@ size_t UtilityRateCalculator::getEnergyPeriod(size_t hourOfYear)
 	return period;
 }
 
-UtilityRateForecast::UtilityRateForecast(rate_data* util_rate, size_t stepsPerHour, const std::vector<double>& monthly_load_forecast, const std::vector<double>& monthly_gen_forecast, const std::vector<double>& monthly_peak_forecast, size_t analysis_period) :
+UtilityRateForecast::UtilityRateForecast(rate_data* util_rate, size_t stepsPerHour, const std::vector<double>& monthly_load_forecast, const std::vector<double>& monthly_gen_forecast, const std::vector<double>& monthly_avg_load_forecast, size_t analysis_period) :
     current_composite_buy_rates(),
     current_composite_sell_rates(),
     next_composite_buy_rates(),
@@ -143,7 +143,7 @@ UtilityRateForecast::UtilityRateForecast(rate_data* util_rate, size_t stepsPerHo
 	rate = std::shared_ptr<rate_data>(new rate_data(*util_rate));
 	m_monthly_load_forecast = monthly_load_forecast;
 	m_monthly_gen_forecast = monthly_gen_forecast;
-	m_monthly_peak_forecast = monthly_peak_forecast;
+	m_monthly_avg_load_forecast = monthly_avg_load_forecast;
     nyears = analysis_period;
 }
 
@@ -153,7 +153,7 @@ UtilityRateForecast::UtilityRateForecast(UtilityRateForecast& tmp) :
 	last_step(tmp.last_step),
 	m_monthly_load_forecast(tmp.m_monthly_load_forecast),
 	m_monthly_gen_forecast(tmp.m_monthly_gen_forecast),
-	m_monthly_peak_forecast(tmp.m_monthly_peak_forecast),
+	m_monthly_avg_load_forecast(tmp.m_monthly_avg_load_forecast),
     current_composite_buy_rates(tmp.current_composite_buy_rates),
     current_composite_sell_rates(tmp.current_composite_sell_rates),
     next_composite_buy_rates(tmp.next_composite_buy_rates),
@@ -382,7 +382,7 @@ void UtilityRateForecast::initializeMonth(int month, size_t year)
 		rate->init_dc_peak_vectors(month);
 		compute_next_composite_tou(month, year);
 
-		double avg_load = m_monthly_peak_forecast[year * 12 + month];
+		double avg_load = m_monthly_avg_load_forecast[year * 12 + month];
 
 		ur_month& curr_month = rate->m_month[month];
 		curr_month.dc_flat_peak = avg_load;

--- a/shared/lib_utility_rate.cpp
+++ b/shared/lib_utility_rate.cpp
@@ -382,6 +382,7 @@ void UtilityRateForecast::initializeMonth(int month, size_t year)
 		rate->init_dc_peak_vectors(month);
 		compute_next_composite_tou(month, year);
 
+        // Ignore any peak charges lower than the average gross load - this prevents the price signal from showing demand charges on the first hour of each month when the load is not really a peak
 		double avg_load = m_monthly_avg_load_forecast[year * 12 + month];
 
 		ur_month& curr_month = rate->m_month[month];

--- a/shared/lib_utility_rate.h
+++ b/shared/lib_utility_rate.h
@@ -156,9 +156,12 @@ protected:
     int last_month_init;
     size_t nyears;
 
+    // Load: total net energy from the grid over the month
 	std::vector<double> m_monthly_load_forecast; // Length is 12 * analysis period
+    // gen: total net energy to the grid (generation) over the month
 	std::vector<double> m_monthly_gen_forecast; // Length is 12 * analysis period
-	std::vector<double> m_monthly_peak_forecast; // Length is 12 * analysis period
+    // Avg load: the average gross load (no gen) over the month. Used to establish a floor for peak shaving costs
+	std::vector<double> m_monthly_avg_load_forecast; // Length is 12 * analysis period
 
 
 };

--- a/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
@@ -511,8 +511,8 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, TestCommercialPeakForecasting) {
     batteryPower = dispatchAutoBTM->getBatteryPower();
     batteryPower->connectionMode = ChargeController::AC_CONNECTED;
 
-    std::vector<double> expectedPower = { 50.02, 44.22, 44.00, 0, -46.0, 0, 0, 50.08, 41.45, 0, 0, -46.0, -46.0, 0, 0, 50.08, 38.49, 0, 0,
-                                         0, 0, -46.0, -42.58, -46.0 };
+    std::vector<double> expectedPower = { 50.02, 44.22, 44.0, 45.24, 1.34, 0, 0, 0, 0, 0.0, 0, -46.0, -46.0, -45.39, -30.26, 50.08, 50.06, 50.15, 13.25,
+                                         0, 0, -46.0, -46.0, -46.0 };
     for (size_t h = 0; h < 24; h++) {
         batteryPower->powerSystem = pv_prediction[h]; // Match the predicted PV
         batteryPower->powerLoad = load_prediction[h]; // Match the predicted load

--- a/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
@@ -465,7 +465,7 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, TestSummerPeakGridChargingSubhourly) {
     batteryPower = dispatchAutoBTM->getBatteryPower();
     batteryPower->connectionMode = ChargeController::AC_CONNECTED;
 
-    std::vector<double> expectedPower = { -0.648, -0.813, -0.912, -0.984, -0.949, -0.695, -0.523, -0.124, -0.723,  -1.093, -1.874, -2.092, -2.092, -1.872, -1.598, -1.21,  1.564, 2.3757, 3.3688,
+    std::vector<double> expectedPower = { -0.648, -0.813, -0.912, -0.984, -0.949, -0.695, -0.523, -0.124, -0.723,  -1.093, -1.874, -2.092, -2.092, -1.872, -1.598, 0.885,  1.564, 2.3757, 3.3688,
                                          4.122, 0.0, 0.0, 0.0, -0.317 };
     for (size_t h = 0; h < 24; h++) {
         batteryPower->powerSystem = pv_prediction[h]; // Match the predicted PV

--- a/test/shared_test/lib_utility_rate_test.cpp
+++ b/test/shared_test/lib_utility_rate_test.cpp
@@ -24,8 +24,8 @@ TEST(lib_utility_rate_test, test_copy)
 	int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 25, 25, 25, 25, 25, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, };
-    std::vector<double> monthly_peak_forecast = { 25, 25, 25, 25, 25, 25 };
-	UtilityRateForecast rate_forecast_1(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    std::vector<double> monthly_avg_gross_load = { 25, 25, 25, 25, 25, 25 };
+	UtilityRateForecast rate_forecast_1(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     UtilityRateForecast rate_forecast_2(rate_forecast_1);
 
@@ -72,10 +72,10 @@ TEST(lib_utility_rate_test, test_tiered_tou_cost_estimates)
 	monthly_load_forecast.push_back(25); // Rates above are kWh/day, but don't want to test that just yet
 	std::vector<double> monthly_gen_forecast;
 	monthly_gen_forecast.push_back(0);
-	std::vector<double> monthly_peak_forecast;
-	monthly_peak_forecast.push_back(7);
+	std::vector<double> monthly_avg_gross_load;
+	monthly_avg_gross_load.push_back(7);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
 	rate_forecast.compute_next_composite_tou(0, 0);
 
@@ -117,10 +117,10 @@ TEST(lib_utility_rate_test, test_tiered_sell_rates)
 	monthly_load_forecast.push_back(0); // Rates above are kWh/day, but don't want to test that just yet
 	std::vector<double> monthly_gen_forecast;
 	monthly_gen_forecast.push_back(10);
-	std::vector<double> monthly_peak_forecast;
-	monthly_peak_forecast.push_back(7);
+	std::vector<double> monthly_avg_gross_load;
+	monthly_avg_gross_load.push_back(7);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
 	rate_forecast.compute_next_composite_tou(0, 0);
 
@@ -143,9 +143,9 @@ TEST(lib_utility_rate_test, test_simple_demand_charges)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 31 * 24, 28 * 24 }; // Average load is 1 kW
     std::vector<double> monthly_gen_forecast = { 0, 0 };
-    std::vector<double> monthly_peak_forecast = { 1, 1 };
+    std::vector<double> monthly_avg_gross_load = { 1, 1 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -1, -1, 0, -2 }; // Demand charge increases by 1 kW from average
@@ -171,9 +171,9 @@ TEST(lib_utility_rate_test, test_demand_charges_crossing_months)
 	int steps_per_hour = 1;
 	std::vector<double> monthly_load_forecast = { 150, 75 };
 	std::vector<double> monthly_gen_forecast = { 0, 0 };
-	std::vector<double> monthly_peak_forecast = { 100, 50 };
+	std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
 	// - is load
 	std::vector<double> forecast = {-100, -50, -50, -25};
@@ -183,7 +183,7 @@ TEST(lib_utility_rate_test, test_demand_charges_crossing_months)
 	int hour_of_year = 742; // 10 pm on Jan 31st
 	double cost = rate_forecast.forecastCost(forecast, 0, hour_of_year, 0);
 
-	// Total cost for the months would be $1511.25, but this subtracts off the peaks predicted by average load ($1500)
+	// Total cost for the months would be $1511.25, but this subtracts off the peaks predicted by average gross load ($1500)
 	ASSERT_NEAR(11.25, cost, 0.02);
 }
 
@@ -196,9 +196,9 @@ TEST(lib_utility_rate_test, test_demand_charges_inaccurate_forecast)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 0 };
-    std::vector<double> monthly_peak_forecast = { 50, 0 };
+    std::vector<double> monthly_avg_gross_load = { 50, 0 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -100, -50, -50, -25 };
@@ -221,9 +221,9 @@ TEST(lib_utility_rate_test, test_changing_rates_crossing_months)
 	int steps_per_hour = 1;
 	std::vector<double> monthly_load_forecast = { 0, 0, 0, 150, 75 };
 	std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0 };
-	std::vector<double> monthly_peak_forecast = { 0, 0, 0, 100, 50 };
+	std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 100, 50 };
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
 	// - is load
 	std::vector<double> forecast = { -100, -50, -50, -25 };
@@ -233,7 +233,7 @@ TEST(lib_utility_rate_test, test_changing_rates_crossing_months)
 	int hour_of_year = 2878; // 10 pm on Apr 30th
 	double cost = rate_forecast.forecastCost(forecast, 0, hour_of_year, 0);
 
-	// Total cost for the months would be $1513.13, but this subtracts off the peaks predicted by monthly peak forecast ($1500)
+	// Total cost for the months would be $1513.13, but this subtracts off the peaks predicted by average gross load forecast ($1500)
 	ASSERT_NEAR(13.125, cost, 0.02);
 }
 
@@ -245,9 +245,9 @@ TEST(lib_utility_rate_test, test_demand_charges_crossing_year)
 	int steps_per_hour = 1;
 	std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 150, 75 };
 	std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-	std::vector<double> monthly_peak_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 50 };
+	std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 50 };
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
 	// - is load
 	std::vector<double> forecast = { -100, -50, -50, -25 };
@@ -302,9 +302,9 @@ TEST(lib_utility_rate_test, test_sell_rates)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 100 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -100, -50, -50, -25, 25, 50, 25 };
@@ -326,9 +326,9 @@ TEST(lib_utility_rate_test, test_net_metering_one_tou_period)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 0 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -100, -50, 50, 100 }; // Net zero load
@@ -356,9 +356,9 @@ TEST(lib_utility_rate_test, test_net_metering_multiple_tou_periods)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 0 }; // Test unexpected generation as well
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -100, -50, 50, 100 }; // Net zero load
@@ -386,9 +386,9 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_carryover)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 0, 150 };
     std::vector<double> monthly_gen_forecast = { 150, 0 };
-    std::vector<double> monthly_peak_forecast = { 0, 100 };
+    std::vector<double> monthly_avg_gross_load = { 0, 100 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 100, 50, -50, -100 }; // Net zero load
@@ -410,9 +410,9 @@ TEST(lib_utility_rate_test, test_net_metering_dollar_credits)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 0, 150 };
     std::vector<double> monthly_gen_forecast = { 150, 0 };
-    std::vector<double> monthly_peak_forecast = { 0, 100 };
+    std::vector<double> monthly_avg_gross_load = { 0, 100 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 100, 50, -50, -100 }; // Net zero load, but credits expire with zero sell rate
@@ -434,9 +434,9 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_cashout)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 0, 150 };
     std::vector<double> monthly_gen_forecast = { 150, 0 };
-    std::vector<double> monthly_peak_forecast = { 0, 100 };
+    std::vector<double> monthly_avg_gross_load = { 0, 100 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 100, 50, -50, -100 }; // Net zero load
@@ -457,9 +457,9 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_charges)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 0 };
     std::vector<double> monthly_gen_forecast = { 0, 150 };
-    std::vector<double> monthly_peak_forecast = { 100, 0 };
+    std::vector<double> monthly_avg_gross_load = { 100, 0 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -100, -50, 50, 100 }; // Net zero load, but charged at end of Jan
@@ -480,9 +480,9 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_charges_subhourly)
     int steps_per_hour = 2;
     std::vector<double> monthly_load_forecast = { 150, 0 };
     std::vector<double> monthly_gen_forecast = { 0, 150 };
-    std::vector<double> monthly_peak_forecast = { 100, 0 };
+    std::vector<double> monthly_avg_gross_load = { 100, 0 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -100, -100, -50, -50, 50, 50, 100, 100 }; // Net zero load, but charged at end of Jan
@@ -503,9 +503,9 @@ TEST(lib_utility_rate_test, test_net_metering_charges_crossing_year)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75, 0 };
-    std::vector<double> monthly_peak_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 50 };
+    std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -25, 25, 50, -25, -25 }; // Get charged for Jan at escalated rate (inflation)
@@ -527,9 +527,9 @@ TEST(lib_utility_rate_test, test_net_metering_charges_crossing_year_other_cash_o
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75, 0 };
-    std::vector<double> monthly_peak_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 50 };
+    std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { -25, 25, 50, -25, -25 };
@@ -550,9 +550,9 @@ TEST(lib_utility_rate_test, test_multiple_forecast_calls)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 100, 75 };
     std::vector<double> monthly_gen_forecast = { 175, 0 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 25, 25, 25, 25 };
@@ -580,9 +580,9 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -594,7 +594,7 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector)
     int hour_of_year = 741; // 9 pm on Jan 31st
     double cost = rate_forecast.forecastCost(forecast, 0, hour_of_year, 0);
 
-    // Total cost for the months would be $1511.25, but this subtracts off the peaks predicted by average load ($3.12)
+    // Total cost for the months would be $1511.25, but this subtracts off the peaks predicted by average gross load load ($3.12)
     ASSERT_NEAR(11.25, cost, 0.02);
 
     cost = 0;
@@ -615,9 +615,9 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_nm_credits)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -649,9 +649,9 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_nm_credits_subhour
     int steps_per_hour = 2;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 50, 50, -100, -100, -50, -50, -50, -50, -25, -25, 25, 25, 50, 50, 100, 100 };
@@ -688,9 +688,9 @@ TEST(lib_utility_rate_test, test_end_of_analyis_period)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75 };
-    std::vector<double> monthly_peak_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50 };
+    std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 1);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 1);
 
     // - is load
     std::vector<double> forecast = { -25, -25, 50 };
@@ -711,9 +711,9 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_buy_and_sell_rates
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -746,9 +746,9 @@ TEST(lib_utility_rate_test, test_ts_buy_only)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -772,9 +772,9 @@ TEST(lib_utility_rate_test, test_ts_sell_only)
     int steps_per_hour = 1;
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
-    std::vector<double> monthly_peak_forecast = { 100, 50 };
+    std::vector<double> monthly_avg_gross_load = { 100, 50 };
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_peak_forecast, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };

--- a/test/shared_test/lib_utility_rate_test.cpp
+++ b/test/shared_test/lib_utility_rate_test.cpp
@@ -570,7 +570,7 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector)
     double cost = rate_forecast.forecastCost(forecast, 0, hour_of_year, 0);
 
     // Total cost for the months would be $1511.25, but this subtracts off the peaks predicted by average load ($3.12)
-    ASSERT_NEAR(1508.11, cost, 0.02);
+    ASSERT_NEAR(11.25, cost, 0.02);
 
     cost = 0;
     for (int i = 0; i < forecast.size(); i++)
@@ -579,7 +579,7 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector)
         cost += forecast_copy.forecastCost(single_forecast, 0, hour_of_year + i, 0);
     }
 
-    ASSERT_NEAR(1508.11, cost, 0.02);
+    ASSERT_NEAR(11.25, cost, 0.02);
 }
 
 TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_nm_credits)

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -810,6 +810,6 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialDCBatteryModelPriceS
         auto batt_q_rel = data_vtab->as_vector_ssc_number_t("batt_capacity_percent");
         auto batt_cyc_avg = data_vtab->as_vector_ssc_number_t("batt_DOD_cycle_average");
         EXPECT_NEAR(batt_q_rel.back(), 97.836, 1e-2);
-        EXPECT_NEAR(batt_cyc_avg.back(), 22.62, 0.5);
+        EXPECT_NEAR(batt_cyc_avg.back(), 24.72, 0.5);
     }
 }


### PR DESCRIPTION
Incorporates several improvements to price signals dispatch to better handle demand charges.

Previously, the price signals dispatch algorithm would ignore peaks on the last day of each month in order to dispatch at midnight, due to a perceived high price for each month's initial load. The forecast function was using net load to forecast demand charges, so the forecast load was lower than typical night time loads. Increase the prediction to average gross load, so that the algorithm waits for higher peaks.

Additionally, anticipate demand charges in future hours by planning additional dispatch in hours with higher net grid use than the highest cost hour. Previously, the 2nd hour of high power would show a much lower cost than the first, leading the algorithm to plan a smaller dispatch, but still seeing a high cost when the cost of the dispatch plan is computed. This approach compensates by looking at the power demand, and planning additional dispatch if the power required is equal to or greater than the highest cost period.

Finally, refactor the cost forecast function to ensure energy charges are handled consistently between 1 hour and multi hour forecasts.

Increases NPV 3.7% for a shopping center load profile.