### PR TITLE
Change warnings about negative calculated irradiance to notices

### DIFF
--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -471,7 +471,7 @@ public:
 		double surfaceAzimuthDegrees; /// The azimuth of the subarray after tracking [degrees]
 		double nonlinearDCShadingDerate; /// The DC loss due to non-linear shading [%]
 		bool usePOAFromWF;     /// Flag indicating whether or not to use POA input from the weatherfile
-		int poaShadWarningCount; /// A counter to track warnings related to POA
+		int poaShadWarningCount = 0; /// A counter to track warnings related to POA
 		std::unique_ptr<poaDecompReq> poaAll; /// A structure containing POA decompositions into the three irrradiance components from input POA
 	} poa;
 

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -472,6 +472,9 @@ public:
 		double nonlinearDCShadingDerate; /// The DC loss due to non-linear shading [%]
 		bool usePOAFromWF;     /// Flag indicating whether or not to use POA input from the weatherfile
 		int poaShadWarningCount; /// A counter to track warnings related to POA
+        int poaDecompBeamWarningCount; /// A counter to track warnings for calculated negative beam irradiance
+        int poaDecompDiffWarningCount; /// A counter to track warnings for calculated negative diffuse irradiance
+        int poaDecompGlobWarningCount; /// A counter to track warnings for calculated negative global irradiance
 		std::unique_ptr<poaDecompReq> poaAll; /// A structure containing POA decompositions into the three irrradiance components from input POA
 	} poa;
 

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -472,9 +472,6 @@ public:
 		double nonlinearDCShadingDerate; /// The DC loss due to non-linear shading [%]
 		bool usePOAFromWF;     /// Flag indicating whether or not to use POA input from the weatherfile
 		int poaShadWarningCount; /// A counter to track warnings related to POA
-        int poaDecompBeamWarningCount; /// A counter to track warnings for calculated negative beam irradiance
-        int poaDecompDiffWarningCount; /// A counter to track warnings for calculated negative diffuse irradiance
-        int poaDecompGlobWarningCount; /// A counter to track warnings for calculated negative global irradiance
 		std::unique_ptr<poaDecompReq> poaAll; /// A structure containing POA decompositions into the three irrradiance components from input POA
 	} poa;
 

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1339,13 +1339,13 @@ void cm_pvsamv1::exec()
 
                 if (code == 40)
                     log(util::format("POA decomposition model calculated negative direct normal irradiance at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
-                        wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_WARNING, (float)idx);
+                        wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_NOTICE, (float)idx);
                 else if (code == 41)
                     log(util::format("POA decomposition model calculated negative diffuse horizontal irradiance at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
-                        wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_WARNING, (float)idx);
+                        wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_NOTICE, (float)idx);
                 else if (code == 42)
                     log(util::format("POA decomposition model calculated negative global horizontal irradiance at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
-                        wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_WARNING, (float)idx);
+                        wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_NOTICE, (float)idx);
 
                 // p_irrad_calc is only weather file records long...
                 if (iyear == 0)
@@ -1415,7 +1415,7 @@ void cm_pvsamv1::exec()
                         if (Irradiance->p_IrradianceCalculated[2][idx] < -1)
                         {
                             log(util::format("Calculated negative beam irradiance of %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], set to zero.",
-                                Irradiance->p_IrradianceCalculated[2][idx], wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_WARNING, (float)idx);
+                                Irradiance->p_IrradianceCalculated[2][idx], wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_NOTICE, (float)idx);
                             Irradiance->p_IrradianceCalculated[2][idx] = 0;
                         }
                     }
@@ -1427,7 +1427,7 @@ void cm_pvsamv1::exec()
                         if (Irradiance->p_IrradianceCalculated[0][idx] < -1)
                         {
                             log(util::format("Calculated negative global horizontal irradiance of %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
-                                Irradiance->p_IrradianceCalculated[0][idx], wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_WARNING, (float)idx);
+                                Irradiance->p_IrradianceCalculated[0][idx], wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_NOTICE, (float)idx);
                             Irradiance->p_IrradianceCalculated[0][idx] = 0;
                         }
                     }
@@ -1439,7 +1439,7 @@ void cm_pvsamv1::exec()
                         if (Irradiance->p_IrradianceCalculated[1][idx] < -1)
                         {
                             log(util::format("Calculated negative diffuse horizontal irradiance of %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
-                                Irradiance->p_IrradianceCalculated[1][idx], wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_WARNING, (float)idx);
+                                Irradiance->p_IrradianceCalculated[1][idx], wf.year, wf.month, wf.day, wf.hour, wf.minute), SSC_NOTICE, (float)idx);
                             Irradiance->p_IrradianceCalculated[1][idx] = 0;
                         }
                     }


### PR DESCRIPTION
This PR changes the way that we report errors about negative calculated irradiances from warnings to notices. Reporting these as warnings can cause SAM to crash because there are so many instances. This fixes NREL/SAM#610 and fixes NREL/SAM#416 . 