### PR TITLE
add grid_outage and run_resiliency_calcs to vartable

### DIFF
--- a/ssc/cmod_grid.cpp
+++ b/ssc/cmod_grid.cpp
@@ -40,6 +40,9 @@ var_info vtab_grid_input[] = {
 	// external compute module inputs
 	{ SSC_INOUT,        SSC_ARRAY,       "gen",								  "System power generated",                "kW",        "Lifetime system generation",          "System Output",                  "",                        "",                              "" },
 	{ SSC_INPUT,		SSC_ARRAY,	     "load",			                  "Electricity load (year 1)",             "kW",	    "",                                    "Load",	                       "",	                      "",	                           "" },
+    { SSC_INPUT,		SSC_ARRAY,	     "crit_load",			              "Critical electricity load (year 1)",    "kW",	        "",				        "Load",                             "",	                      "",	                            "" },
+    { SSC_INPUT,        SSC_ARRAY,       "grid_outage",                       "Timesteps with grid outage",            "0/1",        "0=GridAvailable,1=GridUnavailable,Length=load", "Load",    "",                       "",                               "" },
+    { SSC_INPUT,        SSC_NUMBER,      "run_resiliency_calcs",              "Enable battery storage model",          "0/1",        "0=DisableCalcs,1=EnableCalcs",                  "Load",    "?=0",                    "",                               "" },
     { SSC_INPUT,        SSC_ARRAY,       "load_escalation",                   "Annual load escalation",                "%/year",    "",                                    "Load",                        "?=0",                      "",                            "" },
 
 var_info_invalid };

--- a/ssc/cmod_grid.cpp
+++ b/ssc/cmod_grid.cpp
@@ -42,7 +42,6 @@ var_info vtab_grid_input[] = {
 	{ SSC_INPUT,		SSC_ARRAY,	     "load",			                  "Electricity load (year 1)",             "kW",	    "",                                    "Load",	                       "",	                      "",	                           "" },
     { SSC_INPUT,		SSC_ARRAY,	     "crit_load",			              "Critical electricity load (year 1)",    "kW",	        "",				        "Load",                             "",	                      "",	                            "" },
     { SSC_INPUT,        SSC_ARRAY,       "grid_outage",                       "Timesteps with grid outage",            "0/1",        "0=GridAvailable,1=GridUnavailable,Length=load", "Load",    "",                       "",                               "" },
-    { SSC_INPUT,        SSC_NUMBER,      "run_resiliency_calcs",              "Enable battery storage model",          "0/1",        "0=DisableCalcs,1=EnableCalcs",                  "Load",    "?=0",                    "",                               "" },
     { SSC_INPUT,        SSC_ARRAY,       "load_escalation",                   "Annual load escalation",                "%/year",    "",                                    "Load",                        "?=0",                      "",                            "" },
 
 var_info_invalid };

--- a/ssc/cmod_grid.cpp
+++ b/ssc/cmod_grid.cpp
@@ -168,6 +168,7 @@ void cm_grid::exec()
 	    double gen = gridVars->systemGenerationLifetime_kW[i];
 		double gridNet = gen - gridVars->loadLifetime_kW[i];
 
