### PR TITLE
update price signals lifetime test value due to cycle degradation changes

### DIFF
--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -902,7 +902,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialDCBatteryModelPriceS
         auto batt_q_rel = data_vtab->as_vector_ssc_number_t("batt_capacity_percent");
         auto batt_cyc_avg = data_vtab->as_vector_ssc_number_t("batt_DOD_cycle_average");
         EXPECT_NEAR(batt_q_rel.back(), 98.034, 2e-2);
-        EXPECT_NEAR(batt_cyc_avg.back(), 27.31, 0.2);
+        EXPECT_NEAR(batt_cyc_avg.back(), 27.1, 0.5);
     }
 }
 

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -902,7 +902,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialDCBatteryModelPriceS
         auto batt_q_rel = data_vtab->as_vector_ssc_number_t("batt_capacity_percent");
         auto batt_cyc_avg = data_vtab->as_vector_ssc_number_t("batt_DOD_cycle_average");
         EXPECT_NEAR(batt_q_rel.back(), 98.034, 2e-2);
-        EXPECT_NEAR(batt_cyc_avg.back(), 27.00, 0.2);
+        EXPECT_NEAR(batt_cyc_avg.back(), 27.31, 0.2);
     }
 }
 


### PR DESCRIPTION
Follow on to https://github.com/NREL/ssc/pull/611 - the Windows value got out of tolerance with the changes, but it didn't fail the PR since the Linux value was still within tolerance.