### PR TITLE
Fix SSC 621 - cycle degradation penalty is nan or zero

### DIFF
--- a/shared/lib_battery_lifetime_lmolto.cpp
+++ b/shared/lib_battery_lifetime_lmolto.cpp
@@ -182,5 +182,5 @@ void lifetime_lmolto_t::replaceBattery(double percent_to_replace) {
 }
 
 double lifetime_lmolto_t::estimateCycleDamage() {
-    return state->lmo_lto->dq_relative_cyc / (double)state->n_cycles;
+    return state->lmo_lto->dq_relative_cyc / fmax(1.0, (double)state->n_cycles);
 }

--- a/shared/lib_battery_lifetime_nmc.cpp
+++ b/shared/lib_battery_lifetime_nmc.cpp
@@ -229,8 +229,8 @@ void lifetime_nmc_t::runLifetimeModels(size_t _, bool charge_changed, double pre
 
 double lifetime_nmc_t::estimateCycleDamage() {
     // Use cumulative damage from cycling and average it over elapsed cycles
-    double QLi_cycle_damage = state->nmc_li_neg->dq_relative_li2 / (double)state->n_cycles;
-    double QNeg_cycle_damage = state->nmc_li_neg->dq_relative_neg / (double)state->n_cycles;
+    double QLi_cycle_damage = state->nmc_li_neg->dq_relative_li2 / fmax(1.0, (double)state->n_cycles); // fmax eliminates divide by zero error on first cycle
+    double QNeg_cycle_damage = state->nmc_li_neg->dq_relative_neg / fmax(1.0, (double)state->n_cycles);
     return fmax(QLi_cycle_damage, QNeg_cycle_damage) * 100;
 }
 

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -191,6 +191,9 @@ var_info vtab_battery_inputs[] = {
 
     { SSC_INPUT,        SSC_NUMBER,     "inflation_rate",                              "Inflation rate",                                          "%", "", "Lifetime", "?=0", "MIN=-99", "" },
     { SSC_INPUT,        SSC_ARRAY,      "load_escalation",                             "Annual load escalation",                                  "%/year", "",                                                                                                                                                                                      "Load",                                               "?=0",                                "",                    "" },
+    { SSC_INPUT,        SSC_ARRAY,      "om_batt_replacement_cost"                 , "Replacement cost 1"                                             , "$/kWh"                                  , ""                                      , "System Costs"         , "?=0.0"          , ""                      , "" },
+    { SSC_INPUT,        SSC_NUMBER,     "om_replacement_cost_escal"            , "Replacement cost escalation"                                    , "%/year"                                 , ""                                      , "System Costs"         , "?=0.0"          , ""                      , "" },
+
 
     // Powerflow calculation inputs
     { SSC_INPUT,       SSC_ARRAY,       "fuelcell_power",                               "Electricity from fuel cell",                            "kW",       "",                     "FuelCell",     "",                           "",                         "" },
@@ -470,8 +473,13 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
                 ssc_number_t*  parr = vt.as_array("om_batt_replacement_cost", &cnt);
                 if (cnt == 1)
                 {
+                    double escal = 0.0;
+                    if (vt.is_assigned("om_replacement_cost_escal")) {
+                        escal = vt.as_double("om_replacement_cost_escal");
+                    }
+
                     for (i = 0; i < nyears; i++)
-                        replacement_cost[i] = parr[0] * (ssc_number_t)pow((double)(inflation_rate + 1), (double)i);
+                        replacement_cost[i] = parr[0] * (ssc_number_t)pow((double)(inflation_rate + escal + 1), (double)i);
                 }
                 else if (cnt < nyears)
                 {


### PR DESCRIPTION
* restore o&m variables to battery vartable for algorithms that compute cycle degradation.
* prevent divide by zero errors for new degradation algorithms

#621