### PR TITLE
CSP timestep reporting

### DIFF
--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -501,7 +501,6 @@ static var_info _cm_vtab_tcsmolten_salt[] = {
 
         // Power cycle outputs
     { SSC_OUTPUT,    SSC_ARRAY,  "eta",                                "PC efficiency, gross",                                                                                                                    "",             "",                                  "",                                         "*",                                                                "",              ""},
-    { SSC_OUTPUT,    SSC_ARRAY,  "eta_test",                           "PC TEST efficiency, gross",                                                                                                               "",             "",                                  "",                                         "*",                                                                "",              "" },
     { SSC_OUTPUT,    SSC_ARRAY,  "q_pb",                               "PC input energy",                                                                                                                         "MWt",          "",                                  "",                                         "*",                                                                "",              ""},
     { SSC_OUTPUT,    SSC_ARRAY,  "m_dot_pc",                           "PC HTF mass flow rate",                                                                                                                   "kg/s",         "",                                  "",                                         "*",                                                                "",              ""},
     { SSC_OUTPUT,    SSC_ARRAY,  "q_pc_startup",                       "PC startup thermal energy",                                                                                                               "MWht",         "",                                  "",                                         "*",                                                                "",              ""},
@@ -1242,7 +1241,6 @@ public:
         }
 
         // Set power cycle outputs common to all power cycle technologies
