### PR TITLE
Ssc 561 update for demand ratchets

### DIFF
--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -194,7 +194,7 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
             if (rate->dc_enabled) {
                 int dc_tou_period = rate->get_dc_tou_row(step % (8760 * _steps_per_hour), curr_month - 1);
                 size_t month_idx = year * 12 + (curr_month - 1);
-                double peak = monthly_peaks.at(month_idx, dc_tou_period);
+                double peak = monthly_peaks.at(month_idx, dc_tou_period) - m_batteryPower->powerBatteryDischargeMaxAC; // Peak for dispatch calcs: peak minus battery capacity
                 if (-1.0 * grid_power > peak) {
                     monthly_peaks.set_value(-1.0 * grid_power, month_idx, dc_tou_period);
                 }

--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -172,6 +172,9 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
         double load_during_month = 0.0; double gen_during_month = 0.0; double gross_load_during_month = 0.0;
         size_t array_size = std::min(_P_pv_ac.size(), _P_load_ac.size()); // Cover smaller arrays to make testing easier
         monthly_peaks.resize_fill(_nyears * 12, rate->m_dc_tou_periods_tiers.size(), 0.0);
+        if (rate->dc_enabled) {
+            rate->init_dc_peak_vectors(0);
+        }
         for (size_t idx = 0; idx < num_recs && idx < array_size; idx++)
         {
             double grid_power = _P_pv_ac[idx] - _P_load_ac[idx];
@@ -188,6 +191,15 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
                 gen_during_month += grid_power * _dt_hour;
             }
 
+            if (rate->dc_enabled) {
+                int dc_tou_period = rate->get_dc_tou_row(step % (8760 * _steps_per_hour), curr_month - 1);
+                size_t month_idx = year * 12 + (curr_month - 1);
+                double peak = monthly_peaks.at(month_idx, dc_tou_period);
+                if (-1.0 * grid_power > peak) {
+                    monthly_peaks.set_value(-1.0 * grid_power, month_idx, dc_tou_period);
+                }
+            }
+
             step++;
             if (step == _steps_per_hour)
             {
@@ -195,16 +207,6 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
                 hour_of_year++;
                 if (hour_of_year >= 8760) {
                     hour_of_year = 0;
-                }
-            }
-
-            if (rate->dc_enabled) {
-                rate->init_dc_peak_vectors(curr_month - 1);
-                int dc_tou_period = rate->get_dc_tou_row(step % (8760 * _steps_per_hour), curr_month - 1);
-                size_t month_idx = year * 12 + (curr_month - 1);
-                double peak = monthly_peaks.at(month_idx, dc_tou_period);
-                if (-1.0 * grid_power > peak) {
-                    monthly_peaks.set_value(-1.0 * grid_power, month_idx, dc_tou_period);
                 }
             }
 
@@ -221,6 +223,9 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
                     year++;
                 }
                 curr_month < 12 ? curr_month++ : curr_month = 1;
+                if (rate->dc_enabled) {
+                    rate->init_dc_peak_vectors(curr_month - 1);
+                }
             }
         }
 

--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -199,7 +199,8 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
             }
 
             if (rate->dc_enabled) {
-                int dc_tou_period = rate->get_dc_tou_row(step % (8760 * _steps_per_hour), curr_month);
+                rate->init_dc_peak_vectors(curr_month - 1);
+                int dc_tou_period = rate->get_dc_tou_row(step % (8760 * _steps_per_hour), curr_month - 1);
                 size_t month_idx = year * 12 + (curr_month - 1);
                 double peak = monthly_peaks.at(month_idx, dc_tou_period);
                 if (-1.0 * grid_power > peak) {
@@ -223,7 +224,7 @@ void dispatch_automatic_behind_the_meter_t::setup_rate_forecast()
             }
         }
 