+        // TODO - curtail if grid outage here
 
 		if (gridVars->enable_interconnection_limit){
 		    p_genPreInterconnect_kW[i] = static_cast<ssc_number_t>(gen);

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -489,6 +489,8 @@ static var_info _cm_vtab_pvsamv1[] = {
 { SSC_INPUT, SSC_NUMBER,   "en_batt",                              "Enable battery storage model",                        "0/1",    "",                                                                                                                                                                                      "BatterySystem",                                               "?=0",                                "",                    "" },
 { SSC_INPUT, SSC_ARRAY,    "load",                                 "Electricity load (year 1)",                           "kW",     "",                                                                                                                                                                                      "Load",                                               "?",                                  "",                    "" },
 { SSC_INPUT, SSC_ARRAY,    "crit_load",                            "Critical Electricity load (year 1)",                  "kW",     "",                                                                                                                                                                                      "Load",                                               "",                                   "",                    "" },
+{ SSC_INPUT, SSC_ARRAY,    "grid_outage",                          "Timesteps with grid outage",                          "0/1",    "0=GridAvailable,1=GridUnavailable,Length=load", "Load",    "",                       "",                               "" },
+{ SSC_INPUT, SSC_NUMBER,   "run_resiliency_calcs",                 "Enable resilence calculations for every timestep",    "0/1",    "0=DisableCalcs,1=EnableCalcs",                  "Load",    "?=0",                    "",                               "" },
 { SSC_INPUT, SSC_ARRAY,    "load_escalation",                      "Annual load escalation",                              "%/year", "",                                                                                                                                                                                      "Load",                                               "?=0",                                "",                    "" },
 // NOTE:  other battery storage model inputs and outputs are defined in batt_common.h/batt_common.cpp
 
@@ -1094,11 +1096,17 @@ void cm_pvsamv1::exec()
         if (PVSystem->Inverter->nMpptInputs > 1 && en_batt && batt_topology == ChargeController::DC_CONNECTED)
             throw exec_error("pvsamv1", "DC-connected batteries do not work with multiple MPPT input inverters.");
 
-        if (!p_crit_load_in.empty() && *std::max_element(p_crit_load_in.begin(), p_crit_load_in.end()) > 0) {
-            resilience = std::unique_ptr<resilience_runner>(new resilience_runner(batt));
-            auto logs = resilience->get_logs();
-            if (!logs.empty()) {
-                log(logs[0], SSC_WARNING);
+        bool run_resilience = as_boolean("run_resiliency_calcs");
+        if (run_resilience) {
+            if (!p_crit_load_in.empty() && *std::max_element(p_crit_load_in.begin(), p_crit_load_in.end()) > 0) {
+                resilience = std::unique_ptr<resilience_runner>(new resilience_runner(batt));
+                auto logs = resilience->get_logs();
+                if (!logs.empty()) {
+                    log(logs[0], SSC_WARNING);
+                }
+            }
+            else {
+                throw exec_error("pvsamv1", "If run_resiliency_calcs is 1, crit_load must have length > 0 and values > 0");
             }
         }
     }

--- a/test/ssc_test/cmod_battery_test.cpp
+++ b/test/ssc_test/cmod_battery_test.cpp
@@ -51,6 +51,7 @@ TEST_F(CMBattery_cmod_battery, ResilienceMetricsFullLoad){
     data_vtab->assign("analysis_period", 1);
     data_vtab->assign("gen", var_data(data_vtab->as_array("gen", nullptr), 8760));
     data_vtab->assign("batt_replacement_option", 0);
+    data_vtab->assign("run_resiliency_calcs", 1);
 
     int errors = run_module(data, "battery");
     EXPECT_FALSE(errors);
@@ -106,6 +107,7 @@ TEST_F(CMBattery_cmod_battery, ResilienceMetricsFullLoadLifetime){
     data_vtab->assign("analysis_period", nyears);
     data_vtab->assign("gen", var_data(data_vtab->as_array("gen", nullptr), 8760 * nyears));
     data_vtab->assign("batt_replacement_option", 0);
+    data_vtab->assign("run_resiliency_calcs", 1);
 
     int errors = run_module(data, "battery");
     EXPECT_FALSE(errors);

--- a/test/ssc_test/cmod_battwatts_test.h
+++ b/test/ssc_test/cmod_battwatts_test.h
@@ -44,6 +44,7 @@ public:
         data.assign("crit_load", crit_load);
         data.assign("inverter_model", 0);
         data.assign("inverter_efficiency", 96);
+        data.assign("run_resiliency_calcs", 1);
     }
 };
 


### PR DESCRIPTION
Pairs with SAM PR https://github.com/NREL/SAM/pull/641

First inputs in the vartable for the grid outage work. Want to get this merged sooner to avoid conflicts in defaults files.