-        p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_TEST_DEP_ETA, allocate("eta_test", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_Q_DOT_HTF, allocate("q_pb", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_M_DOT_HTF, allocate("m_dot_pc", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_Q_DOT_STARTUP, allocate("q_dot_pc_startup", n_steps_fixed), n_steps_fixed);
@@ -1253,6 +1251,8 @@ public:
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_T_COND_OUT, allocate("T_cond_out", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_W_DOT_HTF_PUMP, allocate("cycle_htf_pump_power", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_W_DOT_COOLER, allocate("P_cooling_tower_tot", n_steps_fixed), n_steps_fixed);
+
+        p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_ETA_THERMAL, allocate("eta", n_steps_fixed), n_steps_fixed);
 
         if (pb_tech_type == 0) {
             if (rankine_pc.ms_params.m_CT == 4) {
@@ -2244,14 +2244,14 @@ public:
 
         // Do unit post-processing here
         double *p_q_pc_startup = allocate("q_pc_startup", n_steps_fixed);
-        double* p_q_pc_eta = allocate("eta", n_steps_fixed);
+        //double* p_q_pc_eta = allocate("eta", n_steps_fixed);
         size_t count_pc_su = 0;
-        size_t count_pc_q_dot = 0;
-        size_t count_pc_W_dot_gross = 0;
+        //size_t count_pc_q_dot = 0;
+        //size_t count_pc_W_dot_gross = 0;
         ssc_number_t *p_q_dot_pc_startup = as_array("q_dot_pc_startup", &count_pc_su);
-        ssc_number_t* p_q_dot = as_array("q_pb", &count_pc_q_dot);
-        ssc_number_t* p_W_dot_cycle = as_array("P_cycle", &count_pc_W_dot_gross);
-        if( count_pc_su != n_steps_fixed || (int)count_pc_q_dot != n_steps_fixed || (int)count_pc_W_dot_gross != n_steps_fixed)
+        //ssc_number_t* p_q_dot = as_array("q_pb", &count_pc_q_dot);
+        //ssc_number_t* p_W_dot_cycle = as_array("P_cycle", &count_pc_W_dot_gross);
+        if( count_pc_su != n_steps_fixed )
         {
             log("q_dot_pc_startup array is a different length than 'n_steps_fixed'.", SSC_WARNING);
             return;
@@ -2259,12 +2259,6 @@ public:
         for( size_t i = 0; i < n_steps_fixed; i++ )
         {
             p_q_pc_startup[i] = (float)(p_q_dot_pc_startup[i] * (sim_setup.m_report_step / 3600.0));    //[MWh]
-            if (p_q_dot[i] > 0.0) {
-                p_q_pc_eta[i] = (float)(p_W_dot_cycle[i] / p_q_dot[i]);   //[-]
-            }
-            else {
-                p_q_pc_eta[i] = 0.0;    //[-]
-            }
         }
 
         // Convert mass flow rates from [kg/hr] to [kg/s]

--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -501,6 +501,7 @@ static var_info _cm_vtab_tcsmolten_salt[] = {
 
         // Power cycle outputs
     { SSC_OUTPUT,    SSC_ARRAY,  "eta",                                "PC efficiency, gross",                                                                                                                    "",             "",                                  "",                                         "*",                                                                "",              ""},
+    { SSC_OUTPUT,    SSC_ARRAY,  "eta_test",                           "PC TEST efficiency, gross",                                                                                                               "",             "",                                  "",                                         "*",                                                                "",              "" },
     { SSC_OUTPUT,    SSC_ARRAY,  "q_pb",                               "PC input energy",                                                                                                                         "MWt",          "",                                  "",                                         "*",                                                                "",              ""},
     { SSC_OUTPUT,    SSC_ARRAY,  "m_dot_pc",                           "PC HTF mass flow rate",                                                                                                                   "kg/s",         "",                                  "",                                         "*",                                                                "",              ""},
     { SSC_OUTPUT,    SSC_ARRAY,  "q_pc_startup",                       "PC startup thermal energy",                                                                                                               "MWht",         "",                                  "",                                         "*",                                                                "",              ""},
@@ -1241,6 +1242,7 @@ public:
         }
 
         // Set power cycle outputs common to all power cycle technologies
+        p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_TEST_DEP_ETA, allocate("eta_test", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_Q_DOT_HTF, allocate("q_pb", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_M_DOT_HTF, allocate("m_dot_pc", n_steps_fixed), n_steps_fixed);
         p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_Q_DOT_STARTUP, allocate("q_dot_pc_startup", n_steps_fixed), n_steps_fixed);

--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -2244,13 +2244,8 @@ public:
 
         // Do unit post-processing here
         double *p_q_pc_startup = allocate("q_pc_startup", n_steps_fixed);
-        //double* p_q_pc_eta = allocate("eta", n_steps_fixed);
         size_t count_pc_su = 0;
-        //size_t count_pc_q_dot = 0;
-        //size_t count_pc_W_dot_gross = 0;
         ssc_number_t *p_q_dot_pc_startup = as_array("q_dot_pc_startup", &count_pc_su);
-        //ssc_number_t* p_q_dot = as_array("q_pb", &count_pc_q_dot);
-        //ssc_number_t* p_W_dot_cycle = as_array("P_cycle", &count_pc_W_dot_gross);
         if( count_pc_su != n_steps_fixed )
         {
             log("q_dot_pc_startup array is a different length than 'n_steps_fixed'.", SSC_WARNING);

--- a/ssc/cmod_trough_physical.cpp
+++ b/ssc/cmod_trough_physical.cpp
@@ -882,7 +882,6 @@ public:
             p_csp_power_cycle = &rankine_pc;
 
             // Set power cycle outputs common to all power cycle technologies
-            //p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_ETA_THERMAL, allocate("eta", n_steps_fixed), n_steps_fixed);
             p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_Q_DOT_HTF, allocate("q_pb", n_steps_fixed), n_steps_fixed);
             p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_M_DOT_HTF, allocate("m_dot_pc", n_steps_fixed), n_steps_fixed);
             p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_Q_DOT_STARTUP, allocate("q_dot_pc_startup", n_steps_fixed), n_steps_fixed);
@@ -893,6 +892,8 @@ public:
             p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_W_DOT_HTF_PUMP, allocate("cycle_htf_pump_power", n_steps_fixed), n_steps_fixed);
             p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_W_DOT_COOLER, allocate("P_cooling_tower_tot", n_steps_fixed), n_steps_fixed);
 
+                // Dependent reported variable
+            p_csp_power_cycle->assign(C_pc_Rankine_indirect_224::E_ETA_THERMAL, allocate("eta", n_steps_fixed), n_steps_fixed);
         }
 
 
