### PR TITLE
Add error checks for when PV module dimensions are 0

### DIFF
--- a/shared/lib_irradproc.cpp
+++ b/shared/lib_irradproc.cpp
@@ -2473,6 +2473,9 @@ int irrad::calc_rear_side(double transmissionFactor, double groundClearanceHeigh
         double verticalHeight = slopeLength * sin(tiltRadian);
         double horizontalLength = slopeLength * cos(tiltRadian);
 
+        if (horizontalLength == 0)
+            throw std::runtime_error("Bifacial calc_rear_side error: module's horizontal length cannot be 0. Please check module's dimensions.");
+
         // Determine the factors for points on the ground from the leading edge of one row of PV panels to the edge of the next row of panels behind
         std::vector<double> rearSkyConfigFactors, frontSkyConfigFactors;
         this->getSkyConfigurationFactors(rowToRow, verticalHeight, clearanceGround, distanceBetweenRows,

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -993,6 +993,8 @@ void cm_pvsamv1::exec()
 
     // SELF-SHADING MODULE INFORMATION
     double width = sqrt((ref_area_m2 / aspect_ratio));
+    if (width <= 0)
+        throw exec_error("pvsamv1", "Area of PV module must be > 0, but is instead " + util::to_string(width));
     for (size_t nn = 0; nn < num_subarrays; nn++)
     {
         Subarrays[nn]->selfShadingInputs.width = width;
@@ -2333,7 +2335,7 @@ void cm_pvsamv1::exec()
 
             if (iyear == 0)
                 annual_energy += (ssc_number_t)(PVSystem->p_systemACPower[idx] * ts_hour);
-            
+
 
         }
         wdprov->rewind();


### PR DESCRIPTION
When a PV module has an area of 0, the calculated dimensions of the module lead to erroneous behavior in the self-shading and bifacial calculations. Catch this error in pvsamv1 and irradproc.

Close #562 