### PR TITLE
Improve error messages for wfcheck

### DIFF
--- a/shared/lib_util.cpp
+++ b/shared/lib_util.cpp
@@ -919,9 +919,9 @@ size_t util::hour_of_year(size_t month, size_t day, size_t hour)
 		h += hour;
 	else ok = false;
 	if (hour > 8759)
-	    throw std::runtime_error("hour_of_year range is (0-8759) but calculated hour is > 8759.");
+	    throw std::runtime_error("hour_of_year range is (0-8759) but calculated hour is > 8759: " + std::to_string(hour));
 	if (!ok)
-		throw std::runtime_error("hour_of_year input month, day, or hour out of correct range");
+		throw std::runtime_error("hour_of_year input month, day, or hour out of correct range for mm-dd-hh: " + std::to_string(month) + "-" + std::to_string(day) + "-" + std::to_string(hour));
 	return h;
 }
 

--- a/shared/lib_util.cpp
+++ b/shared/lib_util.cpp
@@ -921,7 +921,7 @@ size_t util::hour_of_year(size_t month, size_t day, size_t hour)
 	if (hour > 8759)
 	    throw std::runtime_error("hour_of_year range is (0-8759) but calculated hour is > 8759: " + std::to_string(hour));
 	if (!ok)
-		throw std::runtime_error("hour_of_year input month, day, or hour out of correct range for mm-dd-hh: " + std::to_string(month) + "-" + std::to_string(day) + "-" + std::to_string(hour));
+		throw std::runtime_error("hour_of_year input month, day, or hour out of correct range for m-d-h: " + std::to_string(month) + "-" + std::to_string(day) + "-" + std::to_string(hour));
 	return h;
 }
 


### PR DESCRIPTION
Fixes https://github.com/NREL/SAM/issues/968.

With this fix, it is clearer that the problem with the weather file (see SAM Issue 968)) is that the Day column in this weather file with one-minute data is day-of-year (1-365) instead of day-of month (1-31 for Jan, 1-28 for Feb, 1-30 for Mar, etc.).

![image](https://user-images.githubusercontent.com/27711933/156420674-593e6cfa-a843-46e2-b0a8-45365b63a156.png)
