### PR TITLE
add tolerance to grid charging check to allow for floating point issues

### DIFF
--- a/shared/lib_battery_powerflow.cpp
+++ b/shared/lib_battery_powerflow.cpp
@@ -469,7 +469,7 @@ void BatteryPowerFlow::calculateACConnected()
 
     // Error checking trying to charge from grid when not allowed
     if (!m_BatteryPower->canGridCharge && P_battery_ac < -tolerance) {
-        if ((fabs(P_grid_ac - P_grid_to_load_ac) > tolerance) && (-P_grid_ac > P_grid_to_load_ac)) {
+        if ((fabs(P_grid_ac - P_grid_to_load_ac) > tolerance) && (-P_grid_ac > P_grid_to_load_ac + tolerance)) {
             P_battery_ac = P_pv_ac - P_pv_to_grid_ac - P_pv_to_load_ac - P_system_loss_ac;
             P_battery_ac = P_battery_ac > 0 ? P_battery_ac : 0; // Don't swap from charging to discharging
             m_BatteryPower->powerBatteryDC = -P_battery_ac * m_BatteryPower->singlePointEfficiencyACToDC;


### PR DESCRIPTION
A floating point error (~1e-15) was causing a stack overflow in the powerflow code. Add a tolerance to fix the issue.

![floating_point_stack_overflow](https://user-images.githubusercontent.com/5530592/135140033-32ce2dec-f088-4742-9736-219ffc3e1f1a.png)

Alternative fix would be to set gen to zero if it's smaller than some tolerance. I think "tolerance" in the powerflow code is too high for this approach, I'd want 1e-7 or smaller for this approach.

Test with
[Test_Case.zip](https://github.com/NREL/ssc/files/7246382/Test_Case.zip)
 