### PR TITLE
Ssc 565 fix voltage discharge

### DIFF
--- a/shared/lib_battery_voltage.cpp
+++ b/shared/lib_battery_voltage.cpp
@@ -189,6 +189,8 @@ double voltage_table_t::calculate_max_discharge_w(double q, double qmax, double,
     double max_I = 0;
     for (size_t i = 0; i < slopes.size(); i++) {
         double dod = -(A * slopes[i] + B * intercepts[i]) / (2 * B * slopes[i]);
+        dod = fmin(100, dod);
+        dod = fmax(0, dod);
         double current = qmax * ((1. - DOD0 / 100.) - (1. - dod / 100.)) / params->dt_hr;
         double p = calculate_voltage(dod) * current;
         if (p > max_P) {

--- a/test/shared_test/lib_battery_voltage_test.h
+++ b/test/shared_test/lib_battery_voltage_test.h
@@ -80,6 +80,43 @@ protected:
                                                                dt_hr));
         model->set_initial_SOC(50);
     }
+
+    // Additional test case based on specifying a bank voltage in the voltage table
+    void CreateModel_SSC_565(double dt_hr) {
+        std::vector<double> voltage_vals = { 98.5621,   11.0243,
+                                            93.6232,    11.1811,
+                                            88.5626,    11.3121,
+                                            78.4633,	11.5135,
+                                            73.5146,	11.615,
+                                            67.6633,	11.7263,
+                                            62.8321,	11.8167,
+                                            57.7124,	11.9016,
+                                            52.6853,	11.9711,
+                                            47.8345,	12.0352,
+                                            42.906,	    12.0973,
+                                            37.779,	    12.1562,
+                                            32.7257,	12.2089,
+                                            27.597,	    12.2631,
+                                            22.7296,	12.3161,
+                                            17.3806,	12.3655,
+                                            14.7764,	12.3881,
+                                            12.1762,	12.4084,
+                                            9.49381,	12.4228,
+                                            6.89357,	12.4397,
+                                            4.60535,	12.4521,
+                                            1.80256,	12.463,
+                                            0.269783,	12.4677 };
+        util::matrix_t<double> voltage_table(23, 2, &voltage_vals);
+
+        n_cells_series = 6;
+        n_strings = 28;
+        voltage_nom = 2;
+
+        cap = std::unique_ptr<capacity_lithium_ion_t>(new capacity_lithium_ion_t(10, 50, 95, 5, dt_hr));
+        model = std::unique_ptr<voltage_t>(new voltage_table_t(n_cells_series, n_strings, voltage_nom, voltage_table, R,
+            dt_hr));
+        model->set_initial_SOC(50);
+    }
 };
 
 class voltage_vanadium_lib_battery_voltage_test : public lib_battery_voltage_test


### PR DESCRIPTION
Fix the ssc side of #565 - SSC will now throw an exception if the nominal voltage is outside of the values provided in the voltage table. Additionally add the depth of discharge guardrails to voltage_table_t::calculate_max_discharge_w - this reduces the over-dispatch issue significantly (see screenshot below) but does not solve the SOC issue reported in 565. Another issue will be created to handle that in a future patch.

New behavior:

![image](https://user-images.githubusercontent.com/5530592/116321120-bc2d5880-a776-11eb-9e8c-787a6b7f2389.png)

Improvement in SOC and dispatch relative to the filed issue. Still need to fully restrict dispatch from exceeding SOC limit with a new function.