### PR TITLE
add replacement for batterystateful

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -111,7 +111,7 @@ thermal_t &thermal_t::operator=(const thermal_t &rhs) {
 thermal_t *thermal_t::clone() { return new thermal_t(*this); }
 
 void thermal_t::replace_battery(size_t lifetimeIndex) {
-    if (params->option == thermal_params::VALUE)
+    if (params->option == thermal_params::SCHEDULE)
         state->T_batt = params->T_room_schedule[lifetimeIndex % params->T_room_schedule.size()];
     else
         state->T_batt = state->T_room;

--- a/ssc/cmod_battery_stateful.cpp
+++ b/ssc/cmod_battery_stateful.cpp
@@ -614,6 +614,17 @@ void cm_battery_stateful::exec() {
         battery->ChangeTimestep(dt_hr);
     }
 
+    // Replacements
+    size_t lifetime_index = as_integer("last_idx");
+    size_t steps_per_hour = (size_t)(1 / control_dt_hr);
+    size_t steps_per_year = (size_t)(8760 * steps_per_hour);
+    size_t year = (size_t)(lifetime_index / steps_per_year);
+    size_t year_one_index = lifetime_index - (year * steps_per_year);
+    size_t hour = (size_t)(year_one_index / steps_per_hour);
+    size_t step_of_hour = year_one_index - (hour * steps_per_hour);
+
+    battery->runReplacement(year, hour, step_of_hour);
+
     // Simulate
     if (static_cast<MODE>(as_integer("control_mode")) == MODE::CURRENT) {
         double I = as_number("input_current");

--- a/test/ssc_test/cmod_battery_stateful_test.cpp
+++ b/test/ssc_test/cmod_battery_stateful_test.cpp
@@ -379,7 +379,7 @@ TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestReplacementbySche
     var_table *vt = static_cast<var_table*>(data);
 
     EXPECT_EQ(vt->as_integer("n_replacements"), 1);
-    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 8760);
+    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 17520);
     EXPECT_EQ(vt->as_number("q_relative"), 100);
 }
 
@@ -423,6 +423,6 @@ TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestReplacementByCapa
     var_table* vt = static_cast<var_table*>(data);
 
     EXPECT_EQ(vt->as_integer("n_replacements"), 1);
-    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 1);
+    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 2);
     EXPECT_EQ(vt->as_number("q_relative"), 100);
 }

--- a/test/ssc_test/cmod_battery_stateful_test.cpp
+++ b/test/ssc_test/cmod_battery_stateful_test.cpp
@@ -336,3 +336,93 @@ TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestCycleCount) {
     EXPECT_FALSE(vt->is_assigned("cycle_DOD_max"));
 
 }
+
+TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestReplacementbySchedule) {
+    // test replacement by schedule
+    CreateModel(1);
+
+    ssc_number_t schedule[3] = {0, 50, 0};
+    ssc_data_set_array(data, "replacement_schedule_percent", schedule, 2);
+    ssc_data_set_number(data, "replacement_option", 2);
+    ssc_data_set_number(data, "input_current", 0);
+    EXPECT_TRUE(ssc_stateful_module_setup(mod, data));
+
+    ssc_data_set_number(data, "q_relative_cycle", 50);
+
+    for (size_t i = 0; i < 365 * 24 + 2; i++) {
+        ssc_module_exec(mod, data);
+    }
+
+    var_table* vt = static_cast<var_table*>(data);
+
+    EXPECT_EQ(vt->as_integer("n_replacements"), 1);
+    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 8760);
+    EXPECT_EQ(vt->as_number("q_relative"), 100);
+}
+
+TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestReplacementbyScheduleSubhourly) {
+    // test subhourly
+    CreateModel(0.5);
+
+    ssc_number_t schedule[3] = {0, 50, 0};
+    ssc_data_set_array(data, "replacement_schedule_percent", schedule, 2);
+    ssc_data_set_number(data, "replacement_option", 2);
+    ssc_data_set_number(data, "input_current", 0);
+    EXPECT_TRUE(ssc_stateful_module_setup(mod, data));
+
+    ssc_data_set_number(data, "q_relative_cycle", 50);
+
+    for (size_t i = 0; i < 365 * 24 * 2 + 2; i++) {
+        ssc_module_exec(mod, data);
+    }
+
+    var_table *vt = static_cast<var_table*>(data);
+
+    EXPECT_EQ(vt->as_integer("n_replacements"), 1);
+    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 8760);
+    EXPECT_EQ(vt->as_number("q_relative"), 100);
+}
+
+TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestReplacementByCapacity) {
+    // test replacement by capacity
+    CreateModel(1);
+
+    ssc_data_set_number(data, "replacement_option", 1);
+    ssc_data_set_number(data, "replacement_capacity", 50);
+    EXPECT_TRUE(ssc_stateful_module_setup(mod, data));
+
+    ssc_data_set_number(data, "q_relative_cycle", 50);
+    ssc_data_set_number(data, "q_relative_calendar", 50);
+
+    for (size_t i = 0; i < 2; i++) {
+        ssc_module_exec(mod, data);
+    }
+
+    var_table* vt = static_cast<var_table*>(data);
+
+    EXPECT_EQ(vt->as_integer("n_replacements"), 1);
+    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 1);
+    EXPECT_EQ(vt->as_number("q_relative"), 100);
+}
+
+TEST_F(CMBatteryStatefulIntegration_cmod_battery_stateful, TestReplacementByCapacitySubhourly) {
+    // test subhourly
+    CreateModel(0.5);
+
+    ssc_data_set_number(data, "replacement_option", 1);
+    ssc_data_set_number(data, "replacement_capacity", 50);
+    EXPECT_TRUE(ssc_stateful_module_setup(mod, data));
+
+    ssc_data_set_number(data, "q_relative_cycle", 50);
+    ssc_data_set_number(data, "q_relative_calendar", 50);
+
+    for (size_t i = 0; i < 5; i++) {
+        ssc_module_exec(mod, data);
+    }
+
+    var_table* vt = static_cast<var_table*>(data);
+
+    EXPECT_EQ(vt->as_integer("n_replacements"), 1);
+    EXPECT_EQ(vt->as_vector_ssc_number_t("indices_replaced")[1], 1);
+    EXPECT_EQ(vt->as_number("q_relative"), 100);
+}


### PR DESCRIPTION
Fixes #918 

Problem reported here: https://sam.nrel.gov/forum/forum-general/3080-battery-augmentation-strategy.html?start=6

In that Jupyter notebook example, there are no replacements reported at the end running `simulation['Battery Replacements'].resample("Y").sum()`

Now with this fix, this cmd `simulation['Battery Replacements'].resample("Y").mean()` gives replacements at year 10 and year 19

![image](https://user-images.githubusercontent.com/29387736/199077368-eb5e2aa5-232c-44ed-946c-47808e23815c.png)