-        rate_forecast = std::shared_ptr<UtilityRateForecast>(new UtilityRateForecast(rate.get(), _steps_per_hour, monthly_net_load, monthly_gen, monthly_gross_load, _nyears));
+        rate_forecast = std::shared_ptr<UtilityRateForecast>(new UtilityRateForecast(rate.get(), _steps_per_hour, monthly_net_load, monthly_gen, monthly_gross_load, _nyears, monthly_peaks));
         rate_forecast->initializeMonth(0, 0);
         rate_forecast->copyTOUForecast();
     }

--- a/shared/lib_utility_rate.cpp
+++ b/shared/lib_utility_rate.cpp
@@ -347,7 +347,7 @@ void UtilityRateForecast::initializeMonth(int month, size_t year)
             }
         }
 
-        rate->init_energy_rates(false);
+        rate->init_energy_rates(false, month);
         compute_next_composite_tou(month, year);
         last_month_init = month;
 	}

--- a/shared/lib_utility_rate.cpp
+++ b/shared/lib_utility_rate.cpp
@@ -152,7 +152,7 @@ size_t UtilityRateCalculator::getEnergyPeriod(size_t hourOfYear)
 	return period;
 }
 
-UtilityRateForecast::UtilityRateForecast(rate_data* util_rate, size_t stepsPerHour, const std::vector<double>& monthly_load_forecast, const std::vector<double>& monthly_gen_forecast, const std::vector<double>& monthly_avg_load_forecast, size_t analysis_period) :
+UtilityRateForecast::UtilityRateForecast(rate_data* util_rate, size_t stepsPerHour, const std::vector<double>& monthly_load_forecast, const std::vector<double>& monthly_gen_forecast, const std::vector<double>& monthly_avg_load_forecast, size_t analysis_period, const util::matrix_t<double>& monthly_peak_forecast) :
     current_composite_buy_rates(),
     current_composite_sell_rates(),
     next_composite_buy_rates(),
@@ -166,6 +166,7 @@ UtilityRateForecast::UtilityRateForecast(rate_data* util_rate, size_t stepsPerHo
 	m_monthly_load_forecast = monthly_load_forecast;
 	m_monthly_gen_forecast = monthly_gen_forecast;
 	m_monthly_avg_load_forecast = monthly_avg_load_forecast;
+    m_peaks_forecast = monthly_peak_forecast;
     nyears = analysis_period;
 }
 
@@ -176,6 +177,7 @@ UtilityRateForecast::UtilityRateForecast(UtilityRateForecast& tmp) :
 	m_monthly_load_forecast(tmp.m_monthly_load_forecast),
 	m_monthly_gen_forecast(tmp.m_monthly_gen_forecast),
 	m_monthly_avg_load_forecast(tmp.m_monthly_avg_load_forecast),
+    m_peaks_forecast(tmp.m_peaks_forecast),
     current_composite_buy_rates(tmp.current_composite_buy_rates),
     current_composite_sell_rates(tmp.current_composite_sell_rates),
     next_composite_buy_rates(tmp.next_composite_buy_rates),
@@ -314,22 +316,39 @@ void UtilityRateForecast::compute_next_composite_tou(int month, size_t year)
     next_composite_sell_rates = rate->get_composite_tou_sell_rate(month, year, expected_gen);
 }
 
