### PR TITLE
add ts_hour to ac wiring loss line

### DIFF
--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -2328,7 +2328,7 @@ void cm_pvsamv1::exec()
                 annual_dc_loss_ond += sharedInverter->dcWiringLoss_ond_kW * ts_hour; // (TR)
                 annual_ac_loss_ond += sharedInverter->dcWiringLoss_ond_kW * ts_hour; // (TR)
 
-                annual_ac_wiring_loss += ac_wiringloss;
+                annual_ac_wiring_loss += ac_wiringloss * ts_hour;
             }
 
             if (iyear == 0 || save_full_lifetime_variables == 1)


### PR DESCRIPTION
To test:

- Run a subhourly simulation
- Confirm that the AC wiring losses match the input (1% is default)

Unchecking the "save all output variables over lifetime" option is recommended if testing with a one minute weather file.

Fixes https://github.com/NREL/SAM/issues/1082