### PR TITLE
Ssc 923 use prod factors

### DIFF
--- a/ssc/cmod_pvsamv1_eqns.cpp
+++ b/ssc/cmod_pvsamv1_eqns.cpp
@@ -157,7 +157,7 @@ SSCEXPORT bool Reopt_size_battery_params(ssc_data_t data) {
     std::vector<double> kwac_per_kwdc(year_one_values);
     for (size_t i = 0; i < year_one_values; i++) {
         kwac_per_kwdc[i] = gen[i] / system_cap;
-        kwac_per_kwdc[i] = std::fmax(0.0, kwac_per_kwdc[i]);
+        kwac_per_kwdc[i] = std::max(0.0, kwac_per_kwdc[i]);
     }
     reopt_pv.assign("prod_factor_series_kw", kwac_per_kwdc);
     // The above already includes losses

--- a/ssc/cmod_pvsamv1_eqns.cpp
+++ b/ssc/cmod_pvsamv1_eqns.cpp
@@ -118,8 +118,6 @@ SSCEXPORT bool Reopt_size_battery_params(ssc_data_t data) {
     assign_matching_pv_vars(reopt_pv, "azimuth", "subarray1_azimuth");
     assign_matching_pv_vars(reopt_pv, "tilt", "subarray1_tilt");
     assign_matching_pv_vars(reopt_pv, "gcr", "subarray1_gcr");
-    assign_matching_pv_vars(reopt_pv, "losses", "annual_total_loss_percent", true);
-
 
     // Get appropriate inverter efficiency input and transform to ratio from percent
     int inv_model = 0;
@@ -150,6 +148,19 @@ SSCEXPORT bool Reopt_size_battery_params(ssc_data_t data) {
         map_input(vt, "inv_eff", &reopt_batt, "inverter_efficiency_pct", false, true);
         map_input(vt, "dc_ac_ratio", &reopt_pv, "dc_ac_ratio");
     }
+
+    std::vector<double> gen;
+    vt_get_array_vec(vt, "gen", gen);
+    int analysis_period;
+    vt_get_int(vt, "analysis_period", &analysis_period);
+    size_t year_one_values = gen.size() / analysis_period;
+    std::vector<double> kwac_per_kwdc(year_one_values);
+    for (size_t i = 0; i < year_one_values; i++) {
+        kwac_per_kwdc[i] = gen[i] / system_cap;
+    }
+    reopt_pv.assign("prod_factor_series_kw", kwac_per_kwdc);
+    // The above already includes losses
+    reopt_pv.assign("losses", 0.0);
 
     // financial inputs
     map_optional_input(vt, "itc_fed_percent", &reopt_pv, "federal_itc_pct", 0., true);

--- a/ssc/cmod_pvsamv1_eqns.cpp
+++ b/ssc/cmod_pvsamv1_eqns.cpp
@@ -157,6 +157,7 @@ SSCEXPORT bool Reopt_size_battery_params(ssc_data_t data) {
     std::vector<double> kwac_per_kwdc(year_one_values);
     for (size_t i = 0; i < year_one_values; i++) {
         kwac_per_kwdc[i] = gen[i] / system_cap;
+        kwac_per_kwdc[i] = std::fmax(0.0, kwac_per_kwdc[i]);
     }
     reopt_pv.assign("prod_factor_series_kw", kwac_per_kwdc);
     // The above already includes losses

--- a/ssc/cmod_pvsamv1_eqns.cpp
+++ b/ssc/cmod_pvsamv1_eqns.cpp
@@ -168,6 +168,7 @@ SSCEXPORT bool Reopt_size_battery_params(ssc_data_t data) {
     else if (vt->is_assigned("losses")) {
         map_input(vt, "losses", &reopt_pv, "losses");
     }
+    // Else use REopt default losses (14%)
 
     // financial inputs
     map_optional_input(vt, "itc_fed_percent", &reopt_pv, "federal_itc_pct", 0., true);

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -1089,7 +1089,8 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, reopt_sizing) {
     belpe_default(data);
     ssc_data_set_number(data, "lat", 30);
     ssc_data_set_number(data, "lon", -30);
-    ssc_data_set_number(data, "losses", 15);
+    ssc_number_t gen[8760] = { 0 };
+    ssc_data_set_array(data, "gen", gen, 8760);
 
     Reopt_size_battery_params(data);
 


### PR DESCRIPTION
Use production factors from the actual system instead of lat/lon when getting size and dispatch from REopt. Additional required changes in SAM PR: https://github.com/NREL/SAM/pull/1165 Fixes #923 

Steps to test:
1. Run the attached SAM and weather files in 2021.12.02: 
[2018_weather_file_dispatch.zip](https://github.com/NREL/ssc/files/9923585/2018_weather_file_dispatch.zip)
2. Build SAM from this branch and the SAM branch sam_1092_update_reopt_script
3. See improved sizing and dispatch (via improved NPV) on branches
