### PR TITLE
Fix backtracking configuration for snow shedding model in PVWatts7

### DIFF
--- a/ssc/cmod_pvwattsv7.cpp
+++ b/ssc/cmod_pvwattsv7.cpp
@@ -555,7 +555,7 @@ public:
                 log(util::format("system size is too small to accurately estimate regular row-row self shading impacts. (estimates: #modules=%d, #rows=%d).  disabling self-shading calculations.",
                 (int)pv.nmodules, (int)pv.nrows), SSC_WARNING);*/
 
-            if (pv.type == ONE_AXIS)
+            if (pv.type == ONE_AXIS || pv.type == ONE_AXIS_BACKTRACKING)
                 pv.nmody = 1; // e.g. Nextracker or ArrayTechnologies single portrait
             else
                 pv.nmody = 2; // typical fixed 2 up portrait

--- a/test/ssc_test/cmod_pvwattsv7_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv7_test.cpp
@@ -245,9 +245,9 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, SnowModelFixed_cmod_pvwattsv7) {
 	ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
 
 	ASSERT_EQ(8760, count);
-	int startIndex = 24 * 11 + 6;  // starting at noon on Jan. 12th
 
-	// Snow derate should be non-zero during a snow event, and on a fixed system will always be 0, 0.5, or 1.0 due to the assumption of a 2-up installation
+    // Starting at 6 AM Jan. 12th
+    // Snow derate should be non-zero during a snow event, and on a fixed system will always be 0, 0.5, or 1.0 due to the assumption of a 2-up installation
 	EXPECT_NEAR((double)hourly_snowderate[270], 0.0, error_tolerance);
 	EXPECT_NEAR((double)hourly_snowderate[271], 0.5, error_tolerance);
 	EXPECT_NEAR((double)hourly_snowderate[272], 0.5, error_tolerance);

--- a/test/ssc_test/cmod_pvwattsv7_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv7_test.cpp
@@ -230,72 +230,72 @@ TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, BifacialTest_cmod_pvwattsv7) {
 
 TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, SnowModelFixed_cmod_pvwattsv7) {
 
-	// Snow loss for backtracking, low GCR
-	ssc_data_set_number(data, "array_type", 0);
-	ssc_data_set_number(data, "en_snowloss", 1);
+    // Snow loss for backtracking, low GCR
+    ssc_data_set_number(data, "array_type", 0);
+    ssc_data_set_number(data, "en_snowloss", 1);
 
-	compute();
-	// Snow events in January, February, April, October, and December
-	// Other months seem to unexpectedly end up with a very small boost to total energy.
-	// Without snow loss:                         { 439.755, 485.885, 597.621, 680.543, 724.435, 676.368, 674.804, 658.759, 607.498, 580.084, 460.171, 417.226 };
-	std::vector<double> expected_monthly_energy = { 415.134, 395.622, 597.621, 659.851, 724.460, 676.368, 674.816, 658.761, 607.498, 571.064, 460.186, 386.396 };
-	ValidateMonthlyEnergy(expected_monthly_energy);
+    compute();
+    // Snow events in January, February, April, October, and December
+    // Other months seem to unexpectedly end up with a very small boost to total energy.
+    // Without snow loss:                         { 439.755, 485.885, 597.621, 680.543, 724.435, 676.368, 674.804, 658.759, 607.498, 580.084, 460.171, 417.226 };
+    std::vector<double> expected_monthly_energy = { 415.134, 395.622, 597.621, 659.851, 724.460, 676.368, 674.816, 658.761, 607.498, 571.064, 460.186, 386.396 };
+    ValidateMonthlyEnergy(expected_monthly_energy);
 
-	int count;
-	ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
+    int count;
+    ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
 
-	ASSERT_EQ(8760, count);
+    ASSERT_EQ(8760, count);
 
     // Starting at 6 AM Jan. 12th
     // Snow derate should be non-zero during a snow event, and on a fixed system will always be 0, 0.5, or 1.0 due to the assumption of a 2-up installation
-	EXPECT_NEAR((double)hourly_snowderate[270], 0.0, error_tolerance);
-	EXPECT_NEAR((double)hourly_snowderate[271], 0.5, error_tolerance);
-	EXPECT_NEAR((double)hourly_snowderate[272], 0.5, error_tolerance);
-	// ...
-	EXPECT_NEAR((double)hourly_snowderate[275], 0.5, error_tolerance);
-	EXPECT_NEAR((double)hourly_snowderate[276], 0.5, error_tolerance);
-	EXPECT_NEAR((double)hourly_snowderate[277], 1.0, error_tolerance);
+    EXPECT_NEAR((double)hourly_snowderate[270], 0.0, error_tolerance);
+    EXPECT_NEAR((double)hourly_snowderate[271], 0.5, error_tolerance);
+    EXPECT_NEAR((double)hourly_snowderate[272], 0.5, error_tolerance);
+    // ...
+    EXPECT_NEAR((double)hourly_snowderate[275], 0.5, error_tolerance);
+    EXPECT_NEAR((double)hourly_snowderate[276], 0.5, error_tolerance);
+    EXPECT_NEAR((double)hourly_snowderate[277], 1.0, error_tolerance);
 }
 
-TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, SnowModelBacktracking_cmod_pvwattsv7){
+TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, SnowModelBacktracking_cmod_pvwattsv7) {
 
-	ssc_data_set_number(data, "array_type", 3);
-	ssc_data_set_number(data, "en_snowloss", 1);
+    ssc_data_set_number(data, "array_type", 3);
+    ssc_data_set_number(data, "en_snowloss", 1);
 
-	compute();
+    compute();
 
-	// No snow results:                             527.970, 602.337, 741.523, 854.848, 917.762, 861.674, 835.126, 818.089, 763.014, 731.930, 566.034, 511.322
-	// Results with unintentional 2-up assumption:  510.869, 530.704, 741.523, 835.652, 917.816, 861.674, 835.146, 818.115, 763.014, 723.068, 566.095, 484.364
-	std::vector<double> expected_monthly_energy = { 503.775, 504.950, 741.523, 829.441, 917.816, 861.674, 835.146, 818.115, 763.014, 720.299, 566.095, 477.600 };
-	ValidateMonthlyEnergy(expected_monthly_energy);
+    // No snow results:                             527.970, 602.337, 741.523, 854.848, 917.762, 861.674, 835.126, 818.089, 763.014, 731.930, 566.034, 511.322
+    // Results with unintentional 2-up assumption:  510.869, 530.704, 741.523, 835.652, 917.816, 861.674, 835.146, 818.115, 763.014, 723.068, 566.095, 484.364
+    std::vector<double> expected_monthly_energy = { 503.775, 504.950, 741.523, 829.441, 917.816, 861.674, 835.146, 818.115, 763.014, 720.299, 566.095, 477.600 };
+    ValidateMonthlyEnergy(expected_monthly_energy);
 
-	// A tracker row is assumed to be nx1 panels, so all derates should be either 0 or 1
-	int count;
-	ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
-	for (int hour = 0; hour < count; hour++)
-	{
-		EXPECT_TRUE(hourly_snowderate[hour] == 0 || hourly_snowderate[hour] == 1);
-	}
+    // A tracker row is assumed to be nx1 panels, so all derates should be either 0 or 1
+    int count;
+    ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
+    for (int hour = 0; hour < count; hour++)
+    {
+        EXPECT_TRUE(hourly_snowderate[hour] == 0 || hourly_snowderate[hour] == 1);
+    }
 }
 
 TEST_F(CMPvwattsV7Integration_cmod_pvwattsv7, SnowModelSingleAxis_cmod_pvwattsv7) {
 
-	ssc_data_set_number(data, "array_type", 2);
-	ssc_data_set_number(data, "en_snowloss", 1);
+    ssc_data_set_number(data, "array_type", 2);
+    ssc_data_set_number(data, "en_snowloss", 1);
 
-	compute();
+    compute();
 
-	// No snow results:                             528.405, 604.598, 746.246, 865.370, 929.784, 872.583, 843.064, 827.269, 769.443, 735.272, 567.128, 511.474
-	std::vector<double> expected_monthly_energy = { 508.149, 510.020, 746.246, 839.917, 929.849, 872.583, 843.091, 827.295, 769.443, 723.602, 567.192, 477.753 };
-	ValidateMonthlyEnergy(expected_monthly_energy);
+    // No snow results:                             528.405, 604.598, 746.246, 865.370, 929.784, 872.583, 843.064, 827.269, 769.443, 735.272, 567.128, 511.474
+    std::vector<double> expected_monthly_energy = { 508.149, 510.020, 746.246, 839.917, 929.849, 872.583, 843.091, 827.295, 769.443, 723.602, 567.192, 477.753 };
+    ValidateMonthlyEnergy(expected_monthly_energy);
 
-	// A tracker row is assumed to be nx1 panels, so all derates should be either 0 or 1
-	int count;
-	ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
-	for (int hour = 0; hour < count; hour++)
-	{
-		EXPECT_TRUE(hourly_snowderate[hour] == 0 || hourly_snowderate[hour] == 1);
-	}
+    // A tracker row is assumed to be nx1 panels, so all derates should be either 0 or 1
+    int count;
+    ssc_number_t* hourly_snowderate = ssc_data_get_array(data, "dcsnowderate", &count);
+    for (int hour = 0; hour < count; hour++)
+    {
+        EXPECT_TRUE(hourly_snowderate[hour] == 0 || hourly_snowderate[hour] == 1);
+    }
 }
 
 

