### PR TITLE
Adding ACC design scaling

### DIFF
--- a/tcs/csp_solver_pc_Rankine_indirect_224.cpp
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.cpp
@@ -1965,7 +1965,7 @@ void C_pc_Rankine_indirect_224::RankineCycle_V2(double T_db, double T_wb,
                     m_eta_adj, T_db, T_wb, P_amb, q_reject, m_dot_makeup, W_cool_par, P_cond_calc, T_cond_calc, f_hrsys);
                 break;
             case 2:
-                CSP::ACC(ms_params.m_tech_type, P_cond_min, ms_params.m_n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref * 1000.),
+                CSP::ACC(ms_params.m_tech_type, P_cond_min, T_amb_des, m_Psat_ref, ms_params.m_n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref * 1000.),
                     // 22-06-09 use design efficiency instead of map efficiency
                     ms_params.m_eta_ref, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_calc, T_cond_calc, f_hrsys);
                 break;
@@ -2109,7 +2109,7 @@ void C_pc_Rankine_indirect_224::RankineCycle(double T_db, double T_wb,
 		break;
 	case 2:
 		// For a dry-cooled system
-		CSP::ACC(ms_params.m_tech_type, P_cond_min, ms_params.m_n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), m_eta_adj, T_db, P_amb, q_reject_est, m_dot_air, W_cool_par, P_cond, T_cond, f_hrsys);
+		CSP::ACC(ms_params.m_tech_type, P_cond_min, T_amb_des, m_Psat_ref, ms_params.m_n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), m_eta_adj, T_db, P_amb, q_reject_est, m_dot_air, W_cool_par, P_cond, T_cond, f_hrsys);
 		m_dot_makeup = 0.0;
 		break;
 	case 3:
