### PR TITLE
Fix sam 802 forecast errors

### DIFF
--- a/shared/lib_battery_dispatch_automatic_btm.h
+++ b/shared/lib_battery_dispatch_automatic_btm.h
@@ -129,11 +129,12 @@ protected:
 	void check_debug(size_t hour_of_year, size_t idx, FILE*& p, bool& debug);
     bool check_new_month(size_t hour_of_year, size_t step);
     void compute_energy(double& E_max, FILE* p = NULL, const bool debug = false);
-    void set_battery_power(size_t idx, FILE* p = NULL, const bool debug = false);
+    void set_battery_power(size_t idx, size_t day_index, FILE* p = NULL, const bool debug = false);
 
     /*! Functions used by grid power target algorithms (peak shaving, input grid power targets) */
     void sort_grid(size_t idx, FILE *p = NULL, const bool debug = false);
     void target_power(double E_max, size_t idx, FILE* p = NULL, bool debug = false);
+    void apply_target_power(size_t day_index);
 
     /*! Functions used by price signal dispatch */
     double compute_costs(size_t idx, size_t year, size_t hour_of_year, FILE* p = NULL, bool debug = false); // Initial computation of no-dispatch costs, assigned hourly to grid points

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -625,6 +625,11 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
                     if (batt_vars->batt_target_choice == dispatch_automatic_behind_the_meter_t::TARGET_SINGLE_MONTHLY)
                     {
                         target_power_monthly = batt_vars->target_power_monthly;
+
+                        if (target_power_monthly.size() != 12) {
+                            throw exec_error("battery", "batt_target_power_monthly must have 12 entries if batt_target_choice is target_single_monthly (0).");
+                        }
+
                         target_power.clear();
                         target_power.reserve(8760 * step_per_hour);
                         for (size_t month = 0; month != 12; month++)

--- a/ssc/cmod_battery.h
+++ b/ssc/cmod_battery.h
@@ -301,6 +301,8 @@ struct battstor
 	/*! Use user-input battery dispatch */
 	bool input_custom_dispatch = false;
 
+    bool uses_forecast();
+
 	// for user schedule
 	void check_replacement_schedule();
 	void calculate_monthly_and_annual_outputs( compute_module &cm );

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1103,6 +1103,10 @@ void cm_pvsamv1::exec()
         if (!Simulation->annualSimulation)
             throw exec_error("pvsamv1", "The PV+Battery configuration requires a simulation period that is continuous over one or more years.");
 
+        batt = std::make_shared<battstor>(*m_vartab, en_batt, nrec, ts_hour);
+        batt->setSharedInverter(sharedInverter);
+        batt_topology = batt->batt_vars->batt_topology;
+
         if (is_assigned("batt_load_ac_forecast"))
         {
             p_load_forecast_in = as_vector_ssc_number_t("batt_load_ac_forecast");
@@ -1143,10 +1147,6 @@ void cm_pvsamv1::exec()
                 }
             }
         }
-
-        batt = std::make_shared<battstor>(*m_vartab, en_batt, nrec, ts_hour);
-        batt->setSharedInverter(sharedInverter);
-        batt_topology = batt->batt_vars->batt_topology;
 
         // Multiple MPPT inverters not enabled with DC-connected batteries
         if (PVSystem->Inverter->nMpptInputs > 1 && en_batt && batt_topology == ChargeController::DC_CONNECTED)

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1089,18 +1089,6 @@ void cm_pvsamv1::exec()
         if (nload != nrec && nload != 8760)
             throw exec_error("pvsamv1", "The critical electric load profile must have either same number of time steps as the weather file, or 8760 time steps.");
     }
-    if (is_assigned("batt_load_ac_forecast"))
-    {
-        p_load_forecast_in = as_vector_ssc_number_t("batt_load_ac_forecast");
-        nload = p_load_forecast_in.size();
-        if (nload == 1) {
-            // Length 1 is "empty" to UI lk
-            p_load_forecast_in.clear();
-        }
-        else if (nload != nrec && nload != 8760) {
-            throw exec_error("pvsamv1", "The electric load forecast profile must have either same number of time steps as the weather file, or 8760 time steps.");
-        }
-    }
 
     // resilience metrics for battery
     std::unique_ptr<resilience_runner> resilience = nullptr;
@@ -1115,6 +1103,19 @@ void cm_pvsamv1::exec()
         if (!Simulation->annualSimulation)
             throw exec_error("pvsamv1", "The PV+Battery configuration requires a simulation period that is continuous over one or more years.");
 
