### PR TITLE
Fix issue with cmake finding debug paths for SSC tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.12
+      with:
+        cmake-version: '3.24.x'
+    - name: Test cmake version
+      run: cmake --version
     
     - name: Set relative paths
       run: | 
@@ -73,6 +79,12 @@ jobs:
     runs-on: macos-11
 
     steps:
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.12
+      with:
+        cmake-version: '3.24.x'
+    - name: Test cmake version
+      run: cmake --version
     
     - name: Set relative paths
       run: | 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 #####################################################################################################################
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.24)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,14 +75,7 @@ endif()
 #
 #####################################################################################################################
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR MSVC)
-find_library( GTESTD_LIB
-        NAMES libgtestd.a gtestd.lib libgtestd.so
-        PATHS $ENV{GTESTD_DIR} ${GTDIR}/build/lib ${GTDIR}/build/lib/Debug)
-target_link_libraries(Test debug ${GTESTD_LIB})
-endif()
-
-if (CMAKE_BUILD_TYPE STREQUAL "Release" OR MSVC)
+if (CMAKE_BUILD_TYPE STREQUAL "Release" OR "Debug" OR MSVC)
     find_library( GTEST_LIB
             NAMES libgtest.a gtest.lib libgtest.so
             PATHS $ENV{GTEST_DIR} ${GTDIR}/build/lib ${GTDIR}/build/lib/Release)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,13 @@ endif()
 #
 #####################################################################################################################
 
-if (CMAKE_BUILD_TYPE STREQUAL "Release" OR "Debug" OR MSVC)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR MSVC)
+    find_library( GTESTD_LIB
+            NAMES libgtest.a gtest.lib libgtest.so
+            PATHS $ENV{GTEST_DIR} ${GTDIR}/build/lib ${GTDIR}/build/lib/Debug)
+    target_link_libraries(Test debug ${GTESTD_LIB})
+endif()
+if (CMAKE_BUILD_TYPE STREQUAL "Release" OR MSVC)
     find_library( GTEST_LIB
             NAMES libgtest.a gtest.lib libgtest.so
             PATHS $ENV{GTEST_DIR} ${GTDIR}/build/lib ${GTDIR}/build/lib/Release)


### PR DESCRIPTION
* Need to verify this does not break build process for Linux and Mac

* Depends on single environment variable GTDIR pointing to top-level googletest folder as described in revised Windows build instructions: https://github.com/NREL/SAM/wiki/Windows-Build-Instructions