@@ -2243,7 +2243,7 @@ void C_pc_Rankine_indirect_224::RankineCycle(double T_db, double T_wb,
 				CSP::evap_tower(ms_params.m_tech_type, P_cond_min, ms_params.m_n_pl_inc, dT_cw_ref, T_approach, (P_ref*1000.), m_eta_adj, T_db, T_wb, P_amb, q_reject, m_dot_makeup, W_cool_par, P_cond_guess, T_cond, f_hrsys);
 				break;
 			case 2:
-				CSP::ACC(ms_params.m_tech_type, P_cond_min, ms_params.m_n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), m_eta_adj, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_guess, T_cond, f_hrsys);
+				CSP::ACC(ms_params.m_tech_type, P_cond_min, T_amb_des, m_Psat_ref, ms_params.m_n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), m_eta_adj, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_guess, T_cond, f_hrsys);
 				break;
 			case 3:
 				CSP::HybridHR(/*fcall, */ms_params.m_tech_type, P_cond_min, ms_params.m_n_pl_inc, F_wc, F_wcmax, F_wcmin, T_ITD_des, T_approach, dT_cw_ref, P_cond_ratio, (P_ref*1000.), m_eta_adj, T_db, T_wb,

--- a/tcs/powerblock.cpp
+++ b/tcs/powerblock.cpp
@@ -649,7 +649,8 @@ void C_Indirect_PB::RankineCycle(/*double time,*/double P_ref, double eta_ref, d
 	// that is part of the power block regression coefficients. I.e. if the user provides a ref. ambient temperature
 	// of 25degC, but the power block coefficients indicate that the normalized efficiency equals 1.0 at an ambient
 	// temp of 20degC, we have to adjust the user's efficiency value back to the coefficient set.
-	water_state wp; 
+	water_state wp;
+    m_Psat_ref = 0;
 	if (m_bFirstCall)
 	{
 		double Psat_ref = 0;
@@ -682,7 +683,8 @@ void C_Indirect_PB::RankineCycle(/*double time,*/double P_ref, double eta_ref, d
 				break;
 		}
 		eta_adj = eta_ref/(Interpolate(12,2,Psat_ref)/Interpolate(22,2,Psat_ref));
-		m_bFirstCall = false;
+        m_Psat_ref = Psat_ref;
+        m_bFirstCall = false;
 	}
 
 	// Calculate the specific heat before converting to Kelvin
@@ -736,7 +738,7 @@ void C_Indirect_PB::RankineCycle(/*double time,*/double P_ref, double eta_ref, d
 			break;
 		case 2:
 			// For a dry-cooled system
-			CSP::ACC(m_pbp.tech_type, P_cond_min, m_pbp.n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), eta_adj, T_db, P_amb, q_reject_est, m_dot_air, W_cool_par, P_cond, T_cond, f_hrsys);
+			CSP::ACC(m_pbp.tech_type, P_cond_min, T_amb_des, m_Psat_ref, m_pbp.n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), eta_adj, T_db, P_amb, q_reject_est, m_dot_air, W_cool_par, P_cond, T_cond, f_hrsys);
 			m_dot_makeup = 0.0;
 			break;
 		case 3:
@@ -847,7 +849,7 @@ void C_Indirect_PB::RankineCycle(/*double time,*/double P_ref, double eta_ref, d
 					CSP::evap_tower(m_pbp.tech_type, P_cond_min, m_pbp.n_pl_inc, dT_cw_ref, T_approach, (P_ref*1000.), eta_adj, T_db, T_wb, P_amb, q_reject, m_dot_makeup, W_cool_par, P_cond_guess, T_cond, f_hrsys);
 					break;
 				case 2:
-					CSP::ACC(m_pbp.tech_type, P_cond_min, m_pbp.n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), eta_adj, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_guess, T_cond, f_hrsys);
+					CSP::ACC(m_pbp.tech_type, P_cond_min, T_amb_des, m_Psat_ref, m_pbp.n_pl_inc, T_ITD_des, P_cond_ratio, (P_ref*1000.), eta_adj, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_guess, T_cond, f_hrsys);
 					break;
 				case 3:
 					CSP::HybridHR(/*fcall, */m_pbp.tech_type, P_cond_min, m_pbp.n_pl_inc, F_wc, F_wcmax, F_wcmin, T_ITD_des, T_approach, dT_cw_ref, P_cond_ratio, (P_ref*1000.), eta_adj, T_db, T_wb,

--- a/tcs/powerblock.h
+++ b/tcs/powerblock.h
@@ -162,7 +162,7 @@ private:
 	bool m_bFirstCall;
 
 	double eta_adj, T_hot_diff, eta_acfan_s, eta_acfan, C_air, drift_loss_frac, blowdown_frac, dP_evap, eta_pump, eta_pcw_s, eta_wcfan,
-		  eta_wcfan_s, P_ratio_wcfan, mass_ratio_wcfan, Q_reject_des, q_ac_des, m_dot_acair_des, q_wc_des, c_cw, m_dot_cw_des;
+		  eta_wcfan_s, P_ratio_wcfan, mass_ratio_wcfan, Q_reject_des, q_ac_des, m_dot_acair_des, q_wc_des, c_cw, m_dot_cw_des, m_Psat_ref;
 
 	static inline double dmax1(double a, double b) {return (a > b) ? a : b; }
 	static inline double dmin1(double a, double b) {return (a < b) ? a : b; }

--- a/tcs/sam_csp_util.h
+++ b/tcs/sam_csp_util.h
@@ -96,7 +96,7 @@ namespace CSP
 					double &W_dot_tot, double &P_cond, double &T_cond, double &f_hrsys);
 
 	// Air cooling calculations
-	void ACC( int tech_type, double P_cond_min, int n_pl_inc, double T_ITD_des, double P_cond_ratio, double P_cycle, double eta_ref, 
+	void ACC( int tech_type, double P_cond_min, double T_cond_des, double P_cond_des, int n_pl_inc, double T_ITD_des, double P_cond_ratio, double P_cycle, double eta_ref,
 		 double T_db_K, double P_amb_Pa, double q_reject, double& m_dot_air, double& W_dot_fan, double& P_cond, double& T_cond, 
 		 double &f_hrsys);
 

--- a/tcs/sam_mw_type234.cpp
+++ b/tcs/sam_mw_type234.cpp
@@ -788,7 +788,7 @@ public:
 			CSP::evap_tower( m_tech_type, m_P_cond_min, m_n_pl_inc, m_dT_cw_ref, m_T_approach, m_P_ref*1000.0, m_eta_adj, T_db, T_wb, P_amb, q_reject_est, m_dot_makeup, W_cool_par, P_cond, T_cond, f_hrsys );
 			break;
 		case 2:
-			CSP::ACC( m_tech_type, m_P_cond_min, m_n_pl_inc, m_T_ITD_des, m_P_cond_ratio, m_P_ref*1000.0, m_eta_adj, T_db, P_amb, q_reject_est, m_dot_air, W_cool_par, P_cond, T_cond, f_hrsys );
+			CSP::ACC( m_tech_type, m_P_cond_min, m_T_amb_des, m_Psat_ref, m_n_pl_inc, m_T_ITD_des, m_P_cond_ratio, m_P_ref*1000.0, m_eta_adj, T_db, P_amb, q_reject_est, m_dot_air, W_cool_par, P_cond, T_cond, f_hrsys );
 			m_dot_makeup = 0.0;
 			break;
 		case 3:
@@ -934,7 +934,7 @@ public:
 					CSP::evap_tower( m_tech_type, m_P_cond_min, m_n_pl_inc, m_dT_cw_ref, m_T_approach, m_P_ref*1000.0, m_eta_adj, T_db, T_wb, P_amb, q_reject, m_dot_makeup, W_cool_par, P_cond_guess, T_cond, f_hrsys );
 					break;
 				case 2:
-					CSP::ACC( m_tech_type, m_P_cond_min, m_n_pl_inc, m_T_ITD_des, m_P_cond_ratio, m_P_ref*1000.0, m_eta_adj, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_guess, T_cond, f_hrsys );
+					CSP::ACC( m_tech_type, m_P_cond_min, m_T_amb_des, m_Psat_ref, m_n_pl_inc, m_T_ITD_des, m_P_cond_ratio, m_P_ref*1000.0, m_eta_adj, T_db, P_amb, q_reject, m_dot_air, W_cool_par, P_cond_guess, T_cond, f_hrsys );
 					break;
 				case 3:
 					CSP::HybridHR( m_tech_type, m_P_cond_min, m_n_pl_inc, F_wc_tou, m_F_wcmax, m_F_wcmin, m_T_ITD_des, m_T_approach, m_dT_cw_ref, m_P_cond_ratio, m_P_ref*1000.0, m_eta_adj, T_db, T_wb,


### PR DESCRIPTION
ACC model now scales with design condenser pressure. Scaling ratio is determined based on the user design inputs for condenser temperature and pressure (pressure is based on ITD input)