### PR TITLE
Fix annual total loss percent output value

### DIFF
--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -915,8 +915,7 @@ static var_info _cm_vtab_pvsamv1[] = {
             
                 { SSC_OUTPUT, SSC_NUMBER, "annual_dc_optimizer_loss", "DC power optimizer loss", "kWh", "", "Annual (Year 1)", "", "", "" },
 
-                // total loss diagram losses for single year, does not include lifetime losses
-                { SSC_OUTPUT, SSC_NUMBER, "annual_total_loss_percent", "Total loss from nominal POA to net AC", "kWh", "", "Annual (Year 1)", "", "", "" },
+                { SSC_OUTPUT, SSC_NUMBER, "annual_total_loss_percent", "Total loss from nominal POA to net AC", "%", "", "Annual (Year 1)", "", "", "" },
 
                 //
 
@@ -3133,28 +3132,7 @@ void cm_pvsamv1::exec()
         assign("annual_ac_perf_adj_loss_percent", var_data((ssc_number_t)percent));
         sys_output *= (1.0 - percent / 100.0);
 
-        // total loss diagram losses for single-year simulation (life time losses not included)
-        std::vector<std::string> loss_components = { "annual_poa_shading_loss_percent", "annual_poa_soiling_loss_percent",
-                                                 "annual_poa_cover_loss_percent", "annual_ground_incident_percent",
-                                                 "annual_ground_absorbed_percent", "annual_rear_ground_reflected_percent",
-                                                 "annual_rear_row_reflections_percent", "annual_rear_direct_diffuse_percent",
-                                                 "annual_rear_self_shaded_percent", "annual_rack_shaded_percent",
-                                                 "annual_rear_soiled_percent", "annual_bifacial_electrical_mismatch_percent",
-                                                 "annual_dc_snow_loss_percent", "annual_dc_module_loss_percent",
-                                                 "annual_dc_mppt_clip_loss_percent", "annual_dc_mismatch_loss_percent",
-                                                 "annual_dc_diodes_loss_percent", "annual_dc_wiring_loss_percent",
-                                                 "annual_dc_tracking_loss_percent", "annual_dc_nameplate_loss_percent",
-                                                 "annual_dc_optimizer_loss_percent", "annual_dc_perf_adj_loss_percent",
-                                                 "annual_dc_battery_loss_percent", "annual_ac_battery_loss_percent",
-                                                 "annual_ac_inv_clip_loss_percent", "annual_ac_inv_pso_loss_percent",
-                                                 "annual_ac_inv_pnt_loss_percent","annual_ac_inv_eff_loss_percent",
-                                                 "annual_ac_wiring_loss_percent", "annual_xfmr_loss_percent",
-                                                 "annual_transmission_loss_percent", "annual_ac_perf_adj_loss_percent"};
-        percent = 1.;
-        for (size_t i = 0; i < loss_components.size(); i++) {
-            percent *= (1. - as_number(loss_components[i]) / 100.);
-        }
-        assign("annual_total_loss_percent", var_data((ssc_number_t)(1. - percent) * 100.));
+        assign("annual_total_loss_percent", var_data((ssc_number_t)((1. - annual_energy / as_number("annual_poa_eff")) * 100.)));
         // annual_ac_net = system_output
         //After calculating total loss remove Battery loss percentages from outputs
         if (!en_batt) {


### PR DESCRIPTION
This fixes the calculation for both gain terms and bifacial terms and this issue doesn't need to be revisited after the release.

Closes #911 