### PR TITLE
Sam 877

### DIFF
--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -256,6 +256,8 @@ void cm_windpower::exec()
 	wt.measurementHeight = wt.hubHeight;
 	wt.rotorDiameter = as_double("wind_turbine_rotor_diameter");
 	ssc_number_t *pc_w = as_array("wind_turbine_powercurve_windspeeds", &wt.powerCurveArrayLength);
+    if (wt.powerCurveArrayLength == 1)
+        throw exec_error("windpower", util::format("The wind turbine power curves has insufficient data. Consider changing the turbine design parameters"));
 	ssc_number_t *pc_p = as_array("wind_turbine_powercurve_powerout", NULL);
 	std::vector<double> windSpeeds(wt.powerCurveArrayLength), powerOutput(wt.powerCurveArrayLength);
 	for (size_t i = 0; i < wt.powerCurveArrayLength; i++){

--- a/ssc/cmod_windpower_eqns.cpp
+++ b/ssc/cmod_windpower_eqns.cpp
@@ -178,5 +178,7 @@ bool Turbine_calculate_powercurve(ssc_data_t data)
     vt->assign( "wind_turbine_powercurve_powerout", powerout);
     vt->assign( "rated_wind_speed", rated_wind_speed );
     vt->assign( "hub_efficiency", hub_eff );
+    sprintf(errmsg, "None");
+    vt->assign("error", std::string(errmsg));
     return true;
 }


### PR DESCRIPTION
The behavior of this equation has changed, making the if ( omegaT > omega_m ) return early whereas in the past, it added the error but continued onward to make the power curve. I'm honestly not sure we need to keep this early-exit error if it's failing for reasonable inputs. I think instead of making it an error, we can make it just a warning.

closes https://github.com/NREL/SAM/issues/877, https://github.com/NREL/pysam/issues/107