### PR TITLE
Fix SSC 720

### DIFF
--- a/shared/lib_utility_rate_equations.cpp
+++ b/shared/lib_utility_rate_equations.cpp
@@ -895,7 +895,6 @@ void rate_data::init_dc_peak_vectors(int month)
 	
 	curr_month.dc_tou_peak = std::vector<ssc_number_t>(curr_month.dc_periods.size());
 	curr_month.dc_tou_peak_hour = std::vector<size_t>(curr_month.dc_periods.size());
-	
 }
 
 void rate_data::find_dc_tou_peak(int month, double power, size_t step) {
@@ -949,14 +948,12 @@ ssc_number_t rate_data::get_demand_charge(int month, size_t year)
 		}
 	}
 
-	dc_hourly_peak[curr_month.dc_flat_peak_hour] = curr_month.dc_flat_peak;
 	monthly_dc_fixed[month] = charge; // redundant...
 	total_charge += charge;
 
 	// TOU demand charge for each period find correct tier
 	demand = 0;
 	d_lower = 0;
-	int peak_hour = 0;
 	curr_month.dc_tou_charge.clear();
     monthly_dc_tou[month] = 0;
 	for (period = 0; period < (int)curr_month.dc_tou_ub.nrows(); period++)
@@ -988,6 +985,7 @@ ssc_number_t rate_data::get_demand_charge(int month, size_t year)
 				charge += (demand - d_lower) *
 					curr_month.dc_tou_ch.at(period, tier) * rate_esc;
 				curr_month.dc_tou_charge.push_back(charge);
+                
 			}
 			else if (period < curr_month.dc_periods.size())
 			{
@@ -996,13 +994,23 @@ ssc_number_t rate_data::get_demand_charge(int month, size_t year)
 			}
 		}
 
-		dc_hourly_peak[peak_hour] = demand;
 		// add to payments
 		monthly_dc_tou[month] += charge;
 		total_charge += charge;
 	}
 
 	return total_charge;
+}
+
+void rate_data::set_demand_peak_hours(int month) {
+    ur_month& curr_month = m_month[month];
+    dc_hourly_peak[curr_month.dc_flat_peak_hour] = curr_month.dc_flat_peak;
+    int peak_hour = 0;
+    for (int period = 0; period < (int)curr_month.dc_tou_ub.nrows(); period++)
+    {
+        peak_hour = curr_month.dc_tou_peak_hour[period];
+        dc_hourly_peak[peak_hour] = curr_month.dc_tou_peak[period];
+    }
 }
 
 int rate_data::get_tou_row(size_t year_one_index, int month)

--- a/shared/lib_utility_rate_equations.h
+++ b/shared/lib_utility_rate_equations.h
@@ -164,6 +164,7 @@ public:
 	// Runs each month
 	void init_dc_peak_vectors(int month); // Reinitialize vectors for re-use of memory year to year
 	ssc_number_t get_demand_charge(int month, size_t year);  // Sum time of use and flat demand charges to return total cost. If the mismatch between int month and size_t year looks wierd to you, you're going to have to change lib_util to fix it. Good luck.
+    void set_demand_peak_hours(int month);
     // Returns error codes so compute module can print errors. 0: no error, 10x: error in previous month, 20x: error in current month. x is the period where the error occured
     int transfer_surplus(ur_month& curr_month, ur_month& prev_month); // For net metering rollovers, used between months to copy data
     void compute_surplus(ur_month& curr_month); // For net metering rollovers, used within a single month prior to cost calculations

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -1657,6 +1657,7 @@ public:
 		{
 			ur_month& curr_month = rate.m_month[m];
             curr_month.reset();
+            prev_demand_charge = 0.0;
             
             if (dc_enabled || rate.uses_billing_demand) {
                 rate.init_dc_peak_vectors(m);
@@ -1694,6 +1695,9 @@ public:
 					}
 				}
 			}
+            if (dc_enabled) {
+                rate.set_demand_peak_hours(m);
+            }
 		}
 
 		// monthly cumulative excess energy (positive = excess energy, negative = excess load)
@@ -2196,6 +2200,7 @@ public:
         {
             ur_month& curr_month = rate.m_month[m];
             curr_month.reset();
+            prev_demand_charge = 0.0;
 
             if (dc_enabled || rate.uses_billing_demand) {
                 rate.init_dc_peak_vectors(m);
@@ -2233,6 +2238,9 @@ public:
                         c++;
                     }
                 }
+            }
+            if (dc_enabled) {
+                rate.set_demand_peak_hours(m);
             }
         }
 

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -86,8 +86,8 @@ static var_info vtab_utility_rate5[] = {
 	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_ec_with_system", "Energy charge with system (year 1 hourly)", "$", "", "Time Series", "*", "", "" },
 	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_ec_without_system", "Energy charge without system (year 1 hourly)", "$", "", "Time Series", "*", "", "" },
 
-	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_dc_with_system", "Demand charge with system (year 1 hourly)", "$", "", "Time Series", "*", "", "" },
-	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_dc_without_system", "Demand charge without system (year 1 hourly)", "$", "", "Time Series", "*", "", "" },
+	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_dc_with_system", "Incremental demand charge with system (year 1 hourly)", "$", "", "Time Series", "*", "", "" },
+	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_dc_without_system", "Incremental demand charge without system (year 1 hourly)", "$", "", "Time Series", "*", "", "" },
 
 	{ SSC_OUTPUT, SSC_ARRAY, "year1_hourly_ec_tou_schedule", "TOU period for energy charges (year 1 hourly)", "", "", "Time Series", "*", "", "" },
 	{ SSC_OUTPUT,       SSC_ARRAY,      "year1_hourly_dc_tou_schedule",       "TOU period for demand charges (year 1 hourly)", "", "", "Time Series", "*", "", "" },


### PR DESCRIPTION
- Initializes the demand charge used by year1_hourly_dc_with_system to zero to prevent negative values
- Only sets values in year1_hourly_dc_peak_per_period once each month, preventing redundant values. Should now be one value per TOU period

Closes #720 
