### PR TITLE
Update pv smoothing battery soc at the end of the step

### DIFF
--- a/shared/lib_battery_dispatch_pvsmoothing_fom.cpp
+++ b/shared/lib_battery_dispatch_pvsmoothing_fom.cpp
@@ -322,6 +322,9 @@ void dispatch_pvsmoothing_front_of_meter_t::update_dispatch(size_t year, size_t 
                 }
             }
 
+            // Update SOC to match convention from mainline battery code
+            battery_soc -= battery_power_terminal * power_to_energy_conversion_factor;
+
             // unscaled in public functions
             m_batt_dispatch_pvs_outpower = out_power;
             m_batt_dispatch_pvs_battpower = battery_power_terminal;


### PR DESCRIPTION
Steps to get things to line up with the mainline battery SOC:

1. Open a PV-Battery FOM case
2. Use a 15 minute weather file (or shorter)
3. Set analysis period to 1 year
4. Set the ramp timestep multiplier to 1