### PR TITLE
Variable production O&M cost changes for battery and fuel cell

### DIFF
--- a/ssc/cmod_cashloan.cpp
+++ b/ssc/cmod_cashloan.cpp
@@ -490,25 +490,34 @@ public:
 		escal_or_annual( CF_om_capacity_expense, nyears, "om_capacity", inflation_rate, 1.0, false, as_double("om_capacity_escal")*0.01 );  
 		escal_or_annual( CF_om_fuel_expense, nyears, "om_fuel_cost", inflation_rate, as_double("system_heat_rate")*0.001, false, as_double("om_fuel_cost_escal")*0.01 );
 
-		// additional o and m sub types (e.g. batteries and fuel cells)
-		int add_om_num_types = as_integer("add_om_num_types");
-		ssc_number_t nameplate1 = 0;
-		ssc_number_t nameplate2 = 0;
-
-		if (add_om_num_types > 0)
-		{
+        // additional o and m sub types (e.g. batteries and fuel cells)
+        int add_om_num_types = as_integer("add_om_num_types");
+        ssc_number_t nameplate1 = 0;
+        ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
+        //throw exec_error("singleowner", "Checkpoint 1");
+        if (add_om_num_types > 0) //PV Battery
+        {
             escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
-            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01); //$/MWh
             escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate1 = as_number("ui_batt_capacity");
-		}
-		if (add_om_num_types > 1)
-		{
-			escal_or_annual(CF_om_fixed2_expense, nyears, "om_fuelcell_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal")*0.01);
-			escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal")*0.01);
-			escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal")*0.01);
-			nameplate2 = as_number("ui_fuelcell_capacity");
-		}
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
+        }
+        if (add_om_num_types > 1) // PV Battery Fuel Cell
+        {
+            escal_or_annual(CF_om_fixed2_expense, nyears, "om_fuelcell_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
+            escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
+            nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
+        }
 
         // battery cost - replacement from lifetime analysis
         if ((as_integer("en_batt") == 1) && (as_integer("batt_replacement_option") > 0))
@@ -742,6 +751,11 @@ public:
 
 
 			cf.at(CF_om_fuel_expense,i) *= fuel_use[i];
+
+            //Battery Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
+
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;
 			double decline_percent = 100 - (i-1)*property_tax_decline_percentage;

--- a/ssc/cmod_equpartflip.cpp
+++ b/ssc/cmod_equpartflip.cpp
@@ -1000,16 +1000,25 @@ public:
 		double om_opt_fuel_1_usage = as_double("om_opt_fuel_1_usage");
 		double om_opt_fuel_2_usage = as_double("om_opt_fuel_2_usage");
 
+        // additional o and m sub types (e.g. batteries and fuel cells)
         int add_om_num_types = as_integer("add_om_num_types");
         ssc_number_t nameplate1 = 0;
         ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
         //throw exec_error("singleowner", "Checkpoint 1");
         if (add_om_num_types > 0) //PV Battery
         {
             escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
-            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01); //$/MWh
             escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate1 = as_number("ui_batt_capacity");
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
         }
         if (add_om_num_types > 1) // PV Battery Fuel Cell
         {
@@ -1017,6 +1026,7 @@ public:
             escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
             escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
         }
 
         // battery cost - replacement from lifetime analysis
@@ -1121,6 +1131,10 @@ public:
 			cf.at(CF_om_production_expense,i) *= cf.at(CF_energy_net,i);
 			cf.at(CF_om_capacity_expense,i) *= nameplate;
 			cf.at(CF_om_fuel_expense,i) *= year1_fuel_use;
+
+            //Battery Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
 
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;

--- a/ssc/cmod_fuelcell.h
+++ b/ssc/cmod_fuelcell.h
@@ -258,6 +258,7 @@ protected:
 	ssc_number_t * p_fuelCellToLoad_kW;
 	ssc_number_t * p_fuelCellReplacements;
 	ssc_number_t * p_fuelCellConsumption_MCf_annual;
+    ssc_number_t * p_fuelCellAnnualEnergy;
 };
 
 #endif

--- a/ssc/cmod_host_developer.cpp
+++ b/ssc/cmod_host_developer.cpp
@@ -983,16 +983,25 @@ public:
 		double om_opt_fuel_1_usage = as_double("om_opt_fuel_1_usage");
 		double om_opt_fuel_2_usage = as_double("om_opt_fuel_2_usage");
 