+        if (is_assigned("batt_load_ac_forecast"))
+        {
+            p_load_forecast_in = as_vector_ssc_number_t("batt_load_ac_forecast");
+            nload = p_load_forecast_in.size();
+            if (nload == 1 || !batt->uses_forecast()) {
+                // Length 1 is "empty" to UI lk
+                p_load_forecast_in.clear();
+            }
+            else if (nload != nrec && nload != 8760) {
+                throw exec_error("pvsamv1", "The electric load forecast profile must have either same number of time steps as the weather file, or 8760 time steps.");
+            }
+        }
+
         p_load_forecast_full.reserve(nlifetime);
 
         int batt_forecast_choice = as_integer("batt_dispatch_wf_forecast_choice");
@@ -1122,14 +1123,24 @@ void cm_pvsamv1::exec()
             p_pv_clipping_forecast = as_vector_ssc_number_t("batt_pv_clipping_forecast");
             // Annual simulation is enforced above
             if (p_pv_clipping_forecast.size() < step_per_hour * 8760 && batt_forecast_choice == dispatch_t::WEATHER_FORECAST_CHOICE::WF_CUSTOM) {
-                throw exec_error("pvsamv1", "batt_pv_clipping_forecast forecast length is " + std::to_string(p_pv_clipping_forecast.size()) + " when custom weather file forecast is selected. Change batt_dispatch_wf_forecast_choice or provide a forecast of at least length " + std::to_string(step_per_hour * 8760));
+                if (batt->uses_forecast()) {
+                    throw exec_error("pvsamv1", "batt_pv_clipping_forecast forecast length is " + std::to_string(p_pv_clipping_forecast.size()) + " when custom weather file forecast is selected. Change batt_dispatch_wf_forecast_choice or provide a forecast of at least length " + std::to_string(step_per_hour * 8760));
+                }
+                else {
+                    p_pv_clipping_forecast.clear();
+                }
             }
         }
         if (is_assigned("batt_pv_ac_forecast")) {
             p_pv_ac_forecast = as_vector_ssc_number_t("batt_pv_ac_forecast");
             // Annual simulation is enforced above
             if (p_pv_ac_forecast.size() < step_per_hour * 8760 && batt_forecast_choice == dispatch_t::WEATHER_FORECAST_CHOICE::WF_CUSTOM) {
-                throw exec_error("pvsamv1", "batt_pv_clipping_forecast forecast length is " + std::to_string(p_pv_ac_forecast.size()) + " when custom weather file forecast is selected. Change batt_dispatch_wf_forecast_choice or provide a forecast of at least length " + std::to_string(step_per_hour * 8760));
+                if (batt->uses_forecast()) {
+                    throw exec_error("pvsamv1", "batt_pv_ac_forecast forecast length is " + std::to_string(p_pv_ac_forecast.size()) + " when custom weather file forecast is selected. Change batt_dispatch_wf_forecast_choice or provide a forecast of at least length " + std::to_string(step_per_hour * 8760));
+                }
+                else {
+                    p_pv_ac_forecast.clear();
+                }
             }
         }
 

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -110,8 +110,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialACBatteryModelIntegr
     ssc_number_t expectedBatteryChargeEnergy[3] = { 1442, 1443, 258 };
     ssc_number_t expectedBatteryDischargeEnergy[3] = { 1321, 1323, 233 };
 
-    ssc_number_t peakKwCharge[3] = { -2.91, -3.02, -2.25 };
-    ssc_number_t peakKwDischarge[3] = { 1.39, 1.30, 0.97 };
+    ssc_number_t peakKwCharge[3] = { -2.91, -2.66, -2.25 };
+    ssc_number_t peakKwDischarge[3] = { 1.39, 1.73, 0.97 };
     ssc_number_t peakCycles[3] = { 1, 1, 1 };
     ssc_number_t avgCycles[3] = { 1, 1, 0.4904 };
 
@@ -344,7 +344,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialDCBatteryModelIntegr
     ssc_number_t expectedBatteryDischargeEnergy[3] = { 1283.8, 1285.88, 226.3 };
 
     ssc_number_t peakKwCharge[3] = { -3.21, -2.96, -2.69 };
-    ssc_number_t peakKwDischarge[3] = { 1.40, 1.31, 0.967 };
+    ssc_number_t peakKwDischarge[3] = { 1.40, 1.74, 0.967 };
     ssc_number_t peakCycles[3] = { 1, 1, 1 };
     ssc_number_t avgCycles[3] = { 1.0, 1.0, 0.4794 };
 
@@ -451,7 +451,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_cashloan)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-    EXPECT_NEAR(lcos_real, 571.88, 0.1);
+    EXPECT_NEAR(lcos_real, 588.71, 0.1);
 }
 
 /// Test PVSAMv1 with all defaults and battery enabled with 3 automatic dispatch methods