+// Month is zero indexed
 void UtilityRateForecast::initializeMonth(int month, size_t year)
 {
 	if (last_month_init != month)
 	{
 		rate->init_dc_peak_vectors(month);
-		compute_next_composite_tou(month, year);
 
-        // Ignore any peak charges lower than the average gross load - this prevents the price signal from showing demand charges on the first hour of each month when the load is not really a peak
-		double avg_load = m_monthly_avg_load_forecast[year * 12 + month];
+        ur_month& curr_month = rate->m_month[month];
 
-		ur_month& curr_month = rate->m_month[month];
-		curr_month.dc_flat_peak = avg_load;
-		for (int period = 0; period < (int)curr_month.dc_periods.size(); period++)
-		{
-			curr_month.dc_tou_peak[period] = avg_load;
-		}
+        if (rate->has_kwh_per_kw_rate() || rate->en_billing_demand_lookback) {
+            double tou_peak = 0.0;
+            for (int period = 0; period < (int)curr_month.dc_periods.size(); period++)
+            {
+                tou_peak = m_peaks_forecast[year * 12 + month, period];
+                curr_month.dc_tou_peak[period] = tou_peak;
+                if (tou_peak > curr_month.dc_flat_peak) {
+                    curr_month.dc_flat_peak = tou_peak;
+                }
+            }
+
+        }
+        else { // Standard demand charges
+            // Ignore any peak charges lower than the average gross load - this prevents the price signal from showing demand charges on the first hour of each month when the load is not really a peak
+            double avg_load = m_monthly_avg_load_forecast[year * 12 + month];
+            curr_month.dc_flat_peak = avg_load;
+            for (int period = 0; period < (int)curr_month.dc_periods.size(); period++)
+            {
+                curr_month.dc_tou_peak[period] = avg_load;
+            }
+        }
+
+        rate->init_energy_rates(false);
+        compute_next_composite_tou(month, year);
         last_month_init = month;
 	}
 }

--- a/shared/lib_utility_rate.cpp
+++ b/shared/lib_utility_rate.cpp
@@ -335,6 +335,10 @@ void UtilityRateForecast::initializeMonth(int month, size_t year)
                     curr_month.dc_flat_peak = tou_peak;
                 }
             }
+            double avg_load = m_monthly_avg_load_forecast[year * 12 + month];
+            if (avg_load > curr_month.dc_flat_peak) {
+                curr_month.dc_flat_peak = avg_load; // Choose greater of average load or peak minus battery discharge capacity
+            }
 
         }
         else { // Standard demand charges

--- a/shared/lib_utility_rate.h
+++ b/shared/lib_utility_rate.h
@@ -123,7 +123,7 @@ public:
      * *_forecast vectors need to be 12 * analysis_period in length. Predictions are used to estimate which tiers will be used for energy charges.
      * and set up baseline demand costs - equal to the demand charge at the average load during the month.
      */
-	UtilityRateForecast(rate_data* util_rate, size_t stepsPerHour, const std::vector<double>& monthly_load_forecast, const std::vector<double>& monthly_gen_forecast, const std::vector<double>& monthly_peak_forecast, size_t analysis_period);
+	UtilityRateForecast(rate_data* util_rate, size_t stepsPerHour, const std::vector<double>& monthly_load_forecast, const std::vector<double>& monthly_gen_forecast, const std::vector<double>& monthly_avg_load_forecast, size_t analysis_period, const util::matrix_t<double>& monthly_peak_forecast);
 
 	UtilityRateForecast(UtilityRateForecast& tmp);
 
@@ -184,6 +184,8 @@ protected:
 	std::vector<double> m_monthly_gen_forecast; // Length is 12 * analysis period
     // Avg load: the average gross load (no gen) over the month. Used to establish a floor for peak shaving costs
 	std::vector<double> m_monthly_avg_load_forecast; // Length is 12 * analysis period
+    // Peaks: Peak grid usage by time of use period
+    util::matrix_t<double> m_peaks_forecast; // 12 * analysis period rows, total TOU period cols - indexed by get_dc_tou_row for each month
 
 
 };

--- a/shared/lib_utility_rate_equations.cpp
+++ b/shared/lib_utility_rate_equations.cpp
@@ -129,6 +129,7 @@ rate_data::rate_data() :
 	dc_hourly_peak(),
 	monthly_dc_fixed(12),
 	monthly_dc_tou(12),
+    dc_enabled(false),
     uses_billing_demand(false),
     en_billing_demand_lookback(false),
     prev_peak_demand(12),
@@ -162,6 +163,7 @@ rate_data::rate_data(const rate_data& tmp) :
 	dc_hourly_peak(tmp.dc_hourly_peak),
 	monthly_dc_fixed(tmp.monthly_dc_fixed),
 	monthly_dc_tou(tmp.monthly_dc_tou),
