### PR TITLE
Update cmod_windpower error warnings for failed user-defined wind turbine powercurves

### DIFF
--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -256,6 +256,8 @@ void cm_windpower::exec()
 	wt.measurementHeight = wt.hubHeight;
 	wt.rotorDiameter = as_double("wind_turbine_rotor_diameter");
 	ssc_number_t *pc_w = as_array("wind_turbine_powercurve_windspeeds", &wt.powerCurveArrayLength);
+    if (wt.powerCurveArrayLength == 1)
+        throw exec_error("windpower", util::format("The wind turbine power curves has insufficient data. Consider changing the turbine design parameters"));
 	ssc_number_t *pc_p = as_array("wind_turbine_powercurve_powerout", NULL);
 	std::vector<double> windSpeeds(wt.powerCurveArrayLength), powerOutput(wt.powerCurveArrayLength);
 	for (size_t i = 0; i < wt.powerCurveArrayLength; i++){

--- a/ssc/cmod_windpower_eqns.cpp
+++ b/ssc/cmod_windpower_eqns.cpp
@@ -123,9 +123,8 @@ bool Turbine_calculate_powercurve(ssc_data_t data)
 	                * max_cp * pow(wind_at_omegaT, 2))) * 1000.0 * (rated_hub_power-power_at_omegaT)) + wind_at_omegaT);
 
 	if ( omegaT > omega_m ) {
-		sprintf( errmsg, "Turbine inputs are not valid, please adjust the inputs. omegaT: %f, omegaM: %f", omegaT, omega_m );
+		sprintf( errmsg, "Warning: Turbine inputs may not be valid, please check the inputs. omegaT: %f, omegaM: %f", omegaT, omega_m );
         vt->assign( "error", std::string(errmsg ));
-        return false;
     }
 
 	double step = 0.25;

--- a/ssc/cmod_windpower_eqns.cpp
+++ b/ssc/cmod_windpower_eqns.cpp
@@ -178,5 +178,7 @@ bool Turbine_calculate_powercurve(ssc_data_t data)
     vt->assign( "wind_turbine_powercurve_powerout", powerout);
     vt->assign( "rated_wind_speed", rated_wind_speed );
     vt->assign( "hub_efficiency", hub_eff );
+    sprintf(errmsg, "None");
+    vt->assign("error", std::string(errmsg));
     return true;
 }


### PR DESCRIPTION
-Add error warning when power curve is 0 from failed wind power curve equations in UI. 
-See https://github.com/NREL/SAM/issues/877, https://github.com/NREL/SAM/pull/897