### PR TITLE
Fix ssc 856 xfmr losses

### DIFF
--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -2358,7 +2358,10 @@ void cm_pvsamv1::exec()
             }
 
 
-            // Apply transformer loss
+            // Apply transformer loss - reset variables after DC connected calculations
+            transformerRatingkW = static_cast<ssc_number_t>(PVSystem->ratedACOutput * util::watt_to_kilowatt);
+            xfmr_ll = PVSystem->transformerLoadLossFraction / step_per_hour;
+            xfmr_nll = PVSystem->transformerNoLoadLossFraction * static_cast<ssc_number_t>(ts_hour * transformerRatingkW);
 			// total load loss
             ssc_number_t xfmr_loss = transformerLoss(PVSystem->p_systemACPower[idx], PVSystem->transformerLoadLossFraction, transformerRatingkW, xfmr_ll, xfmr_nll);
 


### PR DESCRIPTION
Fixes https://github.com/NREL/SAM/issues/856

The DC connected batteries need an estimate of loss percent for grid outages, but since some of the transformer load losses use *= the calculation was being applied twice. Reset the variables after the DC loss estimation to fix the issue.

Test by specifying a transformer load loss in a default case. An AC connected battery and DC connected battery should have similar transformer loss %s after running.