+    dc_enabled(tmp.dc_enabled),
     uses_billing_demand(tmp.uses_billing_demand),
     en_billing_demand_lookback(tmp.en_billing_demand_lookback),
     prev_peak_demand(tmp.prev_peak_demand),
@@ -1031,6 +1033,22 @@ int rate_data::get_tou_row(size_t year_one_index, int month)
 		throw exec_error("lib_utility_rate_equations", ss.str());
 	}
 	return (int)(per_num - curr_month.ec_periods.begin());
+}
+
+int rate_data::get_dc_tou_row(size_t year_one_index, int month)
+{
+    int period = m_dc_tou_sched[year_one_index];
+    ur_month& curr_month = m_month[month];
+    // find corresponding monthly period
+    // check for valid period
+    std::vector<int>::iterator per_num = std::find(curr_month.dc_periods.begin(), curr_month.dc_periods.end(), period);
+    if (per_num == curr_month.dc_periods.end())
+    {
+        std::ostringstream ss;
+        ss << "Demand rate Period " << period << " not found for Month " << month << ".";
+        throw exec_error("lib_utility_rate_equations", ss.str());
+    }
+    return (int)(per_num - curr_month.dc_periods.begin());
 }
 
 int rate_data::transfer_surplus(ur_month& curr_month, ur_month& prev_month)