@@ -1315,14 +1316,9 @@ public:
 
         // Do unit post-processing here
         double *p_q_pc_startup = allocate("q_pc_startup", n_steps_fixed);
-        double* p_q_pc_eta = allocate("eta", n_steps_fixed);
         size_t count_pc_su = 0;
-        size_t count_pc_q_dot = 0;
-        size_t count_pc_W_dot_gross = 0;
         ssc_number_t *p_q_dot_pc_startup = as_array("q_dot_pc_startup", &count_pc_su);
-        ssc_number_t *p_q_dot = as_array("q_pb", &count_pc_q_dot);
-        ssc_number_t *p_W_dot_cycle = as_array("P_cycle", &count_pc_W_dot_gross);
-        if ((int)count_pc_su != n_steps_fixed || (int)count_pc_q_dot != n_steps_fixed || (int)count_pc_W_dot_gross != n_steps_fixed)
+        if ((int)count_pc_su != n_steps_fixed)
         {
             log("q_dot_pc_startup array is a different length than 'n_steps_fixed'.", SSC_WARNING);
             return;
@@ -1330,12 +1326,6 @@ public:
         for (int i = 0; i < n_steps_fixed; i++)
         {
             p_q_pc_startup[i] = (float)(p_q_dot_pc_startup[i] * (sim_setup.m_report_step / 3600.0));    //[MWh]
-            if (p_q_dot[i] > 0.0) {
-                p_q_pc_eta[i] = (float)(p_W_dot_cycle[i] / p_q_dot[i]);   //[-]
-            }
-            else {
-                p_q_pc_eta[i] = 0.0;    //[-]
-            }
         }
 
         // Convert mass flow rates from [kg/hr] to [kg/s]

--- a/tcs/csp_solver_pc_Rankine_indirect_224.cpp
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.cpp
@@ -36,7 +36,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static C_csp_reported_outputs::S_output_info S_output_info[] =
 {
-	{C_pc_Rankine_indirect_224::E_ETA_THERMAL, C_csp_reported_outputs::TS_WEIGHTED_AVE},
 	{C_pc_Rankine_indirect_224::E_Q_DOT_HTF, C_csp_reported_outputs::TS_WEIGHTED_AVE},
 	{C_pc_Rankine_indirect_224::E_M_DOT_HTF, C_csp_reported_outputs::TS_WEIGHTED_AVE},
 	{C_pc_Rankine_indirect_224::E_Q_DOT_STARTUP, C_csp_reported_outputs::TS_WEIGHTED_AVE},
@@ -62,7 +61,7 @@ static C_csp_reported_outputs::S_output_info S_output_info[] =
 
 static C_csp_reported_outputs::S_dependent_output_info S_dependent_output_info[] =
 {
-    {C_pc_Rankine_indirect_224::E_TEST_DEP_ETA, C_pc_Rankine_indirect_224::E_W_DOT, C_pc_Rankine_indirect_224::E_Q_DOT_HTF, C_csp_reported_outputs::AoverB},
+    {C_pc_Rankine_indirect_224::E_ETA_THERMAL, C_pc_Rankine_indirect_224::E_W_DOT, C_pc_Rankine_indirect_224::E_Q_DOT_HTF, C_csp_reported_outputs::AoverB},
 
     csp_dep_info_invalid
 };
@@ -1621,7 +1620,8 @@ void C_pc_Rankine_indirect_224::call(const C_csp_weatherreader::S_outputs &weath
 	out_solver.m_P_cycle = P_cycle/1000.0;				//[MWe] Cycle power output, convert from kWe
 	mc_reported_outputs.value(E_W_DOT, P_cycle/1000.0);	//[MWe] Cycle power output, convert from kWe
 
-	mc_reported_outputs.value(E_ETA_THERMAL, eta);	//[-] Cycle thermal efficiency
+    //22.03.04 twn: post-process thermal efficiency at end of timestep reporting
+	//mc_reported_outputs.value(E_ETA_THERMAL, eta);	//[-] Cycle thermal efficiency
 
 	out_solver.m_T_htf_cold = T_htf_cold;				//[C] HTF outlet temperature
 	mc_reported_outputs.value(E_T_HTF_OUT, T_htf_cold);	//[C] HTF outlet temperature

--- a/tcs/csp_solver_pc_Rankine_indirect_224.cpp
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.cpp
@@ -60,6 +60,13 @@ static C_csp_reported_outputs::S_output_info S_output_info[] =
 	csp_info_invalid
 };
 
+static C_csp_reported_outputs::S_dependent_output_info S_dependent_output_info[] =
+{
+    {C_pc_Rankine_indirect_224::E_TEST_DEP_ETA, C_pc_Rankine_indirect_224::E_W_DOT, C_pc_Rankine_indirect_224::E_Q_DOT_HTF, C_csp_reported_outputs::AoverB},
+
+    csp_dep_info_invalid
+};
+
 C_pc_Rankine_indirect_224::C_pc_Rankine_indirect_224()
 {
 	m_is_initialized = false;
@@ -74,7 +81,7 @@ C_pc_Rankine_indirect_224::C_pc_Rankine_indirect_224()
 
 	m_ncall = -1;
 
-	mc_reported_outputs.construct(S_output_info);
+	mc_reported_outputs.construct(S_output_info, S_dependent_output_info);
 }
 
 void C_pc_Rankine_indirect_224::init(C_csp_power_cycle::S_solved_params &solved_params)

--- a/tcs/csp_solver_pc_Rankine_indirect_224.h
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.h
@@ -123,7 +123,10 @@ public:
         E_W_DOT_COOLER,     //[MWe] Cooling parasitic
 
 		// Variables added for backwards compatability with TCS
-		E_M_DOT_HTF_REF		//[kg/hr] HTF mass flow rate at design
+		E_M_DOT_HTF_REF,		//[kg/hr] HTF mass flow rate at design
+
+        // Dependent output variables
+        E_TEST_DEP_ETA
 	};
 
 	C_csp_reported_outputs mc_reported_outputs;

--- a/tcs/csp_solver_pc_Rankine_indirect_224.h
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.h
@@ -103,7 +103,6 @@ public:
 	
     enum
 	{
-		E_ETA_THERMAL,		//[-] Cycle thermal efficiency (gross)
 		E_Q_DOT_HTF,		//[MWt] Cycle thermal power input
 		E_M_DOT_HTF,		//[kg/hr] Cycle HTF mass flow rate
 		E_Q_DOT_STARTUP,	//[MWt] Cycle startup thermal power
@@ -126,7 +125,7 @@ public:
 		E_M_DOT_HTF_REF,		//[kg/hr] HTF mass flow rate at design
 
         // Dependent output variables
-        E_TEST_DEP_ETA
+        E_ETA_THERMAL,		//[-] Cycle thermal efficiency (gross)
 	};
 
 	C_csp_reported_outputs mc_reported_outputs;

--- a/tcs/csp_solver_util.cpp
+++ b/tcs/csp_solver_util.cpp
@@ -25,6 +25,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 
 const C_csp_reported_outputs::S_output_info csp_info_invalid = {-1, -1};
+const C_csp_reported_outputs::S_dependent_output_info csp_dep_info_invalid = { -1, -1, -1, C_csp_reported_outputs::E_AB_relationship::AoverB };
 
 C_csp_reported_outputs::C_output::C_output()
 {
@@ -37,6 +38,8 @@ C_csp_reported_outputs::C_output::C_output()
 	m_counter_reporting_ts_array = 0;
 
 	m_n_reporting_ts_array = -1;
+
+    m_name_indA = m_name_indB = -1;
 }
 
 void C_csp_reported_outputs::C_output::assign(double *p_reporting_ts_array, size_t n_reporting_ts_array)
@@ -56,10 +59,26 @@ void C_csp_reported_outputs::C_output::set_m_is_ts_weighted(int subts_weight_typ
 	if( !(m_subts_weight_type == TS_WEIGHTED_AVE ||
 		  m_subts_weight_type == TS_1ST ||
 		  m_subts_weight_type == TS_LAST ||
-          m_subts_weight_type == TS_MAX) )
+          m_subts_weight_type == TS_MAX ||
+          m_subts_weight_type == DEPENDENT ))
 	{
 		throw(C_csp_exception("C_csp_reported_outputs::C_output::send_to_reporting_ts_array did not recognize subtimestep weighting type"));
 	}
