### PR TITLE
fix upper level m_dot effect calc

### DIFF
--- a/tcs/ud_power_cycle.cpp
+++ b/tcs/ud_power_cycle.cpp
@@ -369,7 +369,7 @@ double C_ud_power_cycle::get_interpolated_ND_output(int i_ME /*M.E. table index*
 	}
 	if( m_dot_htf_ND > m_m_dot_htf_ref )
 	{
-		INT_T_amb_on_m_dot_htf = mc_m_dot_htf_on_T_htf.interpolate_x_col_0(i_ME*2+2,T_htf_hot)*(m_dot_htf_ND-m_m_dot_htf_ref)/(m_m_dot_htf_ref-m_m_dot_htf_high);
+        INT_m_dot_htf_on_T_htf = mc_m_dot_htf_on_T_htf.interpolate_x_col_0(i_ME*2+2,T_htf_hot)*(m_dot_htf_ND-m_m_dot_htf_ref)/(m_m_dot_htf_ref-m_m_dot_htf_high);
 	}
 
 	return m_Y_at_ref[i_ME] + ME_T_htf + ME_T_amb + ME_m_dot_htf + INT_T_htf_on_T_amb + INT_T_amb_on_m_dot_htf + INT_m_dot_htf_on_T_htf;


### PR DESCRIPTION
The User Defined Power Cycle model was using an incorrect equation to calculate the interaction effect for the high level of HTF mass flow rate. This bug only affects cases where the power option is set to the UDPC model, and as such does not influence default CSP cases that use the Rankine cycle model.

When applied to the default molten salt power tower case where the cycle model is changed to the default UDPC inputs, the annual energy increase 0.1%. The effect may be more significant if 1) your UDPC data includes more variation relative to the default data at m_dot_HTF > 1 or 2) your case increases the maximum HTF over-design above the default 1.05 value.