### PR TITLE
Power Block Hourly option causes hour of year indexing failure in Geothermal

### DIFF
--- a/shared/lib_geothermal.cpp
+++ b/shared/lib_geothermal.cpp
@@ -1718,7 +1718,7 @@ bool CGeothermalAnalyzer::RunAnalysis(bool(*update_function)(float, void*), void
 					{	// run power block model
 						if (!mo_PowerBlock.Execute((ml_HourCount - 1) * 3600, mo_pb_in))
 							ms_ErrorString = "There was an error running the power block model: " + mo_PowerBlock.GetLastError();
-                        mp_geo_out->maf_timestep_power[iElapsedTimeSteps] = (float)MAX(mo_PowerBlock.GetOutputkW() * mo_geo_in.haf[int(util::hour_of_year(month, floor(hour/24)+1, hour))] - mp_geo_out->md_PumpWorkKW, 0);
+                        mp_geo_out->maf_timestep_power[iElapsedTimeSteps] = (float)MAX(mo_PowerBlock.GetOutputkW() * mo_geo_in.haf[int(util::hour_of_year(month, floor(hour/24)+1, fmod(hour, 24)))] - mp_geo_out->md_PumpWorkKW, 0);
 						//fJunk = (float)moMA->PlantGrossPowerkW(); // kinda works, but not quite the same
 					}
 


### PR DESCRIPTION
-Hour indexing corrected to go from 0-23 for the day rather than hourly years when the hourly option is selected in the UI