+}
+
+void C_csp_reported_outputs::C_output::set_name_indA(int name_indA)
+{
+    m_name_indA = name_indA;
+}
+
+void C_csp_reported_outputs::C_output::set_name_indB(int name_indB)
+{
+    m_name_indB = name_indB;
+}
+
+void C_csp_reported_outputs::C_output::set_AB_relationship(E_AB_relationship AB_relationship)
+{
+    m_AB_relationship = AB_relationship;
 }
 
 int C_csp_reported_outputs::C_output::get_vector_size()
@@ -73,6 +92,16 @@ void C_csp_reported_outputs::C_output::set_timestep_output(double output_value)
 	{	
 		mv_temp_outputs.push_back(output_value);
 	}
+}
+
+void C_csp_reported_outputs::C_output::send_to_reporting_ts_array(double val_dep)
+{
+    if (m_is_allocated)
+    {
+        mp_reporting_ts_array[m_counter_reporting_ts_array] = (float)val_dep;
+
+        m_counter_reporting_ts_array++;
+    }
 }
 
 void C_csp_reported_outputs::C_output::send_to_reporting_ts_array(double report_time_start, int n_report, 
@@ -127,7 +156,7 @@ void C_csp_reported_outputs::C_output::send_to_reporting_ts_array(double report_
             //   if multiple csp-timesteps for one reporting timestep
             // ************************************************************
             mp_reporting_ts_array[m_counter_reporting_ts_array] =(float)(*std::max_element(mv_temp_outputs.begin(), mv_temp_outputs.end()));
-        }
+        }        
 		else
 		{
 			throw(C_csp_exception("C_csp_reported_outputs::C_output::send_to_reporting_ts_array did not recognize subtimestep weighting type"));
@@ -170,6 +199,33 @@ void C_csp_reported_outputs::send_to_reporting_ts_array(double report_time_start
 		mvc_outputs[i].send_to_reporting_ts_array(report_time_start, n_report, v_temp_ts_time_end,
 			report_time_end, is_save_last_step, n_pop_back);
 	}
+
+    for (int i = 0; i < m_n_dependent_outputs; i++) {
+
+        bool is_A_allocated = mvc_outputs[mvc_dependent_outputs[i].get_name_indA()].get_is_allocated();
+        bool is_B_allocated = mvc_outputs[mvc_dependent_outputs[i].get_name_indB()].get_is_allocated();
+
+        if (is_A_allocated && is_B_allocated) {
+            double val_A = mvc_outputs[mvc_dependent_outputs[i].get_name_indA()].get_last_reported_value();
+            double val_B = mvc_outputs[mvc_dependent_outputs[i].get_name_indB()].get_last_reported_value();
+
+            double val_dep = std::numeric_limits<double>::quiet_NaN();
+            if (mvc_dependent_outputs[i].get_AB_relationship() == AoverB) {
+
+                if (val_B == 0.0) {
+                    val_dep = 0.0;
+                }
+                else {
+                    val_dep = val_A / val_B;
+                }
+            }
+
+            mvc_dependent_outputs[i].send_to_reporting_ts_array(val_dep);
+        }
+        else {
+            mvc_dependent_outputs[i].send_to_reporting_ts_array(-999.9);
+        }
+    }
 }
 
 std::vector<double> C_csp_reported_outputs::C_output::get_output_vector()