--- a/shared/lib_utility_rate_equations.cpp
+++ b/shared/lib_utility_rate_equations.cpp
@@ -896,6 +896,7 @@ void rate_data::sort_energy_to_periods(int month, double energy, size_t step) {
 void rate_data::init_dc_peak_vectors(int month)
 {
 	ur_month& curr_month = m_month[month];
+    curr_month.dc_flat_peak = 0;
 	curr_month.dc_tou_peak.clear();
 	curr_month.dc_tou_peak_hour.clear();
 	

--- a/shared/lib_utility_rate_equations.h
+++ b/shared/lib_utility_rate_equations.h
@@ -155,7 +155,8 @@ public:
 
     /* Populate ur_month objects from those filled out in setup_energy_rates. Called annually in cmod_utility_rate5, other classes may reset ur_month directly
        Can be called right away to create the vectors, but for kWh/kW rates needs to be called once after ur_month.update_net_and_peak to be accurate */
-    void init_energy_rates(bool gen_only);
+    void init_energy_rates_all_months(bool gen_only);
+    void init_energy_rates(bool gen_only, int m);
 
 	// Runs each step
 	void sort_energy_to_periods(int month, double energy, size_t step); // Net metering only

--- a/shared/lib_utility_rate_equations.h
+++ b/shared/lib_utility_rate_equations.h
@@ -114,6 +114,7 @@ public:
 	std::vector<ssc_number_t> monthly_dc_fixed;
 	std::vector<ssc_number_t> monthly_dc_tou;
 
+    bool dc_enabled;
     bool uses_billing_demand; // Has a energy rate with kWh/kw AND/OR has a demand charge. If false, en_billing_demand_lookback must be false
     bool en_billing_demand_lookback; // Enable billing demand lookback percentages
     std::vector<ssc_number_t> prev_peak_demand; // Set before calling init_energy_rates
@@ -160,6 +161,9 @@ public:
 	void sort_energy_to_periods(int month, double energy, size_t step); // Net metering only
 	void find_dc_tou_peak(int month, double power, size_t step);
 	int get_tou_row(size_t year_one_index, int month);
+
+    // Used by setup
+    int get_dc_tou_row(size_t year_one_index, int month);
 
 	// Runs each month
 	void init_dc_peak_vectors(int month); // Reinitialize vectors for re-use of memory year to year

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -263,7 +263,7 @@ static var_info vtab_utility_rate5[] = {
 	var_info_invalid };
 
 void rate_setup::setup(var_table* vt, int num_recs_yearly, size_t nyears, rate_data& rate, std::string cm_name) {
-    bool dc_enabled = vt->as_boolean("ur_dc_enable");
+    rate.dc_enabled = vt->as_boolean("ur_dc_enable");
     rate.en_ts_buy_rate = vt->as_boolean("ur_en_ts_buy_rate");
     rate.en_ts_sell_rate = vt->as_boolean("ur_en_ts_sell_rate");
 
@@ -359,7 +359,7 @@ void rate_setup::setup(var_table* vt, int num_recs_yearly, size_t nyears, rate_d
     ssc_number_t* dc_weekday = NULL; ssc_number_t* dc_weekend = NULL; ssc_number_t* dc_tou_in = NULL; ssc_number_t* dc_flat_in = NULL;
     size_t dc_tier_rows = 0; size_t dc_flat_rows = 0;
 
-    if (dc_enabled)
+    if (rate.dc_enabled)
     {
         dc_weekday = vt->as_matrix("ur_dc_sched_weekday", &nrows, &ncols);
         if (nrows != 12 || ncols != 24)
@@ -424,7 +424,7 @@ void rate_setup::setup(var_table* vt, int num_recs_yearly, size_t nyears, rate_d
             ss << "The ur_dc_billing_demand_periods matrix should have 2 columns. Instead it has " << ncols << " columns.";
             throw exec_error(cm_name, ss.str());
         }
-        else if (dc_enabled && nrows != rate.m_dc_tou_periods.size()) {
+        else if (rate.dc_enabled && nrows != rate.m_dc_tou_periods.size()) {
             std::ostringstream ss;
             ss << "The ur_dc_billing_demand_periods matrix should have " << rate.m_dc_tou_periods.size() << " rows, to match the number of TOU periods. Instead it has " << nrows << " rows.";
             throw exec_error(cm_name, ss.str());

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -434,7 +434,7 @@ void rate_setup::setup(var_table* vt, int num_recs_yearly, size_t nyears, rate_d
     }
     
 
-    rate.init_energy_rates(false); // TODO: update if rate forecast needs to support two meter
+    rate.init_energy_rates_all_months(false); // TODO: update if rate forecast needs to support two meter
 };
 
 class cm_utilityrate5 : public compute_module
@@ -1749,7 +1749,7 @@ public:
 		if (ec_enabled)
 		{
 			// calculate the monthly net energy per tier and period based on units
-			rate.init_energy_rates(gen_only);
+			rate.init_energy_rates_all_months(gen_only);
 			c = 0;
 			for (m = 0; m < (int)rate.m_month.size(); m++)
 			{
@@ -2254,7 +2254,7 @@ public:
 
 		if (ec_enabled)
 		{
-			rate.init_energy_rates(gen_only);
+			rate.init_energy_rates_all_months(gen_only);
 		}
 
 // main loop

--- a/test/input_cases/shared_rate_data.cpp
+++ b/test/input_cases/shared_rate_data.cpp
@@ -62,7 +62,7 @@ void set_up_default_commercial_rate_data(rate_data& data)
 	data.init(8760);
 	data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
 	data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-	data.init_energy_rates(false);
+	data.init_energy_rates_all_months(false);
 
     // enable_nm and nm_credits_w_rollover default to false, meaning this is a net billing rate
 }
@@ -86,7 +86,7 @@ void set_up_pge_residential_rate_data(rate_data& data)
     data.init(8760);
     //data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], dc_tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], ec_tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.enable_nm = true;
     data.nm_credits_w_rollover = true;
     data.nm_credit_sell_rate = 0.028;
@@ -108,7 +108,7 @@ void set_up_residential_1_4_peak(rate_data& data, size_t steps_per_hour)
     data.rate_scale = { 1, 1.025 };
     data.init(8760 * steps_per_hour);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], ec_tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.enable_nm = true;
     data.nm_credits_w_rollover = true;
     data.nm_credit_sell_rate = 0.0;
@@ -144,7 +144,7 @@ void set_up_time_series(rate_data& data)
     data.setup_time_series(8760, ur_ts_sell_rate, ur_ts_buy_rate);
 
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], ec_tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.enable_nm = false; // Can't have time series rates with nm
     data.nm_credits_w_rollover = false;
     data.nm_credit_sell_rate = 0.0;
@@ -195,7 +195,7 @@ void set_up_simple_demand_charge(rate_data& data)
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
     data.uses_billing_demand = true;
     data.en_billing_demand_lookback = false;
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.set_billing_demands();
 
     // enable_nm and nm_credits_w_rollover default to false, meaning this is a net billing rate

--- a/test/shared_test/lib_utility_rate_equations_test.cpp
+++ b/test/shared_test/lib_utility_rate_equations_test.cpp
@@ -86,7 +86,7 @@ TEST(lib_utility_rate_equations_test, test_demand_charges)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.init_dc_peak_vectors(0);
 
     // Peak period 1: 5 kW, peak period 2: 10 kW
@@ -150,7 +150,7 @@ TEST(lib_utility_rate_equations_test, test_seasonal_demand_charges)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], dc_tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.uses_billing_demand = true;
     data.en_billing_demand_lookback = false;
     data.init_dc_peak_vectors(0);
@@ -260,7 +260,7 @@ TEST(lib_utility_rate_equations_test, test_block_step_tiers)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], dc_tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false); // This gets called once to set up all the vectors
+    data.init_energy_rates_all_months(false); // This gets called once to set up all the vectors
     data.init_dc_peak_vectors(0);
     data.uses_billing_demand = true;
     data.en_billing_demand_lookback = false;
@@ -306,7 +306,7 @@ TEST(lib_utility_rate_equations_test, test_block_step_tiers)
     }
 
     // Recompute the tiers based on actual peaks
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
 
     // Each month is only going to have one TOU period in this schedule
     EXPECT_NEAR(3000, curr_month.ec_tou_ub.at(0, 0), 0.1);
@@ -384,7 +384,7 @@ TEST(lib_utility_rate_equations_test, test_kwh_per_kw_only)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], dc_tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false); // This gets called once to set up all the vectors
+    data.init_energy_rates_all_months(false); // This gets called once to set up all the vectors
     data.init_dc_peak_vectors(0);
     data.uses_billing_demand = true;
     data.en_billing_demand_lookback = false;
