### PR TITLE
Update module entry to reflect actual open EI compatability (version 8)

### DIFF
--- a/ssc/cmod_utilityrate.cpp
+++ b/ssc/cmod_utilityrate.cpp
@@ -899,6 +899,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate, "Electricity bill calculator (depricated)", 3 );
+DEFINE_MODULE_ENTRY( utilityrate, "Electricity bill calculator (deprecated)", 3 );
 
 

--- a/ssc/cmod_utilityrate.cpp
+++ b/ssc/cmod_utilityrate.cpp
@@ -899,6 +899,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate, "Complex utility rate structure net revenue calculator", 3 );
+DEFINE_MODULE_ENTRY( utilityrate, "Electricity bill calculator (depricated)", 3 );
 
 

--- a/ssc/cmod_utilityrate2.cpp
+++ b/ssc/cmod_utilityrate2.cpp
@@ -1795,6 +1795,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate2, "Complex utility rate structure net revenue calculator OpenEI Version 2", 1 );
+DEFINE_MODULE_ENTRY( utilityrate2, "Electricity bill calculator based on OpenEI Version 2 (depricated)", 1 );
 
 

--- a/ssc/cmod_utilityrate2.cpp
+++ b/ssc/cmod_utilityrate2.cpp
@@ -1795,6 +1795,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate2, "Electricity bill calculator based on OpenEI Version 2 (depricated)", 1 );
+DEFINE_MODULE_ENTRY( utilityrate2, "Electricity bill calculator based on OpenEI Version 2 (deprecated)", 1 );
 
 

--- a/ssc/cmod_utilityrate3.cpp
+++ b/ssc/cmod_utilityrate3.cpp
@@ -3408,6 +3408,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate3, "Electricity bill calculator based on OpenEI Version 3 (depricated)", 1 );
+DEFINE_MODULE_ENTRY( utilityrate3, "Electricity bill calculator based on OpenEI Version 3 (deprecated)", 1 );
 
 

--- a/ssc/cmod_utilityrate3.cpp
+++ b/ssc/cmod_utilityrate3.cpp
@@ -3408,6 +3408,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate3, "Complex utility rate structure net revenue calculator OpenEI Version 3", 1 );
+DEFINE_MODULE_ENTRY( utilityrate3, "Electricity bill calculator based on OpenEI Version 3 (depricated)", 1 );
 
 

--- a/ssc/cmod_utilityrate4.cpp
+++ b/ssc/cmod_utilityrate4.cpp
@@ -2950,6 +2950,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate4, "Electricity bill calculator based on OpenEI Version 4 (depricated)", 1 );
+DEFINE_MODULE_ENTRY( utilityrate4, "Electricity bill calculator based on OpenEI Version 4 (deprecated)", 1 );
 
 

--- a/ssc/cmod_utilityrate4.cpp
+++ b/ssc/cmod_utilityrate4.cpp
@@ -2950,6 +2950,6 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY( utilityrate4, "Complex utility rate structure net revenue calculator OpenEI Version 4", 1 );
+DEFINE_MODULE_ENTRY( utilityrate4, "Electricity bill calculator based on OpenEI Version 4 (depricated)", 1 );
 
 

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -2668,4 +2668,4 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY(utilityrate5, "Complex utility rate structure net revenue calculator OpenEI Version 4 with net billing", 1);
+DEFINE_MODULE_ENTRY(utilityrate5, "Complex utility rate structure net revenue calculator OpenEI Version 8", 1);

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -2668,4 +2668,4 @@ public:
 
 };
 
-DEFINE_MODULE_ENTRY(utilityrate5, "Complex utility rate structure net revenue calculator OpenEI Version 8", 1);
+DEFINE_MODULE_ENTRY(utilityrate5, "Electricity bill calculator based on OpenEI Version 8", 1);


### PR DESCRIPTION
Noticed that the PySAM documentation was out of date, requires fixing this definition in SSC.