+        // additional o and m sub types (e.g. batteries and fuel cells)
         int add_om_num_types = as_integer("add_om_num_types");
         ssc_number_t nameplate1 = 0;
         ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
         //throw exec_error("singleowner", "Checkpoint 1");
         if (add_om_num_types > 0) //PV Battery
         {
             escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
-            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01); //$/MWh
             escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate1 = as_number("ui_batt_capacity");
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
         }
         if (add_om_num_types > 1) // PV Battery Fuel Cell
         {
@@ -1000,6 +1009,7 @@ public:
             escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
             escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
         }
 
         // battery cost - replacement from lifetime analysis
@@ -1104,6 +1114,10 @@ public:
 			cf.at(CF_om_production_expense,i) *= cf.at(CF_energy_net,i);
 			cf.at(CF_om_capacity_expense,i) *= nameplate;
 			cf.at(CF_om_fuel_expense,i) *= year1_fuel_use;
+
+            //Battery Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
 
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;

--- a/ssc/cmod_levpartflip.cpp
+++ b/ssc/cmod_levpartflip.cpp
@@ -1020,16 +1020,25 @@ public:
 		double om_opt_fuel_1_usage = as_double("om_opt_fuel_1_usage");
 		double om_opt_fuel_2_usage = as_double("om_opt_fuel_2_usage");
 
+        // additional o and m sub types (e.g. batteries and fuel cells)
         int add_om_num_types = as_integer("add_om_num_types");
         ssc_number_t nameplate1 = 0;
         ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
         //throw exec_error("singleowner", "Checkpoint 1");
         if (add_om_num_types > 0) //PV Battery
         {
             escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
-            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01); //$/MWh
             escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate1 = as_number("ui_batt_capacity");
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
         }
         if (add_om_num_types > 1) // PV Battery Fuel Cell
         {
@@ -1037,6 +1046,7 @@ public:
             escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
             escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
         }
 		
         // battery cost - replacement from lifetime analysis
@@ -1143,6 +1153,10 @@ public:
 			cf.at(CF_om_production_expense,i) *= cf.at(CF_energy_net,i);
 			cf.at(CF_om_capacity_expense,i) *= nameplate;
 			cf.at(CF_om_fuel_expense,i) *= year1_fuel_use;
+
+            //Battery Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
 
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;

--- a/ssc/cmod_merchantplant.cpp
+++ b/ssc/cmod_merchantplant.cpp
@@ -1037,17 +1037,25 @@ public:
 		double om_opt_fuel_1_usage = as_double("om_opt_fuel_1_usage");
 		double om_opt_fuel_2_usage = as_double("om_opt_fuel_2_usage");
 
-		// additional o and m sub types (e.g. batteries and fuel cells)
-		int add_om_num_types = as_integer("add_om_num_types");
-		ssc_number_t nameplate1 = 0;
-		ssc_number_t nameplate2 = 0;
-
+        // additional o and m sub types (e.g. batteries and fuel cells)
+        int add_om_num_types = as_integer("add_om_num_types");
+        ssc_number_t nameplate1 = 0;
+        ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
+        //throw exec_error("singleowner", "Checkpoint 1");
         if (add_om_num_types > 0) //PV Battery
         {
             escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
-            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01); //$/MWh
             escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate1 = as_number("ui_batt_capacity");
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
         }
         if (add_om_num_types > 1) // PV Battery Fuel Cell
         {
@@ -1055,6 +1063,7 @@ public:
             escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
             escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
         }
 
 

--- a/ssc/cmod_merchantplant.cpp
+++ b/ssc/cmod_merchantplant.cpp
@@ -1306,6 +1306,10 @@ public:
 			cf.at(CF_om_capacity2_expense, i) *= nameplate2;
 			cf.at(CF_om_fuel_expense,i) *= fuel_use[i];
 
+            //Battery Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
+
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;
 		}

--- a/ssc/cmod_saleleaseback.cpp
+++ b/ssc/cmod_saleleaseback.cpp
@@ -1029,16 +1029,25 @@ public:
 		double om_opt_fuel_1_usage = as_double("om_opt_fuel_1_usage");
 		double om_opt_fuel_2_usage = as_double("om_opt_fuel_2_usage");
 