@@ -180,6 +236,11 @@ std::vector<double> C_csp_reported_outputs::C_output::get_output_vector()
 std::vector<double> C_csp_reported_outputs::get_output_vector(int index)
 {
 	return mvc_outputs[index].get_output_vector();
+}
+
+C_csp_reported_outputs::C_csp_reported_outputs()
+{
+    m_n_dependent_outputs = 0;
 }
 
 void C_csp_reported_outputs::construct(const S_output_info *output_info)
@@ -206,9 +267,36 @@ void C_csp_reported_outputs::construct(const S_output_info *output_info)
 	m_n_reporting_ts_array = -1;
 }
 
+void C_csp_reported_outputs::construct(const S_output_info* output_info, const S_dependent_output_info* dep_output_info)
+{
+    // Test dependent input handling
+    //m_n_dependent_outputs = 1;
+    //mvc_dependent_outputs.resize(m_n_dependent_outputs);
+    //mvc_dependent_outputs[0].set_m_is_ts_weighted(DEPENDENT);
+
+    m_n_dependent_outputs = 0;
+    while (dep_output_info[m_n_dependent_outputs].m_name != csp_info_invalid.m_name) {
+        m_n_dependent_outputs++;
+    }
+
+    if (m_n_dependent_outputs > 0) {
+        mvc_dependent_outputs.resize(m_n_dependent_outputs);
+
+        // Loop through dependent output info and set member data
+        for (int i = 0; i < m_n_dependent_outputs; i++) {
+            mvc_dependent_outputs[i].set_m_is_ts_weighted(DEPENDENT);
+            mvc_dependent_outputs[i].set_name_indA(dep_output_info->m_name_indA);
+            mvc_dependent_outputs[i].set_name_indB(dep_output_info->m_name_indB);
+            mvc_dependent_outputs[i].set_AB_relationship(dep_output_info->m_AB_relationship);
+        }
+    }
+
+    construct(output_info);
+}
+
 bool C_csp_reported_outputs::assign(int index, double *p_reporting_ts_array, size_t n_reporting_ts_array)
 {
-	if(index < 0 || index >= m_n_outputs)
+	if(index < 0 || index >= m_n_outputs + m_n_dependent_outputs)
 		return false;
 
 	if(m_n_reporting_ts_array == -1)
@@ -221,7 +309,15 @@ bool C_csp_reported_outputs::assign(int index, double *p_reporting_ts_array, siz
 			return false;
 	}
 
-	mvc_outputs[index].assign(p_reporting_ts_array, n_reporting_ts_array);
+    if (index < m_n_outputs) {
+        mvc_outputs[index].assign(p_reporting_ts_array, n_reporting_ts_array);
+    }
+    else {
+        // Can't check allocation here, because assign might not be called in index order
+
+        mvc_dependent_outputs[index-m_n_outputs].assign(p_reporting_ts_array, n_reporting_ts_array);
+        
+    }
 
 	return true;
 }
