### PR TITLE
783 sequential wiring and transmission losses (#790) to develop

### DIFF
--- a/shared/lib_pv_io_manager.cpp
+++ b/shared/lib_pv_io_manager.cpp
@@ -869,6 +869,7 @@ void PVSystem_IO::AllocateOutputs(compute_module* cm)
     p_inverterThermalLoss = cm->allocate("inv_tdcloss", numberOfWeatherFileRecords);
     p_inverterTotalLoss = cm->allocate("inv_total_loss", numberOfWeatherFileRecords);
 
+    p_inverterACOutputPreLoss = cm->allocate("ac_gross", numberOfWeatherFileRecords);
     p_acWiringLoss = cm->allocate("ac_wiring_loss", numberOfWeatherFileRecords);
     p_transmissionLoss = cm->allocate("ac_transmission_loss", numberOfWeatherFileRecords);
     p_acPerfAdjLoss = cm->allocate("ac_perf_adj_loss", numberOfWeatherFileRecords);
@@ -882,10 +883,6 @@ void PVSystem_IO::AllocateOutputs(compute_module* cm)
         p_dcDegradationFactor = cm->allocate("dc_degrade_factor", numberOfYears);
     }
 
-}
-void PVSystem_IO::AssignOutputs(compute_module* cm)
-{
-    cm->assign("ac_loss", var_data((ssc_number_t)(acLossPercent + transmissionLossPercent)));
 }
 
 Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)

--- a/shared/lib_pv_io_manager.h
+++ b/shared/lib_pv_io_manager.h
@@ -265,7 +265,6 @@ struct PVSystem_IO
 	PVSystem_IO(compute_module* cm, std::string cmName, Simulation_IO * SimulationIO, Irradiance_IO * IrradianceIO, std::vector<Subarray_IO*> Subarrays, Inverter_IO * InverterIO);
 
 	void AllocateOutputs(compute_module *cm);
-	void AssignOutputs(compute_module *cm);
 	void SetupPOAInput();
 
 	size_t numberOfSubarrays;
@@ -377,6 +376,7 @@ struct PVSystem_IO
 	ssc_number_t *p_inverterThermalLoss;
 	ssc_number_t *p_inverterTotalLoss;
 
+    ssc_number_t* p_inverterACOutputPreLoss; // kWac
 	ssc_number_t *p_acWiringLoss; // kWac
 	ssc_number_t *p_transmissionLoss; // kWac
     ssc_number_t *p_acPerfAdjLoss; // kWac


### PR DESCRIPTION
* Apply the losses sequentially. Looks good in the time series outputs, but the losses diagram is a little off

* clean up transmission and ac wiring loss computations

* delete commented out line

* add test for fixed transmission loss behavior

* Swap the order of lifetime and availability losses so that the solls diagram percentages are computed correctly

* Add new inverter AC gross power output. Fix inverter warning with high losses