### PR TITLE
Fix ssc 694

### DIFF
--- a/ssc/cmod_merchantplant_eqns.cpp
+++ b/ssc/cmod_merchantplant_eqns.cpp
@@ -470,7 +470,7 @@ bool mp_ancillary_services(ssc_data_t data)
 								error = util::format("ancillary services 4 market cleared capacity %g is less than zero at timestep %d", ancillary_services4_capacity[i], int(i));
 								break;
 							}
-							else */  if ((cleared_capacity_sum[i] > 0) && (abs(cleared_capacity_sum[i] - system_generation[i]) > 1e-7 * abs(system_generation[i]) ))
+							else */  if ((cleared_capacity_sum[i] > 0) && ((cleared_capacity_sum[i] - system_generation[i]) > 1e-7 * abs(system_generation[i]) ))
 							{
 								error = util::format("sum of cleared capacity %g MW does not match system capacity %g MW at timestep %d", cleared_capacity_sum[i], system_generation[i], int(i));
 								break;

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -725,7 +725,7 @@ bool forecast_price_signal::setup(size_t nsteps)
 		as_revenue.clear();
 		as_revenue.reserve(n_marketrevenue_per_year);
 		for (size_t j = 0; j < n_marketrevenue_per_year; j++)
-			as_revenue.push_back(mp_energy_market_revenue_mat.at(j, 0) * mp_energy_market_revenue_mat.at(j, 1) / step_per_hour);
+			as_revenue.push_back(mp_energy_market_revenue_mat.at(j, 1) / step_per_hour / 1000.0);
 		as_revenue_extrapolated = extrapolate_timeseries(as_revenue, step_per_hour);
 		std::transform(m_forecast_price.begin(), m_forecast_price.end(), as_revenue_extrapolated.begin(), m_forecast_price.begin(), std::plus<double>());
 
@@ -733,7 +733,7 @@ bool forecast_price_signal::setup(size_t nsteps)
 		as_revenue.clear();
 		as_revenue.reserve(n_ancserv_1_revenue_per_year);
 		for (size_t j = 0; j < n_ancserv_1_revenue_per_year; j++)
-			as_revenue.push_back(mp_ancserv_1_revenue_mat.at(j, 0) * mp_ancserv_1_revenue_mat.at(j, 1) / step_per_hour);
+			as_revenue.push_back(mp_ancserv_1_revenue_mat.at(j, 1) / step_per_hour / 1000.0);
 		as_revenue_extrapolated = extrapolate_timeseries(as_revenue, step_per_hour);
 		std::transform(m_forecast_price.begin(), m_forecast_price.end(), as_revenue_extrapolated.begin(), m_forecast_price.begin(), std::plus<double>());
 
@@ -741,7 +741,7 @@ bool forecast_price_signal::setup(size_t nsteps)
 		as_revenue.clear();
 		as_revenue.reserve(n_ancserv_2_revenue_per_year);
 		for (size_t j = 0; j < n_ancserv_2_revenue_per_year; j++)
-			as_revenue.push_back(mp_ancserv_2_revenue_mat.at(j, 0) * mp_ancserv_2_revenue_mat.at(j, 1) / step_per_hour);
+			as_revenue.push_back(mp_ancserv_2_revenue_mat.at(j, 1) / step_per_hour / 1000.0);
 		as_revenue_extrapolated = extrapolate_timeseries(as_revenue, step_per_hour);
 		std::transform(m_forecast_price.begin(), m_forecast_price.end(), as_revenue_extrapolated.begin(), m_forecast_price.begin(), std::plus<double>());
 
@@ -749,7 +749,7 @@ bool forecast_price_signal::setup(size_t nsteps)
 		as_revenue.clear();
 		as_revenue.reserve(n_ancserv_3_revenue_per_year);
 		for (size_t j = 0; j < n_ancserv_3_revenue_per_year; j++)
-			as_revenue.push_back(mp_ancserv_3_revenue_mat.at(j, 0) * mp_ancserv_3_revenue_mat.at(j, 1) / step_per_hour);
+			as_revenue.push_back(mp_ancserv_3_revenue_mat.at(j, 1) / step_per_hour / 1000.0);
 		as_revenue_extrapolated = extrapolate_timeseries(as_revenue, step_per_hour);
 		std::transform(m_forecast_price.begin(), m_forecast_price.end(), as_revenue_extrapolated.begin(), m_forecast_price.begin(), std::plus<double>());
 
@@ -757,7 +757,7 @@ bool forecast_price_signal::setup(size_t nsteps)
 		as_revenue.clear();
 		as_revenue.reserve(n_ancserv_4_revenue_per_year);
 		for (size_t j = 0; j < n_ancserv_4_revenue_per_year; j++)
-			as_revenue.push_back(mp_ancserv_4_revenue_mat.at(j, 0) * mp_ancserv_4_revenue_mat.at(j, 1) / step_per_hour);
+			as_revenue.push_back(mp_ancserv_4_revenue_mat.at(j, 1) / step_per_hour / 1000.0);
 		as_revenue_extrapolated = extrapolate_timeseries(as_revenue, step_per_hour);
 		std::transform(m_forecast_price.begin(), m_forecast_price.end(), as_revenue_extrapolated.begin(), m_forecast_price.begin(), std::plus<double>());
 	}

--- a/test/ssc_test/save_as_JSON_test.cpp
+++ b/test/ssc_test/save_as_JSON_test.cpp
@@ -179,7 +179,7 @@ TEST(save_as_JSON_test_run, pv_batt_mechant_plant_rapidjson) {
     EXPECT_TRUE(success);
     ssc_number_t npv;
     ssc_data_get_number(data, "project_return_aftertax_npv", &npv);
-    EXPECT_NEAR(npv, -94521027, fabs(-94521027) / 1e6);
+    EXPECT_NEAR(npv, -81248213, fabs(-81248213) / 1e6);
 }
 
 TEST(save_as_JSON_test_run, pt_mechant_plant_rapidjson) {


### PR DESCRIPTION
cmod_merchant_plant_eqns now delivers units of $/kWh to the battery dispatch code. This allows the automated battery controller battery to dispatch based on the price regardless of the cleared capacity. Introducing cleared capacity into the battery dispatch is scheduled for (the often delayed) https://github.com/NREL/sam/issues/181

Additionally, clean up the merchant plant error checking for cases where gen > cleared capacity.

Fixes https://github.com/NREL/ssc/issues/694