@@ -430,7 +430,7 @@ TEST(lib_utility_rate_equations_test, test_kwh_per_kw_only)
     }
 
     // Recompute the tiers based on actual peaks
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
 
     // Each month is only going to have one TOU period in this schedule
     EXPECT_NEAR(131600, curr_month.ec_tou_ub.at(0, 0), 0.1);
@@ -495,7 +495,7 @@ TEST(lib_utility_rate_equations_test, test_billing_demand_calcs)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], dc_tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false); // This gets called once to set up all the vectors
+    data.init_energy_rates_all_months(false); // This gets called once to set up all the vectors
     for (size_t i = 0; i < 12; i++) {
         data.init_dc_peak_vectors(i);
     }
@@ -627,7 +627,7 @@ TEST(lib_utility_rate_equations_test, test_billing_demand_calcs_w_tou)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], dc_tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false); // This gets called once to set up all the vectors
+    data.init_energy_rates_all_months(false); // This gets called once to set up all the vectors
     for (size_t i = 0; i < 12; i++) {
         data.init_dc_peak_vectors(i);
     }

--- a/test/shared_test/lib_utility_rate_test.cpp
+++ b/test/shared_test/lib_utility_rate_test.cpp
@@ -47,7 +47,9 @@ TEST(lib_utility_rate_test, test_copy)
     std::vector<double> monthly_load_forecast = { 25, 25, 25, 25, 25, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, };
     std::vector<double> monthly_avg_gross_load = { 25, 25, 25, 25, 25, 25 };