@@ -230,6 +326,11 @@ void C_csp_reported_outputs::set_timestep_outputs()
 {
 	for(int i = 0; i < m_n_outputs; i++)
 		mvc_outputs[i].set_timestep_output(mv_latest_calculated_outputs[i]);
+}
+
+double C_csp_reported_outputs::C_output::get_last_reported_value()
+{
+    return mp_reporting_ts_array[m_counter_reporting_ts_array - 1];
 }
 
 void C_csp_reported_outputs::C_output::overwrite_vector_to_constant(double value)

--- a/tcs/csp_solver_util.h
+++ b/tcs/csp_solver_util.h
@@ -38,8 +38,14 @@ public:
 		TS_WEIGHTED_AVE,
 		TS_1ST,
 		TS_LAST,
-        TS_MAX
+        TS_MAX,
+        DEPENDENT
 	};
+
+    enum E_AB_relationship
+    {
+        AoverB
+    };
 
 	class C_output
 	{
@@ -52,7 +58,11 @@ public:
 		
 		int m_subts_weight_type;	// 0: timestep-weighted average, 1: Take first piont in mv_temp_outputs, 2: Take final point in mv_temp_outupts
 		//bool m_is_ts_weighted;		// True = timestep-weighted average of mv_temp_outputs, False = take first point in mv_temp_outputs
-		
+
+        int m_name_indA;
+        int m_name_indB;
+        E_AB_relationship m_AB_relationship;
+
 		int m_counter_reporting_ts_array;	//[-] Tracking current location of reporting array
 
 	public:
@@ -61,6 +71,15 @@ public:
 		int get_vector_size();
 
 		void set_m_is_ts_weighted(int subts_weight_type);
+        void set_name_indA(int name_indA);
+        void set_name_indB(int name_indB);
+        void set_AB_relationship(E_AB_relationship AB_relationship);
+
+        int get_name_indA() { return m_name_indA; }
+        int get_name_indB() { return m_name_indB; }
+        E_AB_relationship get_AB_relationship() { return m_AB_relationship; }
+
+        bool get_is_allocated() { return m_is_allocated; }
 
 		void assign(double *p_reporting_ts_array, size_t n_reporting_ts_array);
 
@@ -72,8 +91,12 @@ public:
 
 		std::vector<double> get_output_vector();
 
+        double get_last_reported_value();
+
 		void send_to_reporting_ts_array(double report_time_start, int n_report,
 			const std::vector<double> & v_temp_ts_time_end, double report_time_end, bool is_save_last_step, int n_pop_back);
+
+        void send_to_reporting_ts_array(double val);
 	};
 
 	struct S_output_info
