### PR TITLE
783 sequential wiring and transmission losses

### DIFF
--- a/shared/lib_pv_io_manager.cpp
+++ b/shared/lib_pv_io_manager.cpp
@@ -881,10 +881,6 @@ void PVSystem_IO::AllocateOutputs(compute_module* cm)
     }
 
 }
-void PVSystem_IO::AssignOutputs(compute_module* cm)
-{
-    cm->assign("ac_loss", var_data((ssc_number_t)(acLossPercent + transmissionLossPercent)));
-}
 
 Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)
 {

--- a/shared/lib_pv_io_manager.cpp
+++ b/shared/lib_pv_io_manager.cpp
@@ -871,6 +871,7 @@ void PVSystem_IO::AllocateOutputs(compute_module* cm)
     p_inverterThermalLoss = cm->allocate("inv_tdcloss", numberOfWeatherFileRecords);
     p_inverterTotalLoss = cm->allocate("inv_total_loss", numberOfWeatherFileRecords);
 
+    p_inverterACOutputPreLoss = cm->allocate("ac_gross", numberOfWeatherFileRecords);
     p_acWiringLoss = cm->allocate("ac_wiring_loss", numberOfWeatherFileRecords);
     p_transmissionLoss = cm->allocate("ac_transmission_loss", numberOfWeatherFileRecords);
     p_acPerfAdjLoss = cm->allocate("ac_perf_adj_loss", numberOfWeatherFileRecords);

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -376,6 +376,7 @@ struct PVSystem_IO
 	ssc_number_t *p_inverterThermalLoss;
 	ssc_number_t *p_inverterTotalLoss;
 
+    ssc_number_t* p_inverterACOutputPreLoss; // kWac
 	ssc_number_t *p_acWiringLoss; // kWac
 	ssc_number_t *p_transmissionLoss; // kWac
     ssc_number_t *p_acPerfAdjLoss; // kWac

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -265,7 +265,6 @@ struct PVSystem_IO
 	PVSystem_IO(compute_module* cm, std::string cmName, Simulation_IO * SimulationIO, Irradiance_IO * IrradianceIO, std::vector<Subarray_IO*> Subarrays, Inverter_IO * InverterIO);
 
 	void AllocateOutputs(compute_module *cm);
-	void AssignOutputs(compute_module *cm);
 	void SetupPOAInput();
 
 	size_t numberOfSubarrays;

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -854,7 +854,7 @@ static var_info _cm_vtab_pvsamv1[] = {
             */
             { SSC_OUTPUT, SSC_NUMBER, "annual_ac_wiring_loss", "AC wiring loss", "kWh", "", "Annual (Year 1)", "", "", "" },
             { SSC_OUTPUT, SSC_NUMBER, "annual_transmission_loss", "Transmission loss", "kWh", "", "Annual (Year 1)", "", "", "" },
-            //	{ SSC_OUTPUT, SSC_NUMBER, "annual_ac_transformer_loss", "AC step-up transformer loss", "kWh", "", "Annual (Year 1)", "", "", "" },
+            
                 { SSC_OUTPUT, SSC_NUMBER, "annual_dc_optimizer_loss", "DC power optimizer loss", "kWh", "", "Annual (Year 1)", "", "", "" },
 
                 // total loss diagram losses for single year, does not include lifetime losses

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -694,6 +694,7 @@ static var_info _cm_vtab_pvsamv1[] = {
         { SSC_OUTPUT,        SSC_ARRAY,      "inv_tdcloss",                       	 "Inverter thermal derate DC power loss",                "kW",   "",   "Time Series (Inverter)",      "*",             "",                   "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "inv_total_loss",                       "Inverter total power loss",                            "kW",   "",   "Time Series (Inverter)",      "*",             "",                   "" },
         { SSC_OUTPUT,        SSC_ARRAY,      "ac_wiring_loss",                       "AC wiring loss",                                       "kW",   "",   "Time Series (Inverter)",      "*",                        "",                   "" },
+        { SSC_OUTPUT,        SSC_ARRAY,      "ac_gross",                             "Inverter AC output power",                                       "kW",   "",   "Time Series (Array)",       "*",                    "",                              "" },
 
         // transformer model outputs
         { SSC_OUTPUT,        SSC_ARRAY,      "xfmr_nll_ts",                          "Transformer no load loss",                              "kW", "",    "Time Series (Transformer)", "", "", "" },
@@ -2332,6 +2333,7 @@ void cm_pvsamv1::exec()
 
             if (iyear == 0 || save_full_lifetime_variables == 1)
             {
+                PVSystem->p_inverterACOutputPreLoss[idx] = acpwr_gross;
                 PVSystem->p_inverterEfficiency[idx] = (ssc_number_t)(sharedInverter->efficiencyAC);
                 PVSystem->p_inverterClipLoss[idx] = (ssc_number_t)(sharedInverter->powerClipLoss_kW);
                 PVSystem->p_inverterPowerConsumptionLoss[idx] = (ssc_number_t)(sharedInverter->powerConsumptionLoss_kW);
@@ -3137,7 +3139,7 @@ void cm_pvsamv1::inverter_size_check()
     ratedACOutput = ratedACOutput * util::watt_to_kilowatt; // W to kW to compare to hourly output
     ratedDCOutput = ratedDCOutput * util::watt_to_kilowatt; // W to kW to compare to hourly output
 
-    acPower = as_array("gen", &acCount);
+    acPower = as_array("ac_gross", &acCount);
     dcPower = as_array("dc_net", &dcCount);
     if (acCount == dcCount)
     {


### PR DESCRIPTION
Apply the wiring loss and _then_ the transmission loss, so that the numbers can't be greater than 100%. Update the loss calculations so this appropriately shows up in the loss diagram. Transmission losses were added in SAM PR [1000](https://github.com/NREL/SAM/pull/1000)

I'm happy to add a unit test for this, but wanted to confirm the loss behavior with you prior to writing it.