### PR TITLE
Fixing SAM issue 898

### DIFF
--- a/ssc/csp_common.cpp
+++ b/ssc/csp_common.cpp
@@ -239,7 +239,12 @@ bool solarpilot_invoke::run(std::shared_ptr<weather_data_provider> wdata)
 
 	weather_header hdr;
 	wdata->header(&hdr);
-		
+
+    // If cavity in southern hemisphere, then receiver faces south
+    if (rec_type == 1 && hdr.lat < 0) {
+        rf->rec_azimuth.val = 180;
+    }
+
     amb.latitude.val = hdr.lat;
 	amb.longitude.val = hdr.lon;
 	amb.time_zone.val = hdr.tz;


### PR DESCRIPTION
Rotating cavity receiver when plant is in the southern hemisphere.

Closes NREL/SAM/issues/898

North hemisphere: (3623 heliostats)
![image](https://user-images.githubusercontent.com/34353104/152055661-5e283d14-1ffc-4e5b-a9af-42df2246f8b4.png)
![image](https://user-images.githubusercontent.com/34353104/152055805-03b851cf-a300-49fe-8855-5c6cece13848.png)


South hemisphere: (3650 heliostats)
![image](https://user-images.githubusercontent.com/34353104/152055774-a3c749fa-bc07-4d88-b23d-bc459b8091fc.png)
![image](https://user-images.githubusercontent.com/34353104/152055796-89ea7a34-9dd3-47ef-852f-fbb247cb3531.png)

Small difference is most likely caused by SolarPilot field layout algorithm.
If the northern hemisphere heliostat field is exported, flipped, and imported for the southern hemisphere case, the gap in annual energy is reduced.
![image](https://user-images.githubusercontent.com/34353104/152056959-a9884f8c-9c89-496b-bf36-c1bb8f8d4602.png)

