### PR TITLE
Move batt stateful sizing to ssc equations

### DIFF
--- a/ssc/CMakeLists.txt
+++ b/ssc/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SSC_SRC
 		cmod_annualoutput.cpp
 		cmod_battery.cpp
 		cmod_battery.h
+		cmod_battery_eqns.cpp
+		cmod_battery_eqns.h
         cmod_battery_stateful.cpp
         cmod_battery_stateful.h
 		cmod_battwatts.cpp

--- a/ssc/cmod_battery_eqns.cpp
+++ b/ssc/cmod_battery_eqns.cpp
@@ -1,0 +1,80 @@
+/**
+BSD-3-Clause
+Copyright 2019 Alliance for Sustainable Energy, LLC
+Redistribution and use in source and binary forms, with or without modification, are permitted provided
+that the following conditions are met :
+1.	Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3.	Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDER, CONTRIBUTORS, UNITED STATES GOVERNMENT OR UNITED STATES
+DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "cmod_battery_eqns.h"
+
+#include "vartab.h"
+
+#include <cmath>
+
+void Size_batterystateful(ssc_data_t data) {
+    auto vt = static_cast<var_table*>(data);
+    if (!vt) {
+        throw std::runtime_error("ssc_data_t data invalid");
+    }
+
+    double nominal_energy, desired_voltage, desired_capacity;
+
+    vt_get_number(vt, "nominal_energy", &nominal_energy);
+    vt_get_number(vt, "desired_voltage", &desired_voltage);
+    vt_get_number(vt, "desired_capacity", &desired_capacity);
+
+    vt->assign("original_capacity", nominal_energy);
+
+    Calculate_thermal_params(data);
+
+    vt->assign("nominal_energy", desired_capacity);
+    vt->assign("nominal_voltage", desired_voltage);
+}
+
+void Calculate_thermal_params(ssc_data_t data) {
+    auto vt = static_cast<var_table*>(data);
+    if (!vt) {
+        throw std::runtime_error("ssc_data_t data invalid");
+    }
+
+    double mass, surface_area, original_capacity, desired_capacity, module_capacity, module_surface_area;
+
+    vt_get_number(vt, "mass", &mass);
+    vt_get_number(vt, "surface_area", &surface_area);
+    vt_get_number(vt, "original_capacity", &original_capacity);
+    vt_get_number(vt, "desired_capacity", &desired_capacity);
+
+    double mass_per_specific_energy = mass / original_capacity;
+
+    double volume = std::pow((surface_area / 6.0), (3.0 / 2.0));
+
+    double volume_per_specific_energy = volume / original_capacity;
+
+    mass = mass_per_specific_energy * desired_capacity;
+
+    surface_area = std::pow((volume_per_specific_energy * desired_capacity), (2.0 / 3.0)) * 6;
+
+    if (vt->is_assigned("module_capacity") && vt->is_assigned("module_surface_area")) {
+        vt_get_number(vt, "module_capacity", &module_capacity);
+        vt_get_number(vt, "module_surface_area", &module_surface_area);
+        surface_area = module_surface_area * desired_capacity / module_capacity;
+    }
+
+    vt->assign("mass", mass);
+    vt->assign("surface_area", surface_area);
+}
+

--- a/ssc/ssc_equations.h
+++ b/ssc/ssc_equations.h
@@ -2,6 +2,7 @@
 #define __ssc_eqn_h
 
 #include "sscapi.h"
+#include "cmod_battery_eqns.h"
 #include "cmod_windpower_eqns.h"
 #include "cmod_mhk_eqns.h"
 #include "cmod_merchantplant_eqns.h"
@@ -56,6 +57,20 @@ static ssc_equation_entry ssc_equation_table [] = {
             false, true},
         {"Reopt_size_battery_post", Reopt_size_battery_params,
             "Pvwattsv7", Reopt_size_battery_params_doc,
+            false, true},
+
+        // Battery
+        {"Calculate_thermal_params", Calculate_thermal_params,
+            "Battery", calculate_thermal_params_doc,
+            false, true},
+
+        // Battery stateful
+        {"Calculate_thermal_params", Calculate_thermal_params,
+            "battery_stateful", calculate_thermal_params_doc,
+            false, true},
+
+        {"Size_batterystateful", Size_batterystateful,
+            "battery_stateful", size_batterystateful_doc,
             false, true},
 
         // Wind

--- a/test/ssc_test/cmod_battery_eqns_test.cpp
+++ b/test/ssc_test/cmod_battery_eqns_test.cpp
@@ -1,0 +1,50 @@
+/**
+BSD-3-Clause
+Copyright 2019 Alliance for Sustainable Energy, LLC
+Redistribution and use in source and binary forms, with or without modification, are permitted provided
+that the following conditions are met :
+1.	Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3.	Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDER, CONTRIBUTORS, UNITED STATES GOVERNMENT OR UNITED STATES
+DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <chrono>
+
+#include "cmod_battery_eqns_test.h"
+
+#include "cmod_battery_eqns.h"
+TEST_F(CMBatteryEqns_cmod_battery_eqns, TestStatefulSizeModifications) {
+    CreateModel(1.);
+
+    ssc_data_set_number(data, "desired_voltage", 600.0); // Increase voltage from 500 V
+    ssc_data_set_number(data, "desired_capacity", 20.0); // Increase capacity from 10 kWh
+
+    Size_batterystateful(data);
+
+    EXPECT_TRUE(ssc_stateful_module_setup(mod, data));
+    EXPECT_TRUE(ssc_module_exec(mod, data));
+
+    ssc_number_t new_voltage, new_capacity, new_mass, new_surface_area;
+    ssc_data_get_number(data, "nominal_voltage", &new_voltage);
+    ssc_data_get_number(data, "nominal_energy", &new_capacity);
+    ssc_data_get_number(data, "mass", &new_mass);
+    ssc_data_get_number(data, "surface_area", &new_surface_area);
+
+    EXPECT_NEAR(600.0, new_voltage, m_error_tolerance_lo);
+    EXPECT_NEAR(20.0, new_capacity, m_error_tolerance_lo);
+    EXPECT_NEAR(1014.0, new_mass, m_error_tolerance_lo);
+    EXPECT_NEAR(3.2033, new_surface_area, m_error_tolerance_lo);
+}
+

--- a/test/ssc_test/cmod_battery_eqns_test.h
+++ b/test/ssc_test/cmod_battery_eqns_test.h
@@ -1,0 +1,58 @@
+/**
+BSD-3-Clause
+Copyright 2019 Alliance for Sustainable Energy, LLC
+Redistribution and use in source and binary forms, with or without modification, are permitted provided
+that the following conditions are met :
+1.	Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3.	Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDER, CONTRIBUTORS, UNITED STATES GOVERNMENT OR UNITED STATES
+DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#ifndef SAM_SIMULATION_CORE_CMOD_BATTERY_EQNS_TEST_H
+#define SAM_SIMULATION_CORE_CMOD_BATTERY_EQNS_TEST_H
+
+#include <gtest/gtest.h>
+#include "core.h"
+
+#include "vartab.h"
+
+class CMBatteryEqns_cmod_battery_eqns : public ::testing::Test {
+
+public:
+
+    ssc_data_t data;
+    ssc_module_t mod;
+    std::string params_str;
+    double m_error_tolerance_hi = 0.1;
+    double m_error_tolerance_lo = 0.0001;
+
+    void CreateModel(double dt_hour = 1.) {
+        params_str = R"({ "control_mode": 0, "input_current": 1, "chem": 1, "nominal_energy": 10, "nominal_voltage": 500, "qmax_init": 1000.000, "initial_SOC": 50.000, "maximum_SOC": 95.000, "minimum_SOC": 5.000, "dt_hr": 1.000, "leadacid_tn": 0.000, "leadacid_qn": 0.000, "leadacid_q10": 0.000, "leadacid_q20": 0.000, "voltage_choice": 0, "Vnom_default": 3.600, "resistance": 0.000, "Vfull": 4.100, "Vexp": 4.050, "Vnom": 3.400, "Vcut": 2.706, "Qfull": 2.250, "Qexp": 0.040, "Qnom": 2.000, "C_rate": 0.200, "mass": 507.000, "surface_area": 2.018, "Cp": 1004.000, "h": 20.000, "cap_vs_temp": [ [ -10, 60 ], [ 0, 80 ], [ 25, 1E+2 ], [ 40, 1E+2 ] ], "option": 1, "T_room_init": 20, "life_model": 0, "cycling_matrix": [ [ 20, 0, 1E+2 ], [ 20, 5E+3, 80 ], [ 20, 1E+4, 60 ], [ 80, 0, 1E+2 ], [ 80, 1E+3, 80 ], [ 80, 2E+3, 60 ] ], "calendar_choice": 1, "calendar_q0": 1.020, "calendar_a": 0.003, "calendar_b": -7280.000, "calendar_c": 930.000, "calendar_matrix": [ [ -3.1E+231 ] ], "loss_choice": 0, "monthly_charge_loss": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], "monthly_discharge_loss": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], "monthly_idle_loss": [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], "schedule_loss": [], "replacement_option": 0, "replacement_capacity": 0.000, "replacement_schedule": [], "replacement_schedule_percent": [], "analysis_period": 1, "load_escalation": [0]})";
+        data = json_to_ssc_data(params_str.c_str());
+        ssc_data_set_number(data, "dt_hr", dt_hour);
+        mod = ssc_module_create("battery_stateful");
+        EXPECT_TRUE(ssc_stateful_module_setup(mod, data));
+    }
+
+    void TearDown() override {
+        ssc_data_free(data);
+        ssc_module_free(mod);
+    }
+
+};
+
+
+#endif //SAM_SIMULATION_CORE_CMOD_BATTERY_EQNS_TEST_H


### PR DESCRIPTION
Convert two functions currently in pysam's battery tools to ssc equations such that they can be used by the API in all languages.

Future pull requests will add additional cmod_battery functions.