-	UtilityRateForecast rate_forecast_1(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
+	UtilityRateForecast rate_forecast_1(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     UtilityRateForecast rate_forecast_2(rate_forecast_1);
 
@@ -96,8 +98,10 @@ TEST(lib_utility_rate_test, test_tiered_tou_cost_estimates)
 	monthly_gen_forecast.push_back(0);
 	std::vector<double> monthly_avg_gross_load;
 	monthly_avg_gross_load.push_back(7);
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
 	rate_forecast.compute_next_composite_tou(0, 0);
 
@@ -142,8 +146,10 @@ TEST(lib_utility_rate_test, test_tiered_sell_rates)
 	monthly_gen_forecast.push_back(10);
 	std::vector<double> monthly_avg_gross_load;
 	monthly_avg_gross_load.push_back(7);
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
 	rate_forecast.compute_next_composite_tou(0, 0);
 
@@ -167,8 +173,10 @@ TEST(lib_utility_rate_test, test_simple_demand_charges)
     std::vector<double> monthly_load_forecast = { 31 * 24, 28 * 24 }; // Average load is 1 kW
     std::vector<double> monthly_gen_forecast = { 0, 0 };
     std::vector<double> monthly_avg_gross_load = { 1, 1 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -1, -1, 0, -2 }; // Demand charge increases by 1 kW from average
@@ -195,8 +203,10 @@ TEST(lib_utility_rate_test, test_demand_charges_crossing_months)
 	std::vector<double> monthly_load_forecast = { 150, 75 };
 	std::vector<double> monthly_gen_forecast = { 0, 0 };
 	std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
 	// - is load
 	std::vector<double> forecast = {-100, -50, -50, -25};
@@ -220,8 +230,10 @@ TEST(lib_utility_rate_test, test_demand_charges_inaccurate_forecast)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 0 };
     std::vector<double> monthly_avg_gross_load = { 50, 0 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -100, -50, -50, -25 };
@@ -245,8 +257,10 @@ TEST(lib_utility_rate_test, test_changing_rates_crossing_months)
 	std::vector<double> monthly_load_forecast = { 0, 0, 0, 150, 75 };
 	std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0 };
 	std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
 	// - is load
 	std::vector<double> forecast = { -100, -50, -50, -25 };
@@ -269,8 +283,10 @@ TEST(lib_utility_rate_test, test_demand_charges_crossing_year)
 	std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 150, 75 };
 	std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 	std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+	UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
 	// - is load
 	std::vector<double> forecast = { -100, -50, -50, -25 };
@@ -327,8 +343,10 @@ TEST(lib_utility_rate_test, test_sell_rates)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 100 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -100, -50, -50, -25, 25, 50, 25 };
@@ -351,8 +369,10 @@ TEST(lib_utility_rate_test, test_net_metering_one_tou_period)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 0 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -100, -50, 50, 100 }; // Net zero load
@@ -381,8 +401,10 @@ TEST(lib_utility_rate_test, test_net_metering_multiple_tou_periods)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 0, 0 }; // Test unexpected generation as well
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -100, -50, 50, 100 }; // Net zero load
@@ -411,8 +433,10 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_carryover)
     std::vector<double> monthly_load_forecast = { 0, 150 };
     std::vector<double> monthly_gen_forecast = { 150, 0 };
     std::vector<double> monthly_avg_gross_load = { 0, 100 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 100, 50, -50, -100 }; // Net zero load
@@ -435,8 +459,10 @@ TEST(lib_utility_rate_test, test_net_metering_dollar_credits)
     std::vector<double> monthly_load_forecast = { 0, 150 };
     std::vector<double> monthly_gen_forecast = { 150, 0 };
     std::vector<double> monthly_avg_gross_load = { 0, 100 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 100, 50, -50, -100 }; // Net zero load, but credits expire with zero sell rate
@@ -459,8 +485,10 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_cashout)
     std::vector<double> monthly_load_forecast = { 0, 150 };
     std::vector<double> monthly_gen_forecast = { 150, 0 };
     std::vector<double> monthly_avg_gross_load = { 0, 100 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 100, 50, -50, -100 }; // Net zero load
@@ -482,8 +510,10 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_charges)
     std::vector<double> monthly_load_forecast = { 150, 0 };
     std::vector<double> monthly_gen_forecast = { 0, 150 };
     std::vector<double> monthly_avg_gross_load = { 100, 0 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -100, -50, 50, 100 }; // Net zero load, but charged at end of Jan