--- a/test/ssc_test/cmod_pvwattsv7_test.h
+++ b/test/ssc_test/cmod_pvwattsv7_test.h
@@ -29,6 +29,34 @@ protected: //doesn't really matter if this is protected or public, but you need 
 		ssc_data_free(data);
 		data = nullptr;
 	} 
+	void ValidateMonthlyEnergy(std::vector<double> expectedMonthlyEnergy)
+	{
+		ASSERT_EQ(12, expectedMonthlyEnergy.size());
+
+		std::vector<std::string> messages = {
+			"Monthly energy of January",
+			"Monthly energy of February",
+			"Monthly energy of March",
+			"Monthly energy of April",
+			"Monthly energy of May",
+			"Monthly energy of June",
+			"Monthly energy of July",
+			"Monthly energy of August",
+			"Monthly energy of September",
+			"Monthly energy of October",
+			"Monthly energy of November",
+			"Month energy of December"
+		};
+		int count;
+		ssc_number_t* monthly_energy = ssc_data_get_array(data, "monthly_energy", &count);
+		EXPECT_EQ(12, count);
+
+		for (int month = 0; month < count; month++)
+		{
+			EXPECT_NEAR((double)monthly_energy[month], expectedMonthlyEnergy[month], error_tolerance) << messages[month];
+		}
+
+	}
 };
 
 //this function will be available to run the pvwattsV7 compute module from within tests

--- a/test/ssc_test/cmod_pvwattsv7_test.h
+++ b/test/ssc_test/cmod_pvwattsv7_test.h
@@ -29,34 +29,33 @@ protected: //doesn't really matter if this is protected or public, but you need 
 		ssc_data_free(data);
 		data = nullptr;
 	} 
-	void ValidateMonthlyEnergy(std::vector<double> expectedMonthlyEnergy)
-	{
-		ASSERT_EQ(12, expectedMonthlyEnergy.size());
+    void ValidateMonthlyEnergy(std::vector<double> expectedMonthlyEnergy)
+    {
+        ASSERT_EQ(12, expectedMonthlyEnergy.size());
 
-		std::vector<std::string> messages = {
-			"Monthly energy of January",
-			"Monthly energy of February",
-			"Monthly energy of March",
-			"Monthly energy of April",
-			"Monthly energy of May",
-			"Monthly energy of June",
-			"Monthly energy of July",
-			"Monthly energy of August",
-			"Monthly energy of September",
-			"Monthly energy of October",
-			"Monthly energy of November",
-			"Month energy of December"
-		};
-		int count;
-		ssc_number_t* monthly_energy = ssc_data_get_array(data, "monthly_energy", &count);
-		EXPECT_EQ(12, count);
+        std::vector<std::string> messages = {
+            "Monthly energy of January",
+            "Monthly energy of February",
+            "Monthly energy of March",
+            "Monthly energy of April",
+            "Monthly energy of May",
+            "Monthly energy of June",
+            "Monthly energy of July",
+            "Monthly energy of August",
+            "Monthly energy of September",
+            "Monthly energy of October",
+            "Monthly energy of November",
+            "Monthly energy of December"
+        };
+        int count;
+        ssc_number_t* monthly_energy = ssc_data_get_array(data, "monthly_energy", &count);
+        EXPECT_EQ(12, count);
 
-		for (int month = 0; month < count; month++)
-		{
-			EXPECT_NEAR((double)monthly_energy[month], expectedMonthlyEnergy[month], error_tolerance) << messages[month];
-		}
-
-	}
+        for (int month = 0; month < count; month++)
+        {
+            EXPECT_NEAR((double)monthly_energy[month], expectedMonthlyEnergy[month], error_tolerance) << messages[month];
+        }
+    }
 };
 
 //this function will be available to run the pvwattsV7 compute module from within tests


### PR DESCRIPTION
The snow shedding model requires a number of strings or panels along the height of the row slant height.  The PVWatts7 model estimates this based on the tracking type, making the assumption that most fixed systems have strings of panels in each row and single-axis have only one.  However, for single-axis trackers that support backtracking it was falling through to the fixed assumption while it should be consistent with the single-axis true-tracker assumption.

Added some test cases to verify behavior of the snow model in all three cases.

This address issue #581.