### PR TITLE
Remove crit_load input from PVWatts battery ReOpt calls

### DIFF
--- a/ssc/cmod_pvsamv1_eqns.cpp
+++ b/ssc/cmod_pvsamv1_eqns.cpp
@@ -290,12 +290,15 @@ SSCEXPORT bool Reopt_size_battery_params(ssc_data_t data) {
     reopt_load.assign("loads_kw", var_data(&vec[0], sim_len));
     reopt_load.assign("loads_kw_is_net", false);
 
-	vt_get_array_vec(vt, "crit_load", vec);
-	if (vec.size() != sim_len) {
-	    vt->assign("error", var_data("Critical load profile's length must be same as for load."));
-	    return false;
+    vd = vt->lookup("crit_load");
+    if (vd) {
+        vt_get_array_vec(vt, "crit_load", vec);
+        if (vec.size() != sim_len) {
+            vt->assign("error", var_data("Critical load profile's length must be same as for load."));
+            return false;
+        }
+        reopt_load.assign("critical_loads_kw", var_data(&vec[0], vec.size()));
     }
-    reopt_load.assign("critical_loads_kw", var_data(&vec[0], vec.size()));
 
     // assign the reopt parameter table and log messages
     reopt_electric.assign_match_case("urdb_response", reopt_utility);

--- a/ssc/cmod_pvsamv1_eqns.h
+++ b/ssc/cmod_pvsamv1_eqns.h
@@ -94,7 +94,7 @@ static const char *Reopt_size_battery_params_doc =
         "         'ur_ec_sched_weekend': matrix [tiers], Energy charge weekend schedule, count starts at 1, 12mx24hr\\n"
         "         'ur_ec_tou_mat': matrix [[period, tier, kw, $], Demand rates (TOU), each row provides period, tier, peak power, and charge\\n"
         "         'load': array [kW], Electricity load (year 1)\\n"
-        "         'crit_load': array [kW], Critical electricity load (year 1)\\n"
+        "         'crit_load': optional array [kW], Critical electricity load (year 1)\\n"
         "     ++ Financial inputs ++\\n"
         "         'analysis_period': double [years]\\n"
         "         'rate_escalation': double [%/year], Annual electricity rate escalation, 0-100\\n"


### PR DESCRIPTION
-Callback error for PVWatts Battery ReOpt invoke function stems from crit_load being defined even though critical load is not defined in PVWatts Battery. Added an assignment check before passing critical load to ReOpt (does not seem to be a required input)
-See https://github.com/NREL/SAM/pull/945