### PR TITLE
Better enforce "don't export to grid" constraints

### DIFF
--- a/shared/lib_battery_dispatch.cpp
+++ b/shared/lib_battery_dispatch.cpp
@@ -659,8 +659,9 @@ bool dispatch_automatic_t::check_constraints(double& I, size_t count)
 				I -= dI;
 			}
 		}
+
 		// Behind the meter
-		else if (m_batteryPower->meterPosition == dispatch_t::BEHIND)
+		if (m_batteryPower->meterPosition == dispatch_t::BEHIND)
 		{
 			// Don't let PV export to grid if can still charge battery (increase charging) (unless following custom dispatch)
 			if (_mode != dispatch_t::CUSTOM_DISPATCH && m_batteryPower->powerSystemToGrid  > tolerance && m_batteryPower->canSystemCharge &&
@@ -674,10 +675,14 @@ bool dispatch_automatic_t::check_constraints(double& I, size_t count)
 			// Don't let battery export to the grid if behind the meter
 			else if (m_batteryPower->powerBatteryToGrid > tolerance)
 			{
-				if (fabs(m_batteryPower->powerBatteryAC) < tolerance)
-					I -= (m_batteryPower->powerBatteryToGrid * util::kilowatt_to_watt / _Battery->V());
-				else
-					I -= (m_batteryPower->powerBatteryToGrid / fabs(m_batteryPower->powerBatteryAC)) * fabs(I);
+                if (fabs(m_batteryPower->powerBatteryAC) < tolerance) {
+                    I -= (m_batteryPower->powerBatteryToGrid * util::kilowatt_to_watt / _Battery->V());
+                }
+                else {
+                    I -= (m_batteryPower->powerBatteryToGrid / fabs(m_batteryPower->powerBatteryAC)) * fabs(I);
+                }
+                m_batteryPower->powerBatteryTarget -= m_batteryPower->powerBatteryToGrid;
+                m_batteryPower->powerBatteryAC -= m_batteryPower->powerBatteryToGrid; // Target was too large given PV, reduce
 			}
 			else
 				iterate = false;

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -143,7 +143,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialACDCBatteryModelInte
     ssc_number_t expectedBatteryDischargeEnergy[2] = { 0.76, 7.6 };
 
     ssc_number_t peakKwCharge[2] = { -2.7, -2.8 };
-    ssc_number_t peakKwDischarge[2] = { 0.6, 4.0 };
+    ssc_number_t peakKwDischarge[2] = { 0.03, 0.16 };
     ssc_number_t peakCycles[2] = { 1, 1 };
     ssc_number_t avgCycles[2] = { 0.0027, 0.0027 };
 
@@ -193,8 +193,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialACDCBatteryModelInte
     set_array(data, "batt_custom_dispatch", custom_dispatch_residential_hourly_schedule, 8760);
 
     ssc_number_t expectedEnergy[2] = { 8708, 8672 };
-    ssc_number_t expectedBatteryChargeEnergy[2] = { 511, 538 };
-    ssc_number_t expectedBatteryDischargeEnergy[2] = { 469, 495 };
+    ssc_number_t expectedBatteryChargeEnergy[2] = { 396.1, 359.95 };
+    ssc_number_t expectedBatteryDischargeEnergy[2] = { 395.95, 419.2 };
 
     ssc_number_t peakKwCharge[2] = { -0.47, -0.46 };
     ssc_number_t peakKwDischarge[2] = { 0.39, 0.41 };

--- a/test/ssc_test/cmod_battwatts_test.cpp
+++ b/test/ssc_test/cmod_battwatts_test.cpp
@@ -78,7 +78,7 @@ TEST_F(CMBattwatts_cmod_battwatts, ResidentialDefaults) {
     ssc_number_t peakKwDischarge = *std::max_element(batt_power_data.begin(), batt_power_data.end());
     ssc_number_t peakKwCharge = *std::min_element(batt_power_data.begin(), batt_power_data.end());
 
-    EXPECT_NEAR(peakKwDischarge, 2.2, 0.1);
+    EXPECT_NEAR(peakKwDischarge, 1.97, 0.1);
     EXPECT_NEAR(peakKwCharge, -3.0, 0.1);
 
     auto batt_voltage = data.as_vector_ssc_number_t("batt_voltage");
@@ -108,7 +108,7 @@ TEST_F(CMBattwatts_cmod_battwatts, ResidentialDefaultsLeadAcid) {
     ssc_number_t peakKwDischarge = *std::max_element(batt_power_data.begin(), batt_power_data.end());
     ssc_number_t peakKwCharge = *std::min_element(batt_power_data.begin(), batt_power_data.end());
 
-    EXPECT_NEAR(peakKwDischarge, 2.0, 0.1);
+    EXPECT_NEAR(peakKwDischarge, 1.83, 0.1);
     EXPECT_NEAR(peakKwCharge, -2.7, 0.1);
 
     auto batt_voltage = data.as_vector_ssc_number_t("batt_voltage");
@@ -147,5 +147,5 @@ TEST_F(CMBattwatts_cmod_battwatts, NoPV) {
 
     auto cycles = data.as_vector_ssc_number_t("batt_cycles");
     ssc_number_t maxCycles = *std::max_element(cycles.begin(), cycles.end());
-    EXPECT_NEAR(maxCycles, 514, 0.1);
+    EXPECT_NEAR(maxCycles, 522, 0.1);
 }


### PR DESCRIPTION
Two changes: First - pull adjustments out of else-if chain to ensure they are applied consistently. This also helps increase charging targets in price signals dispatch. Second, adjust the custom dispatch targets if they are too high, reducing iteration. Adjust tests as needed

- Includes a new test to trigger this specific bug
- Changes to two other custom dispatch tests were expected
- Price signals dispatch now has better access to charging power, due to a related constraint in the if-else chain
- The BattWatts changes were unexpected, but justified when I checked the tests in the debugger