### PR TITLE
fixed dispatch reporting issue

### DIFF
--- a/tcs/etes_dispatch.cpp
+++ b/tcs/etes_dispatch.cpp
@@ -1189,14 +1189,12 @@ void etes_dispatch_opt::set_outputs_from_lp_solution(lprec* lp, unordered_map<st
     outputs.clear();
     outputs.resize(nt);
 
-    int ncols = get_Ncolumns(lp);
-
-    REAL* vars = new REAL[ncols];
-    get_variables(lp, vars);
+    int ncols = get_Norig_columns(lp);
+    int nrows = get_Norig_rows(lp);
 
     for (int c = 1; c < ncols; c++)
     {
-        char* colname = get_col_name(lp, c);
+        char* colname = get_origcol_name(lp, c);
         if (!colname) continue;
 
         char root[15];
@@ -1204,46 +1202,45 @@ void etes_dispatch_opt::set_outputs_from_lp_solution(lprec* lp, unordered_map<st
         if (parse_column_name(colname, root, ind)) continue;  //a 2D variable
 
         int t = atoi(ind);
+        double val = get_var_primalresult(lp, nrows + c);
 
         if (strcmp(root, "ycsu") == 0)     //Cycle start up
         {
-            bool su = (fabs(1 - vars[c - 1]) < 0.001);
+            bool su = (fabs(1 - val) < 0.001);
             outputs.pb_operation.at(t) = outputs.pb_operation.at(t) || su;
             outputs.q_pb_startup.at(t) = su ? params["Qcsu"] : 0.;
         }
         else if (strcmp(root, "y") == 0)     //Cycle operation
         {
-            outputs.pb_operation.at(t) = outputs.pb_operation.at(t) || (fabs(1. - vars[c - 1]) < 0.001);
+            outputs.pb_operation.at(t) = outputs.pb_operation.at(t) || (fabs(1. - val) < 0.001);
         }
         else if (strcmp(root, "qdot") == 0)     //Cycle thermal energy consumption
         {
-            outputs.q_pb_target.at(t) = vars[c - 1];
+            outputs.q_pb_target.at(t) = val;
         }
         else if (strcmp(root, "yhsu") == 0)     //Receiver start up
         {
-            bool su = (fabs(1 - vars[c - 1]) < 0.001);
+            bool su = (fabs(1 - val) < 0.001);
             outputs.rec_operation.at(t) = outputs.rec_operation.at(t) || su;
             outputs.q_rec_startup.at(t) = su ? params["Qhsu"] : 0.;
         }
         else if (strcmp(root, "yeh") == 0)
         {
-            outputs.rec_operation.at(t) = outputs.rec_operation.at(t) || (fabs(1 - vars[c - 1]) < 0.001);
+            outputs.rec_operation.at(t) = outputs.rec_operation.at(t) || (fabs(1 - val) < 0.001);
         }
         else if (strcmp(root, "s") == 0)         //Thermal storage charge state
         {
-            outputs.tes_charge_expected.at(t) = vars[c - 1];
+            outputs.tes_charge_expected.at(t) = val;
         }
         else if (strcmp(root, "qeh") == 0)   //receiver production
         {
-            outputs.q_sf_expected.at(t) = vars[c - 1] * 1.0001;  // small increase to ensure heater starts when minimum power is applied
+            outputs.q_sf_expected.at(t) = val * 1.0001;  // small increase to ensure heater starts when minimum power is applied
         }
         else if (strcmp(root, "wdot") == 0) //electricity production
         {
-            outputs.w_pb_target.at(t) = vars[c - 1];
+            outputs.w_pb_target.at(t) = val;
         }
     }
-
-    delete[] vars;
 }
 
 bool etes_dispatch_opt::set_dispatch_outputs()


### PR DESCRIPTION
LpSolve presolve was resulting in time periods where the reported dispatch state of charge was zero when it actually was not. This occurred at the beginning of the dispatch horizon sometimes. To fix, now dispatch solution is saved using the original model form and not the subset model after presolve. This results in all variable values being updated.