+        // additional o and m sub types (e.g. batteries and fuel cells)
         int add_om_num_types = as_integer("add_om_num_types");
         ssc_number_t nameplate1 = 0;
         ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
         //throw exec_error("singleowner", "Checkpoint 1");
         if (add_om_num_types > 0) //PV Battery
         {
             escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal") * 0.01);
-            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
+            escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01); //$/MWh
             escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate1 = as_number("ui_batt_capacity");
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
         }
         if (add_om_num_types > 1) // PV Battery Fuel Cell
         {
@@ -1046,6 +1055,7 @@ public:
             escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal") * 0.01);
             escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal") * 0.01);
             nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
         }
 
 		
@@ -1153,6 +1163,10 @@ public:
 			cf.at(CF_om_production_expense,i) *= cf.at(CF_energy_net,i);
 			cf.at(CF_om_capacity_expense,i) *= nameplate;
 			cf.at(CF_om_fuel_expense,i) *= year1_fuel_use;
+
+            //Battery, Fuel Cell Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
 
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;

--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -1055,6 +1055,11 @@ public:
 		ssc_number_t nameplate1 = 0;
 		ssc_number_t nameplate2 = 0;
         std::vector<double> battery_discharged;
+        std::vector<double> fuelcell_discharged;
+        for (int i = 0; i <= nyears; i++) {
+            battery_discharged.push_back(0);
+            fuelcell_discharged.push_back(0);
+        }
         //throw exec_error("singleowner", "Checkpoint 1");
 		if (add_om_num_types > 0) //PV Battery
 		{
@@ -1064,10 +1069,6 @@ public:
 			nameplate1 = as_number("ui_batt_capacity");
             if (as_integer("en_batt") == 1)
                 battery_discharged = as_vector_double("batt_annual_discharge_energy");
-            else
-                for (int i = 0; i < nyears; i++) {
-                    battery_discharged[i] = 0;
-                }
 		}
 		if (add_om_num_types > 1) // PV Battery Fuel Cell
 		{
@@ -1075,6 +1076,7 @@ public:
 			escal_or_annual(CF_om_production2_expense, nyears, "om_fuelcell_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal")*0.01);
 			escal_or_annual(CF_om_capacity2_expense, nyears, "om_fuelcell_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal")*0.01);
 			nameplate2 = as_number("ui_fuelcell_capacity");
+            fuelcell_discharged = as_vector_double("fuelcell_annual_energy_discharged");
 		}
 
 
@@ -1377,7 +1379,7 @@ public:
 
             //Battery Production OM Costs
             cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
-            
+            cf.at(CF_om_production2_expense, i) *= fuelcell_discharged[i];
 
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;

