### PR TITLE
Set initial SOC for voltage with battery capacity rather than cell

### DIFF
--- a/shared/lib_battery_voltage.cpp
+++ b/shared/lib_battery_voltage.cpp
@@ -342,7 +342,7 @@ void voltage_dynamic_t::parameter_compute() {
 }
 
 void voltage_dynamic_t::set_initial_SOC(double init_soc) {
-    updateVoltage(init_soc * 0.01 * params->dynamic.Qfull, params->dynamic.Qfull, 0, 25, params->dt_hr);
+    updateVoltage(init_soc * 0.01 * params->dynamic.Qfull * params->num_strings, params->dynamic.Qfull * params->num_strings, 0, 25, params->dt_hr);
 }
 
 // everything in here is on a per-cell basis

--- a/shared/lib_battery_voltage.h
+++ b/shared/lib_battery_voltage.h
@@ -188,8 +188,9 @@ public:
 
     double calculate_voltage_for_current(double I, double q, double qmax, double T_k) override;
 
-    void updateVoltage(double q, double qmax, double I, double temp, double dt) override;
-
+    
+    void updateVoltage(double q, double qmax, double I, double temp, double dt) override; //updates battery voltage based on system capacity (Ah), system maximum capacity (Ah), current (A), temperature (C), and time step (hr)
+    
 
 protected:
     double _A;

--- a/test/shared_test/lib_battery_dispatch_manual_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_manual_test.cpp
@@ -468,7 +468,7 @@ TEST_F(ManualTest_lib_battery_dispatch, InverterEfficiencyCutoffDC)
     // Test discharge constraints. First constraint does not hit backoff
     batteryPower->powerSystem = 0; batteryPower->voltageSystem = 600; batteryPower->powerGridToBattery = 0; batteryPower->powerLoad = 7;
     dispatchManual->dispatch(year, 0, step_of_hour);
-    EXPECT_NEAR(batteryPower->sharedInverter->efficiencyAC, 36.48, 0.1); // Not enforced becasue no PV
+    EXPECT_NEAR(batteryPower->sharedInverter->efficiencyAC, 35.82, 0.1); // Not enforced becasue no PV
     EXPECT_NEAR(batteryPower->powerBatteryDC, 4.43, 0.1);
 
     batteryPower->powerSystem = 770; batteryPower->voltageSystem = 600; batteryPower->powerGridToBattery = 0; batteryPower->powerLoad = 1000;

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -398,12 +398,12 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_ManualDispatchBatteryModelI
     grid_and_rate_defaults(data);
     singleowner_defaults(data);
 
-    ssc_number_t expectedEnergy = 37176158;
+    ssc_number_t expectedEnergy = 37175792;
     ssc_number_t expectedBatteryChargeEnergy = 1297985;
-    ssc_number_t expectedBatteryDischargeEnergy = 1166100;
+    ssc_number_t expectedBatteryDischargeEnergy = 1165634;
 
     ssc_number_t peakKwCharge = -1052.0;
-    ssc_number_t peakKwDischarge = 857.2;
+    ssc_number_t peakKwDischarge = 846.8;
     ssc_number_t peakCycles = 1;
     ssc_number_t avgCycles = 1;
 


### PR DESCRIPTION
-Change set_initial_SOC for dynamic voltage model to use battery capacity rather than cell capacity, as updateVoltage() divides by the number of strings to get to cell capacity. 
-Closes #520 