### PR TITLE
clean up max power eff function for large numbers of inverters

### DIFF
--- a/shared/lib_shared_inverter.cpp
+++ b/shared/lib_shared_inverter.cpp
@@ -387,11 +387,11 @@ void SharedInverter::convertOutputsToKWandScale(double tempLoss, double powerAC_
 double SharedInverter::getMaxPowerEfficiency()
 {
     if (m_inverterType == SANDIA_INVERTER || m_inverterType == DATASHEET_INVERTER || m_inverterType == COEFFICIENT_GENERATOR)
-        calculateACPower(m_sandiaInverter->Paco * util::watt_to_kilowatt, m_sandiaInverter->Vdco, 0.0);
+        calculateACPower(m_sandiaInverter->Paco * util::watt_to_kilowatt * m_numInverters, m_sandiaInverter->Vdco, 0.0);
     else if (m_inverterType == PARTLOAD_INVERTER)
-        calculateACPower(m_partloadInverter->Paco * util::watt_to_kilowatt, m_partloadInverter->Vdco, 0.0);
+        calculateACPower(m_partloadInverter->Paco * util::watt_to_kilowatt * m_numInverters, m_partloadInverter->Vdco, 0.0);
     else if (m_inverterType == OND_INVERTER)
-        calculateACPower(m_ondInverter->PMaxOUT * util::watt_to_kilowatt, m_ondInverter->VAbsMax, 0.0);
+        calculateACPower(m_ondInverter->PMaxOUT * util::watt_to_kilowatt * m_numInverters, m_ondInverter->VAbsMax, 0.0);
 
     return efficiencyAC;
 }

--- a/test/shared_test/lib_battery_powerflow_test.cpp
+++ b/test/shared_test/lib_battery_powerflow_test.cpp
@@ -2325,9 +2325,9 @@ TEST_F(BatteryPowerFlowTest_lib_battery_powerflow, DC_PVCharging_ExcessLoad_outa
     EXPECT_NEAR(m_batteryPower->powerGridToLoad, 0.0, error);
     EXPECT_NEAR(m_batteryPower->powerSystemToGrid, 0, error);
     EXPECT_NEAR(m_batteryPower->powerBatteryToLoad, 0, error);
-    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 2.179, error); // Inverter night time losses - will be cleaned up by pv ac code as appropriate
+    EXPECT_NEAR(m_batteryPower->powerConversionLoss, 1.13, error); // Inverter night time losses - will be cleaned up by pv ac code as appropriate
     EXPECT_NEAR(m_batteryPower->powerSystemLoss, 1.0, error);
-    EXPECT_NEAR(m_batteryPower->powerLossesUnmet, 2.179, error);
+    EXPECT_NEAR(m_batteryPower->powerLossesUnmet, 1.13, error);
     EXPECT_NEAR(m_batteryPower->powerCritLoadUnmet, 50.0, error);
     EXPECT_NEAR(m_batteryPower->powerInterconnectionLoss, 0.0, error);
 


### PR DESCRIPTION
Fix the max efficiency function by multiplying by the number of inverters. Update tests for improved efficiency estimates accordingly.

Fixes #722 