### PR TITLE
TOD multipliers for LCOS calculations

### DIFF
--- a/ssc/cmod_cashloan.cpp
+++ b/ssc/cmod_cashloan.cpp
@@ -1034,7 +1034,7 @@ public:
             cf_lcos.at(8, y) = cf.at(CF_om_capacity1_expense, y); //Capacity OM Battery Cost
         }
         int grid_charging_cost_version = 0;
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, total_cost, real_discount_rate, grid_charging_cost_version, 0);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, total_cost, real_discount_rate, grid_charging_cost_version);
     }
     /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ssc/cmod_equpartflip.cpp
+++ b/ssc/cmod_equpartflip.cpp
@@ -2482,7 +2482,7 @@ public:
         int grid_charging_cost_version = 1; //FOM systems
         size_t n_multipliers;
         ssc_number_t* ppa_multipliers = as_array("ppa_multipliers", &n_multipliers);
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, ppa_multipliers);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version);
     }
     /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ssc/cmod_host_developer.cpp
+++ b/ssc/cmod_host_developer.cpp
@@ -2767,7 +2767,7 @@ public:
             cf_lcos.at(8, y) = cf.at(CF_om_capacity1_expense, y); //Capacity OM Battery Cost
         }
         int grid_charging_cost_version = 0;
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, 0);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version);
         /*
         double lcos_investment_cost = as_double("battery_total_cost_lcos"); //does not include replacement costs
         double lcos_om_cost = npv(CF_om_capacity1_expense, nyears, nom_discount_rate); //Todo: include variable om due to charging

--- a/ssc/cmod_levpartflip.cpp
+++ b/ssc/cmod_levpartflip.cpp
@@ -2759,7 +2759,7 @@ public:
         int grid_charging_cost_version = 1;
         size_t n_multipliers;
         ssc_number_t* ppa_multipliers = as_array("ppa_multipliers", &n_multipliers);
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, ppa_multipliers);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version);
     }
     /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ssc/cmod_merchantplant.cpp
+++ b/ssc/cmod_merchantplant.cpp
@@ -2731,7 +2731,7 @@ public:
 
         }
         int grid_charging_cost_version = 2; //Merchant plant
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, 0);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version);
         /*
         double lcos_investment_cost = as_double("battery_total_cost_lcos"); //does not include replacement costs
         double lcos_om_cost = npv(CF_om_capacity1_expense, nyears, nom_discount_rate); //Todo: include variable om due to charging

--- a/ssc/cmod_saleleaseback.cpp
+++ b/ssc/cmod_saleleaseback.cpp
@@ -2565,7 +2565,7 @@ public:
         int grid_charging_cost_version = 1;
         size_t n_multipliers;
         ssc_number_t* ppa_multipliers = as_array("ppa_multipliers", &n_multipliers);
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, ppa_multipliers);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version);
     }
     /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -2997,6 +2997,14 @@ public:
             cf_lcos.at(8, y) = cf.at(CF_om_capacity1_expense, y); //Capacity OM Battery Cost
         }
         int grid_charging_cost_version = 1;
+        ssc_number_t* tod_multipliers;
+        size_t* n_tod_multipliers = 0;
+        if (is_assigned("ppa_multiplier_model") && as_integer("ppa_multiplier_model") == 0) {
+            tod_multipliers = ppa_multipliers;
+        }
+        else if (is_assigned("ppa_multiplier_model") && as_integer("ppa_multiplier_model") == 1) {
+            tod_multipliers = as_array("dispatch_factors_ts", n_tod_multipliers);
+        }
         lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, ppa_multipliers);
     }
     /////////////////////////////////////////////////////////////////////////////////////////

--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -2999,13 +2999,7 @@ public:
         int grid_charging_cost_version = 1;
         ssc_number_t* tod_multipliers;
         size_t* n_tod_multipliers = 0;
-        if (is_assigned("ppa_multiplier_model") && as_integer("ppa_multiplier_model") == 0) {
-            tod_multipliers = ppa_multipliers;
-        }
-        else if (is_assigned("ppa_multiplier_model") && as_integer("ppa_multiplier_model") == 1) {
-            tod_multipliers = as_array("dispatch_factors_ts", n_tod_multipliers);
-        }
-        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version, ppa_multipliers);
+        lcos_calc(this, cf_lcos, nyears, nom_discount_rate, inflation_rate, lcoe_real, cost_prefinancing, disc_real, grid_charging_cost_version);
     }
     /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ssc/common_financial.cpp
+++ b/ssc/common_financial.cpp
@@ -3401,7 +3401,7 @@ void save_cf(int cf_line, int nyears, const std::string& name, util::matrix_t<do
         arrp[i] = (ssc_number_t)cf.at(cf_line, i);
 }
 
-void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double nom_discount_rate, double inflation_rate, double lcoe_real, double total_cost, double real_discount_rate, int grid_charging_cost_version, ssc_number_t* ppa_multipliers = { 0 }) {
+void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double nom_discount_rate, double inflation_rate, double lcoe_real, double total_cost, double real_discount_rate, int grid_charging_cost_version) {
     enum {
         CF_battery_replacement_cost_lcos,
         CF_battery_replacement_cost_schedule_lcos,
@@ -3528,13 +3528,7 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
                     double ppa_value = cf.at(CF_ppa_price_lcos, a); //PPA price at year a
                     if (ppa_purchases && a != 0) {
                         for (size_t h = 0; h < n_steps_per_year; h++) {
-                            if (size_t(n_tod_multipliers) > 8760) {
-                                tod_mult_index = h;
-                            }
-                            else {
-                                tod_mult_index = floor(h / 8760);
-                            }
-                            
+                            tod_mult_index = floor(h / (n_steps_per_year/8760));
                             cf.at(CF_charging_cost_grid_lcos, a) += grid_to_batt[(size_t(a) - 1) * n_steps_per_year + h] * 8760 / n_steps_per_year * ppa_value / 100.0 * tod_multipliers[tod_mult_index]; //Grid charging cost from PPA price ($)
                         }
                     }
@@ -3556,12 +3550,8 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
 
                     if (ppa_purchases && a != 0) { //PPA purchases enabled and not in investment year
                         for (size_t h = 0; h < 8760; h++) {
-                            if (size_t(n_tod_multipliers) > 8760) {
-                                tod_mult_index = h;
-                            }
-                            else {
-                                tod_mult_index = floor(h / 8760);
-                            }
+                            
+                            tod_mult_index = floor(h / 8760);
                             cf.at(CF_charging_cost_grid_lcos, a) += grid_to_batt[h] * cf.at(CF_degradation_lcos, a) * ppa_value / 100.0 * tod_multipliers[h]; //Grid charging cost calculated from PPA price ($)
                         }
                     }

--- a/ssc/common_financial.h
+++ b/ssc/common_financial.h
@@ -41,7 +41,7 @@ void save_cf(int cf_line, int nyears, const std::string& name, util::matrix_t<do
 
 extern var_info vtab_lcos_inputs[]; //LCOS var table
 
-void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double nom_discount_rate, double inflation_rate, double lcoe_real, double total_cost, double real_discount_rate, int grid_charging_cost_version, ssc_number_t* ppa_multipliers); //LCOS function
+void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double nom_discount_rate, double inflation_rate, double lcoe_real, double total_cost, double real_discount_rate, int grid_charging_cost_version); //LCOS function
 
 
 class dispatch_calculations


### PR DESCRIPTION
-Added array size checks for sub-hourly simulations
-Added check for schedule or array ppa multiplier model to build array
-Using var table inputs now rather than extra input in lcos_calc function; Removed extra variable