@@ -664,18 +664,18 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
 /// Test PVSAMv1 clipping with multiple subarrays
 TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, CommercialMultipleSubarrayBatteryIntegration)
 {
-    commercial_multiarray_default(data);
+    commercial_multiarray_default(data); // AC connected
 
     std::map<std::string, double> pairs;
     pairs["analysis_period"] = 1;
 
     ssc_number_t expectedEnergy = 543888;
-    ssc_number_t expectedBatteryChargeEnergy = 929;
-    ssc_number_t expectedBatteryDischargeEnergy = 849;
+    ssc_number_t expectedBatteryChargeEnergy = 785.1;
+    ssc_number_t expectedBatteryDischargeEnergy = 715.1;
     ssc_number_t expectedClipLoss = 590.8;
 
-    ssc_number_t peakKwCharge = -10.12;
-    ssc_number_t peakKwDischarge = 1.39;
+    ssc_number_t peakKwCharge = -9.93;
+    ssc_number_t peakKwDischarge = 1.24;
     ssc_number_t peakCycles = 1;
     ssc_number_t avgCycles = 1;
 
@@ -713,14 +713,14 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, CommercialMultipleSubarrayBatte
 
         auto batt_q_rel = data_vtab->as_vector_ssc_number_t("batt_capacity_percent");
         auto batt_cyc_avg = data_vtab->as_vector_ssc_number_t("batt_DOD_cycle_average");
-        EXPECT_NEAR(batt_q_rel.back(), 99.221, 2e-2);
-        EXPECT_NEAR(batt_cyc_avg.back(), 10.68, m_error_tolerance_lo);
+        EXPECT_NEAR(batt_q_rel.back(), 99.344, 2e-2);
+        EXPECT_NEAR(batt_cyc_avg.back(), 8.97, m_error_tolerance_lo);
     }
 
 }
 
 /// Test Clipping forecast and dispatch
-TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest1_DC_FOM_Dispatch)
+TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest1_DC_Dispatch)
 {
     commercial_multiarray_default(data);
 
@@ -733,7 +733,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest1_DC_FOM_Di
     ssc_number_t expectedBatteryDischargeEnergy = 343.96;
     ssc_number_t expectedClipLoss = 590.8;
 
-    ssc_number_t peakKwCharge = -9.488;
+    ssc_number_t peakKwCharge = -9.238;
     ssc_number_t peakKwDischarge = 1.1;
     ssc_number_t peakCycles = 1;
     ssc_number_t avgCycles = 1;
@@ -772,7 +772,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest1_DC_FOM_Di
 
 }
 
-TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest2_DC_FOM_Dispatch_w_forecast)
+TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest2_DC_Dispatch_w_forecast)
 {
     commercial_multiarray_default(data);
 
@@ -780,13 +780,14 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ClippingForecastTest2_DC_FOM_Di
     pairs["analysis_period"] = 1;
     pairs["batt_ac_or_dc"] = 0;
     set_array(data, "batt_pv_clipping_forecast", clipping_forecast, 8760);
+    // TODO: consider changing the dispatch algorithm for this and the previous test. Peak shaving does not use clipped energy, meaning the results are the same for this and the previous test
 
     ssc_number_t expectedEnergy = 543485;
     ssc_number_t expectedBatteryChargeEnergy = 929;
     ssc_number_t expectedBatteryDischargeEnergy = 343.96;
     ssc_number_t expectedClipLoss = 590.8;
 
-    ssc_number_t peakKwCharge = -9.488;
+    ssc_number_t peakKwCharge = -9.238;
     ssc_number_t peakKwDischarge = 1.1;
     ssc_number_t peakCycles = 1;
     ssc_number_t avgCycles = 1;


### PR DESCRIPTION
Fixes SAM issue https://github.com/NREL/SAM/issues/802

- Checks the chosen dispatch method prior to throwing an exception about forecast errors
- Uses the actual grid power for dispatch rather than the forecast grid power. This removes the effect of the forecast variables on input grid power targets
    - This also increases the NPV of the "one day look behind" forecast option. Since only the grid power target uses the forecast now and the dispatch uses the actual grid power, the NPV increases by a factor of ~6 in the default commercial case (20% of the lookahead value to 90% of the lookahead value)

To test:

(1)
- Select a pv-battery behind the meter sytem
- Go to the dispatch options
- Select "custom weather file"
- Select "input grid power targets"
- Click on "edit values" next to "monthly grid power targets", click "ok" use the default targets
- Run the simulation
- The simulation should run instead of throwing an exception

(2)
- Duplicate the case from (1)
- Return the dispatch option from peak shaving and select another forecast option
- Return the dispatch option to "input grid power targets"
- Run the case
- The simulation should have the same results as the prior case (unaffected by forecast option.