@@ -505,8 +535,10 @@ TEST(lib_utility_rate_test, test_net_metering_end_of_month_charges_subhourly)
     std::vector<double> monthly_load_forecast = { 150, 0 };
     std::vector<double> monthly_gen_forecast = { 0, 150 };
     std::vector<double> monthly_avg_gross_load = { 100, 0 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -100, -100, -50, -50, 50, 50, 100, 100 }; // Net zero load, but charged at end of Jan
@@ -528,8 +560,10 @@ TEST(lib_utility_rate_test, test_net_metering_charges_crossing_year)
     std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75, 0 };
     std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -25, 25, 50, -25, -25 }; // Get charged for Jan at escalated rate (inflation)
@@ -552,8 +586,10 @@ TEST(lib_utility_rate_test, test_net_metering_charges_crossing_year_other_cash_o
     std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75, 0 };
     std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -25, 25, 50, -25, -25 };
@@ -575,8 +611,10 @@ TEST(lib_utility_rate_test, test_multiple_forecast_calls)
     std::vector<double> monthly_load_forecast = { 100, 75 };
     std::vector<double> monthly_gen_forecast = { 175, 0 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 25, 25, 25, 25 };
@@ -605,8 +643,10 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -640,8 +680,10 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_nm_credits)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -674,8 +716,10 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_nm_credits_subhour
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 50, 50, -100, -100, -50, -50, -50, -50, -25, -25, 25, 25, 50, 50, 100, 100 };
@@ -713,8 +757,10 @@ TEST(lib_utility_rate_test, test_end_of_analyis_period)
     std::vector<double> monthly_load_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25 };
     std::vector<double> monthly_gen_forecast = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75 };
     std::vector<double> monthly_avg_gross_load = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 1);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 1, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { -25, -25, 50 };
@@ -736,8 +782,10 @@ TEST(lib_utility_rate_test, test_one_at_a_time_vs_full_vector_buy_and_sell_rates
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -771,8 +819,10 @@ TEST(lib_utility_rate_test, test_ts_buy_only)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };
@@ -797,8 +847,10 @@ TEST(lib_utility_rate_test, test_ts_sell_only)
     std::vector<double> monthly_load_forecast = { 150, 75 };
     std::vector<double> monthly_gen_forecast = { 50, 175 };
     std::vector<double> monthly_avg_gross_load = { 100, 50 };
+    util::matrix_t<double> monthly_peaks;
+    monthly_peaks.resize_fill(1, 1, 0.0);
 
-    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2);
+    UtilityRateForecast rate_forecast(&data, steps_per_hour, monthly_load_forecast, monthly_gen_forecast, monthly_avg_gross_load, 2, monthly_peaks);
 
     // - is load
     std::vector<double> forecast = { 50, -100, -50, -50, -25, 25, 50, 100 };

--- a/test/shared_test/lib_utility_rate_test.cpp
+++ b/test/shared_test/lib_utility_rate_test.cpp
@@ -336,7 +336,7 @@ TEST(lib_utility_rate_test, test_sell_rates)
     data.init(8760);
     data.setup_demand_charges(&p_ur_dc_sched_weekday[0], &p_ur_dc_sched_weekend[0], tou_rows, &p_ur_dc_tou_mat[0], dc_flat_rows, &p_ur_dc_flat_mat[0]);
     data.setup_energy_rates(&p_ur_ec_sched_weekday[0], &p_ur_ec_sched_weekend[0], tou_rows, &p_ur_ec_tou_mat[0], sell_eq_buy);
-    data.init_energy_rates(false);
+    data.init_energy_rates_all_months(false);
     data.nm_credits_w_rollover = true;
 
     int steps_per_hour = 1;


### PR DESCRIPTION
Update price signals dispatch to support kWh/kW rates without crashing. The key difference here is rate_data.init_energy_rates can now be called for a single month, and peak data by TOU period is now passed into the rate calculation function for use with these rates.