### PR TITLE
add function that was enforcing dispatch soc limits for lithium ion batteries

### DIFF
--- a/shared/lib_battery_capacity.cpp
+++ b/shared/lib_battery_capacity.cpp
@@ -382,6 +382,8 @@ void capacity_kibam_t::updateCapacity(double &I, double dt_hour) {
     state->leadacid.q2_0 = q2;
     state->q0 = q1 + q2;
 
+    check_SOC();
+
     update_SOC();
     check_charge_change();
 

--- a/test/ssc_test/cmod_battwatts_test.cpp
+++ b/test/ssc_test/cmod_battwatts_test.cpp
@@ -124,7 +124,7 @@ TEST_F(CMBattwatts_cmod_battwatts, ResidentialDefaultsLeadAcid) {
     EXPECT_FALSE(errors);
 
     double charge_percent = data.as_number("batt_system_charge_percent");
-    EXPECT_NEAR(charge_percent, 95.70, 0.1);
+    EXPECT_NEAR(charge_percent, 96.13, 0.1);
 
     auto batt_power_data = data.as_vector_ssc_number_t("batt_power");
     ssc_number_t peakKwDischarge = *std::max_element(batt_power_data.begin(), batt_power_data.end());
@@ -139,7 +139,7 @@ TEST_F(CMBattwatts_cmod_battwatts, ResidentialDefaultsLeadAcid) {
 
     auto cycles = data.as_vector_ssc_number_t("batt_cycles");
     ssc_number_t maxCycles = *std::max_element(cycles.begin(), cycles.end());
-    EXPECT_NEAR(maxCycles, 614, 0.1);
+    EXPECT_NEAR(maxCycles, 613, 0.1);
 }
 
 TEST_F(CMBattwatts_cmod_battwatts, NoPV) {


### PR DESCRIPTION
Fix issue #832 by ensuring the check_soc function is applied to both battery types.