--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -884,7 +884,8 @@ enum {
 
     CF_energy_without_battery,
 
-	
+	CF_battery_discharged,
+    CF_fuelcell_discharged,
 
     CF_energy_charged_grid,
     CF_energy_charged_pv,
@@ -1053,13 +1054,20 @@ public:
 		int add_om_num_types = as_integer("add_om_num_types");
 		ssc_number_t nameplate1 = 0;
 		ssc_number_t nameplate2 = 0;
+        std::vector<double> battery_discharged;
         //throw exec_error("singleowner", "Checkpoint 1");
 		if (add_om_num_types > 0) //PV Battery
 		{
 			escal_or_annual(CF_om_fixed1_expense, nyears, "om_batt_fixed_cost", inflation_rate, 1.0, false, as_double("om_fixed_escal")*0.01);
-			escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 1.0, false, as_double("om_production_escal")*0.01);
+			escal_or_annual(CF_om_production1_expense, nyears, "om_batt_variable_cost", inflation_rate, 0.001, false, as_double("om_production_escal")*0.01); //$/MWh
 			escal_or_annual(CF_om_capacity1_expense, nyears, "om_batt_capacity_cost", inflation_rate, 1.0, false, as_double("om_capacity_escal")*0.01);
 			nameplate1 = as_number("ui_batt_capacity");
+            if (as_integer("en_batt") == 1)
+                battery_discharged = as_vector_double("batt_annual_discharge_energy");
+            else
+                for (int i = 0; i < nyears; i++) {
+                    battery_discharged[i] = 0;
+                }
 		}
 		if (add_om_num_types > 1) // PV Battery Fuel Cell
 		{
@@ -1351,7 +1359,7 @@ public:
 		m_disp_calcs.init(this, degrade_cf, hourly_energy_calcs.hourly_energy());
 		// end of energy and dispatch initialization
 
-
+       
 
 		for (i=1;i<=nyears;i++)
 		{
@@ -1366,6 +1374,10 @@ public:
 			cf.at(CF_om_capacity1_expense, i) *= nameplate1;
 			cf.at(CF_om_capacity2_expense, i) *= nameplate2;
 			cf.at(CF_om_fuel_expense,i) *= fuel_use[i];
+
+            //Battery Production OM Costs
+            cf.at(CF_om_production1_expense, i) *= battery_discharged[i]; //$/MWh * 0.001 MWh/kWh * kWh = $
+            
 
 			cf.at(CF_om_opt_fuel_1_expense,i) *= om_opt_fuel_1_usage;
 			cf.at(CF_om_opt_fuel_2_expense,i) *= om_opt_fuel_2_usage;

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -128,6 +128,8 @@ var_info vtab_oandm[] = {
 { SSC_INPUT,SSC_ARRAY   , "om_fuelcell_fixed_cost"                            , "Fuel cell fixed System Costs annual amount"                     , "$/year"                                 , ""                                      , "System Costs"         , "?=0.0"          , ""                      , ""},
 { SSC_INPUT,SSC_ARRAY   , "om_fuelcell_variable_cost"                       , "Fuel cell production-based System Costs amount"                 , "$/MWh"                                  , ""                                      , "System Costs"         , "?=0.0"          , ""                      , ""},
 { SSC_INPUT,SSC_ARRAY   , "om_fuelcell_capacity_cost"                         , "Fuel cell capacity-based System Costs amount"                   , "$/kWcap"                                , ""                                      , "System Costs"         , "?=0.0"          , ""                      , ""},
+{ SSC_INPUT, SSC_ARRAY,   "fuelcell_annual_energy_discharged",  "Annual energy from fuelcell",    "kWh",        "",                 "System Costs",                  "?=0",                        "",                              "" },
+
 var_info_invalid };
 
 var_info vtab_equip_reserve[] = {

--- a/ssc/common_financial.cpp
+++ b/ssc/common_financial.cpp
@@ -3597,13 +3597,11 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
             //cf.at(CF_charging_cost_grid, a) = charged_grid[a] * 10 / 100; //using 0.10 $/kWh as a placeholder
             if (cm->as_integer("system_use_lifetime_output") == 1 && a != 0) { //Lifetime
                 cf.at(CF_charging_cost_pv_lcos, a) = charged_pv[a] * lcoe_real_lcos / 100 * pow(1 + inflation_rate, a - 1); //Calculate system charging cost from year a system charged amount ($)
-                cf.at(CF_om_production1_expense_lcos, a) *= lcos_energy_discharged[a];
                 cf.at(CF_energy_discharged_lcos, a) = lcos_energy_discharged[a];
 
             }
             else if (cm->as_integer("system_use_lifetime_output") != 1 && a != 0) { //Not lifetime
                 cf.at(CF_charging_cost_pv_lcos, a) = charged_pv[0] * cf.at(CF_degradation_lcos, a) * lcoe_real_lcos / 100 * pow(1 + inflation_rate, a - 1); //Calculate system charging cost from year 1 sytem charged amount ($) (Probably need to account for degradation)
-                cf.at(CF_om_production1_expense_lcos, a) *= lcos_energy_discharged[0] * cf.at(CF_degradation_lcos, a); //Scale om production expense by amount discharged in year 1 ($) account for degradation
                 cf.at(CF_energy_discharged_lcos, a) = lcos_energy_discharged[0] * cf.at(CF_degradation_lcos, a); //Store energy discharged in year 1 to each year of the cash flow
             }
             cf.at(CF_annual_cost_lcos_lcos, a) = -cf.at(CF_charging_cost_grid_lcos, a) + //Grid charging cost +


### PR DESCRIPTION
-Added 0.001 scaling for om_batt_variable_cost and om_fuelcell_variable_cost to use $/MWh inputs from GUI
-Added calculations for annual variable production costs based on battery annual discharged energy and new fuelcell annual energy out variable
-Removed cost by energy calculations for battery variable OM costs from LCOS calculations to pass already calculated cash flow from financial models instead
-Changes carried over to all financial models