@@ -85,6 +108,15 @@ public:
 		//bool m_is_ts_weighted;		// True = timestep-weighted average of mv_temp_outputs, False = take first point in mv_temp_outputs	
 	};
 
+    struct S_dependent_output_info
+    {
+        int m_name;
+        int m_name_indA;
+        int m_name_indB;
+        E_AB_relationship m_AB_relationship;
+
+    };
+
 private:
 
 	std::vector<C_output> mvc_outputs;	//[-] vector of Output Classes
@@ -94,11 +126,16 @@ private:
 
 	std::vector<double> mv_latest_calculated_outputs;	//[-] Output after most recent 
 
+    std::vector<C_output> mvc_dependent_outputs;    //[-] vector of *dependent* outputs
+    int m_n_dependent_outputs;
+
 public:
 
-	C_csp_reported_outputs(){};
+	C_csp_reported_outputs();
 
 	void construct(const S_output_info *output_info);
+
+    void construct(const S_output_info* output_info, const S_dependent_output_info* dep_output_info);
 
 	bool assign(int index, double *p_reporting_ts_array, size_t n_reporting_ts_array);
 
@@ -122,6 +159,7 @@ public:
 };
 
 extern const C_csp_reported_outputs::S_output_info csp_info_invalid;
+extern const C_csp_reported_outputs::S_dependent_output_info csp_dep_info_invalid;
 
 class C_csp_messages
 {


### PR DESCRIPTION
Update CSP solver component output writer to set outputs that are dependent on other variables. For example, when there are multiple sub-timesteps in a single reporting timestep, calculated the weighted average of a metric like efficiency is inaccurate. This pull requests provides a starting point for a framework that calculates efficiency on the reporting timestep interval based on the reporting timestep interval values of thermal input and power output.