### PR TITLE
Added optional override for max number of turbines

### DIFF
--- a/shared/lib_windwatts.cpp
+++ b/shared/lib_windwatts.cpp
@@ -136,10 +136,11 @@ windPowerCalculator::windPowerUsingResource(double windSpeed, double windDirDeg,
 
 	size_t i, j;
 	//unsigned char wt_id[MAX_WIND_TURBINES], wid; // unsigned char has 256 limit
-	size_t wt_id[MAX_WIND_TURBINES], wid;
+    size_t wid;
+	std::vector<size_t> wt_id;
 
 	for (i = 0; i<nTurbines; i++)
-		wt_id[i] = i;
+		wt_id.push_back(i);
 
 	// convert barometric pressure in ATM to air density
 	double fAirDensity = (airPressureAtm * physics::Pa_PER_Atm) / (physics::R_GAS_DRY_AIR * physics::CelciusToKelvin(TdryC));   //!Air Density, kg/m^3
@@ -365,10 +366,11 @@ bool windPowerCalculator::windPowerUsingDistribution(std::vector<std::vector<dou
 
     size_t i, j;
     //unsigned char wt_id[MAX_WIND_TURBINES], wid; // unsigned char has 256 limit
-    size_t wt_id[MAX_WIND_TURBINES], wid;
+    size_t wid;
+    std::vector<size_t> wt_id;
 
     for (i = 0; i<nTurbines; i++)
-        wt_id[i] = i;
+        wt_id.push_back(i);
 
 
     double freq_total = 0.0, farmpower = 0.0, farmgross = 0.0;

--- a/shared/lib_windwatts.h
+++ b/shared/lib_windwatts.h
@@ -52,7 +52,8 @@ private:
 public:
 	windTurbine* windTurb;
 	size_t nTurbines;
-	double turbulenceIntensity;	
+	double turbulenceIntensity;
+    int MAX_WIND_TURBINES = 300;
 	windPowerCalculator() {
 		//m_dShearExponent = 1.0/7.0;
 		// check classes are initialized
@@ -61,7 +62,6 @@ public:
 		errDetails="";
 	}
 	
-	static const int MAX_WIND_TURBINES = 300;	// Max turbines in the farm
 	static const int MIN_DIAM_EV = 2;			// Minimum number of rotor diameters between turbines for EV wake modeling to work
 	static const int EV_SCALE = 1;				// Uo or 1.0 depending on how you read Ainslie 1988
 
@@ -73,6 +73,7 @@ public:
 	std::vector<double> XCoords, YCoords;
 
 	size_t GetMaxTurbines() {return MAX_WIND_TURBINES;}
+    void SetMaxTurbines(int x) { MAX_WIND_TURBINES = x; }
 	bool InitializeModel(std::shared_ptr<wakeModelBase>selectedWakeModel);
 	std::string GetWakeModelName();
 	std::string GetErrorDetails() { return errDetails; }

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -50,6 +50,7 @@ static var_info _cm_vtab_windpower[] = {
 	{ SSC_INPUT  , SSC_NUMBER , "system_capacity"                    , "Nameplate capacity"                       , "kW"      ,""                                    , "Farm"                                 , "*"                                               , "MIN=0"                                           , "" } ,
 	{ SSC_INPUT  , SSC_ARRAY  , "wind_farm_xCoordinates"             , "Turbine X coordinates"                    , "m"       ,""                                    , "Farm"                                 , "*"                                               , ""                                                , "" } ,
 	{ SSC_INPUT  , SSC_ARRAY  , "wind_farm_yCoordinates"             , "Turbine Y coordinates"                    , "m"       ,""                                    , "Farm"                                 , "*"                                               , "LENGTH_EQUAL=wind_farm_xCoordinates"             , "" } ,
+    { SSC_INPUT  , SSC_NUMBER , "max_turbine_override"               , "Override the max number of turbines for wake modeling","numTurbines","set new max num turbines","Farm"                                , ""                                                , ""                                                , "" } ,
 
 	{ SSC_INPUT  , SSC_NUMBER , "en_low_temp_cutoff"                 , "Enable Low Temperature Cutoff"            , "0/1"     ,""                                    , "Losses"                               , "?=0"                                             , "INTEGER"                                         , "" } ,
 	{ SSC_INPUT  , SSC_NUMBER , "low_temp_cutoff"                    , "Low Temperature Cutoff"                   , "C"       ,""                                    , "Losses"                               , "en_low_temp_cutoff=1"                            , ""                                                , "" } ,
@@ -280,6 +281,14 @@ void cm_windpower::exec()
 		throw exec_error("windpower", util::format("wind turbine class not properly initialized"));
 	if (wpc.nTurbines < 1)
 		throw exec_error("windpower", util::format("the number of wind turbines was zero."));
+
+    // check for maximum number of turbines
+    int newMaxTurbines = 0;
+    if (is_assigned("max_turbine_override"))
+    {
+        newMaxTurbines = as_integer("max_turbine_override");
+        wpc.SetMaxTurbines(newMaxTurbines);
+    }
 	if (wpc.nTurbines > wpc.GetMaxTurbines())
 		throw exec_error("windpower", util::format("the wind model is only configured to handle up to %d turbines.", wpc.GetMaxTurbines()));
 

--- a/test/ssc_test/cmod_windpower_test.cpp
+++ b/test/ssc_test/cmod_windpower_test.cpp
@@ -361,6 +361,30 @@ TEST_F(CMWindPowerIntegration, IcingAndLowTempCutoff_cmod_windpower) {
     free_winddata_array(windresourcedata);
 }
 
+/// Override for number of wind turbines with wake model
+TEST_F(CMWindPowerIntegration, WakeModelMaxTurbineOverride) {
+    // set up 301 turbines
+    ssc_number_t xcoord[301];
+    ssc_number_t ycoord[301];
+    for (int i = 0; i < 301; i++) {
+        double x = i % 20;
+        xcoord[i] = (ssc_number_t)x;
+        double y = floor(i / 30);
+        ycoord[i] = (ssc_number_t)y;
+    }
+    ssc_data_set_array(data, "wind_farm_xCoordinates", xcoord, 301);
+    ssc_data_set_array(data, "wind_farm_yCoordinates", ycoord, 301);
+
+    // should fail with an error for 301 turbines
+    int errors = windpower_nofinancial_testfile(data);
+    EXPECT_TRUE(errors);
+
+    ssc_number_t annual_energy;
+    ssc_data_get_number(data, "annual_energy", &annual_energy);
+    EXPECT_NEAR(annual_energy, 31081848, e) << "Eddy";
+}
+
+
 /// Testing Turbine powercurve calculation
 TEST(Turbine_powercurve_cmod_windpower_eqns, NoData) {
     ASSERT_FALSE(Turbine_calculate_powercurve(nullptr));

--- a/test/ssc_test/cmod_windpower_test.cpp
+++ b/test/ssc_test/cmod_windpower_test.cpp
@@ -376,12 +376,12 @@ TEST_F(CMWindPowerIntegration, WakeModelMaxTurbineOverride) {
     ssc_data_set_array(data, "wind_farm_yCoordinates", ycoord, 310);
 
     // should fail with an error for 310 turbines
-    int errors = windpower_nofinancial_testfile(data);
-    EXPECT_TRUE(errors);
+    ssc_module_t module = ssc_module_create("windpower");
+    ASSERT_FALSE(ssc_module_exec(module, data));
 
-    ssc_number_t annual_energy;
+    /*ssc_number_t annual_energy;
     ssc_data_get_number(data, "annual_energy", &annual_energy);
-    EXPECT_NEAR(annual_energy, 31081848, e) << "Eddy";
+    EXPECT_NEAR(annual_energy, 31081848, e) << "Eddy";*/
 }
 
 

--- a/test/ssc_test/cmod_windpower_test.cpp
+++ b/test/ssc_test/cmod_windpower_test.cpp
@@ -363,19 +363,19 @@ TEST_F(CMWindPowerIntegration, IcingAndLowTempCutoff_cmod_windpower) {
 
 /// Override for number of wind turbines with wake model
 TEST_F(CMWindPowerIntegration, WakeModelMaxTurbineOverride) {
-    // set up 301 turbines
-    ssc_number_t xcoord[301];
-    ssc_number_t ycoord[301];
-    for (int i = 0; i < 301; i++) {
+    // set up 310 turbines
+    ssc_number_t xcoord[310];
+    ssc_number_t ycoord[310];
+    for (int i = 0; i < 310; i++) {
         double x = i % 20;
         xcoord[i] = (ssc_number_t)x;
         double y = floor(i / 30);
         ycoord[i] = (ssc_number_t)y;
     }
-    ssc_data_set_array(data, "wind_farm_xCoordinates", xcoord, 301);
-    ssc_data_set_array(data, "wind_farm_yCoordinates", ycoord, 301);
+    ssc_data_set_array(data, "wind_farm_xCoordinates", xcoord, 310);
+    ssc_data_set_array(data, "wind_farm_yCoordinates", ycoord, 310);
 
-    // should fail with an error for 301 turbines
+    // should fail with an error for 310 turbines
     int errors = windpower_nofinancial_testfile(data);
     EXPECT_TRUE(errors);
 

--- a/test/ssc_test/cmod_windpower_test.cpp
+++ b/test/ssc_test/cmod_windpower_test.cpp
@@ -379,9 +379,12 @@ TEST_F(CMWindPowerIntegration, WakeModelMaxTurbineOverride) {
     ssc_module_t module = ssc_module_create("windpower");
     ASSERT_FALSE(ssc_module_exec(module, data));
 
-    /*ssc_number_t annual_energy;
+    // set new override input and test that it works
+    ssc_data_set_number(data, "max_turbine_override", 315);
+    ssc_module_exec(module, data);
+    ssc_number_t annual_energy;
     ssc_data_get_number(data, "annual_energy", &annual_energy);
-    EXPECT_NEAR(annual_energy, 31081848, e) << "Eddy";*/
+    EXPECT_NEAR(annual_energy, 31636868.6, 1) << "Turbine override";
 }
 
 


### PR DESCRIPTION
The wind wake models would previously throw an error if >300 turbines were specified. Added an optional input to the SDK only, "max_turbine_override", that allows a user to specify a new number of maximum turbines. Added an associated test. All wind tests are passing with these changes. Fixes #628 .