### PR TITLE
Added divide by zero check for BTM battery grid charging cost

### DIFF
--- a/ssc/common_financial.cpp
+++ b/ssc/common_financial.cpp
@@ -3545,7 +3545,7 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
                                 }
                             }
                         }
-                        cf.at(CF_charging_cost_grid_lcos, a) += -monthly_grid_to_batt[m - 1] / monthly_e_fromgrid[m - 1] * (net_annual_true_up.at(a, m - 1) + net_billing_credit.at(a, m - 1) + net_metering_credit.at(a, m - 1));
+                        if (a != 0 && monthly_e_fromgrid[m - 1] > 0) cf.at(CF_charging_cost_grid_lcos, a) += -monthly_grid_to_batt[m - 1] / monthly_e_fromgrid[m - 1] * (net_annual_true_up.at(a, m - 1) + net_billing_credit.at(a, m - 1) + net_metering_credit.at(a, m - 1));
                         if (std::isnan(cf.at(CF_charging_cost_grid_lcos, a))) throw exec_error("Lcos_calculation", "grid charging cost nan error");
                     }
                 }
@@ -3564,6 +3564,9 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
                                 }
                             }
                         }
+                        if (a != 0 && monthly_e_fromgrid[m - 1] > 0) cf.at(CF_charging_cost_grid_lcos, a) += -monthly_grid_to_batt[m - 1] / monthly_e_fromgrid[m - 1] * (net_annual_true_up.at(a, m - 1) + net_billing_credit.at(a, m - 1) + net_metering_credit.at(a, m - 1));
+                        if (std::isnan(cf.at(CF_charging_cost_grid_lcos, a))) throw exec_error("Lcos_calculation", "grid charging cost nan error");
+
                     }
                 }
             }

--- a/ssc/common_financial.cpp
+++ b/ssc/common_financial.cpp
@@ -3546,7 +3546,6 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
                             }
                         }
                         if (a != 0 && monthly_e_fromgrid[m - 1] > 0) cf.at(CF_charging_cost_grid_lcos, a) += -monthly_grid_to_batt[m - 1] / monthly_e_fromgrid[m - 1] * (net_annual_true_up.at(a, m - 1) + net_billing_credit.at(a, m - 1) + net_metering_credit.at(a, m - 1));
-                        if (std::isnan(cf.at(CF_charging_cost_grid_lcos, a))) throw exec_error("Lcos_calculation", "grid charging cost nan error");
                     }
                 }
                 else {
@@ -3565,8 +3564,6 @@ void lcos_calc(compute_module* cm, util::matrix_t<double> cf, int nyears, double
                             }
                         }
                         if (a != 0 && monthly_e_fromgrid[m - 1] > 0) cf.at(CF_charging_cost_grid_lcos, a) += -monthly_grid_to_batt[m - 1] / monthly_e_fromgrid[m - 1] * (net_annual_true_up.at(a, m - 1) + net_billing_credit.at(a, m - 1) + net_metering_credit.at(a, m - 1));
-                        if (std::isnan(cf.at(CF_charging_cost_grid_lcos, a))) throw exec_error("Lcos_calculation", "grid charging cost nan error");
-
                     }
                 }
             }


### PR DESCRIPTION
-Avoid error in LCOS BTM calculations by checking for 0 monthly grid charge before performing parasitic cost calculations
-Fixes https://github.com/NREL/SAM/issues/801