### PR TITLE
Fixed utilityrate to check for hourly buy rates 

### DIFF
--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -2306,6 +2306,7 @@ public:
                                     if (c < rate.m_ec_ts_buy_rate.size()) {
                                         tier_energy = energy_deficit;
                                         br = rate.m_ec_ts_buy_rate[c];
+                                        tier_charge = tier_energy * br * rate_esc;
                                         charge_amt = tier_energy * br * rate_esc;
                                         curr_month.ec_energy_use.at(row, deficit_tier) += (ssc_number_t)tier_energy;
                                         curr_month.ec_charge.at(row, deficit_tier) += (ssc_number_t)charge_amt;


### PR DESCRIPTION
-ur_calc_timestep updates tier_charge within hourly buy rates loop to avoid falling back on TOU rates
-Closes  https://github.com/NREL/SAM/issues/736