### PR TITLE
pin the version of gtest to the last one that worked with our current tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         repository: google/googletest
         path: googletest
+        ref: b85864c64758dec007208e56af933fc3f52044ee
     
     - name: build Gtest
       run: | 


### PR DESCRIPTION
https://github.com/NREL/ssc/runs/6181437239?check_suite_focus=true failed even though the build before it succeeded, the PR succeeded, and the build succeeds locally. It looks like some of our tests are incompatible with the latest version of gtest. Revert to the last version that worked, and fix things in an issue that is to be created.