### PR TITLE
Remove extraneous i==1 from cashloan. Also correct typo in comments to issue number (1038)

### DIFF
--- a/ssc/cmod_cashloan.cpp
+++ b/ssc/cmod_cashloan.cpp
@@ -303,7 +303,7 @@ enum {
     CF_utility_bill,
     CF_parasitic_cost,
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_amount,
     CF_itc_fed_percent_maxvalue,
@@ -704,7 +704,7 @@ public:
 			- ( as_boolean("cbi_oth_deprbas_fed")  ? cbi_oth_amount : 0 );
 
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -767,14 +767,14 @@ public:
 			- ( as_boolean("cbi_oth_deprbas_sta")  ? cbi_oth_amount : 0 );
 
 
-        // SAM 1308
+        // SAM 1038
         itc_sta_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_sta_percent_amount, k) = min(cf.at(CF_itc_sta_percent_maxvalue, k), cf.at(CF_itc_sta_percent_amount, k) * state_itc_basis);
             itc_sta_per += cf.at(CF_itc_sta_percent_amount, k);
         }
 
-        // SAM 1308
+        // SAM 1038
         itc_fed_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed_percent_amount, k) = min(cf.at(CF_itc_fed_percent_maxvalue, k), cf.at(CF_itc_fed_percent_amount, k) * federal_itc_basis);
@@ -863,7 +863,7 @@ public:
 //		double itc_total_fed = itc_fed_amount + itc_fed_per;
 //		double itc_total_sta = itc_sta_amount + itc_sta_per;
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -1005,7 +1005,7 @@ public:
 				cf.at(CF_sta_taxable_income_less_deductions, i) -= cf.at(CF_debt_payment_interest,i);
 
 			cf.at(CF_sta_tax_savings, i) = cf.at(CF_ptc_sta,i) - cf.at(CF_state_tax_frac,i)*cf.at(CF_sta_taxable_income_less_deductions,i);
-// SAM 1308			if (i==1) cf.at(CF_sta_tax_savings, i) += itc_sta_amount + itc_sta_per;
+// SAM 1038			if (i==1) cf.at(CF_sta_tax_savings, i) += itc_sta_amount + itc_sta_per;
             cf.at(CF_sta_tax_savings, i) += cf.at(CF_itc_sta_amount,i) + cf.at(CF_itc_sta_percent_amount,i);
 
 			// ************************************************
@@ -1039,8 +1039,8 @@ public:
 				cf.at(CF_fed_taxable_income_less_deductions, i) -= cf.at(CF_debt_payment_interest,i);
 			
 			cf.at(CF_fed_tax_savings, i) = cf.at(CF_ptc_fed,i) - cf.at(CF_federal_tax_frac,i)*cf.at(CF_fed_taxable_income_less_deductions,i);
-//  SAM 1308          if (i == 1) cf.at(CF_fed_tax_savings, i) += itc_fed_amount + itc_fed_per;
-            if (i == 1) cf.at(CF_fed_tax_savings, i) += cf.at(CF_itc_fed_amount,i) + cf.at(CF_itc_fed_percent_amount,i);
+//  SAM 1038          if (i == 1) cf.at(CF_fed_tax_savings, i) += itc_fed_amount + itc_fed_per;
+            cf.at(CF_fed_tax_savings, i) += cf.at(CF_itc_fed_amount,i) + cf.at(CF_itc_fed_percent_amount,i);
 
 			// ************************************************
 			// combined tax savings and cost/cash flows
@@ -1418,7 +1418,7 @@ public:
 		save_cf( CF_ptc_total, nyears, "cf_ptc_total" );
 
 
-        // SAM 1308
+        // SAM 1038
         double itc_fed_total = 0.0;
         double itc_sta_total = 0.0;
         double itc_total = 0.0;
@@ -1486,7 +1486,7 @@ public:
 		assign( "present_value_insandproptax", var_data((ssc_number_t)(pvInsurance + pvPropertyTax)));
 
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_communitysolar.cpp
+++ b/ssc/cmod_communitysolar.cpp
@@ -1118,7 +1118,7 @@ enum {
     CF_community_solar_recurring_capacity,
     CF_community_solar_recurring_generation,
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -2088,7 +2088,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue"); 
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2998,7 +2998,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -3255,7 +3255,7 @@ public:
 				cf.at(CF_statax,i) +
 				cf.at(CF_ptc_sta,i) +
                 cf.at(CF_itc_sta, i);
-            //	SAM 1308		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
+            //	SAM 1038		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
 
 
 			// pbi in ebitda - so remove if non-taxable
@@ -3267,7 +3267,7 @@ public:
 				cf.at(CF_project_return_aftertax_cash,i) +
 				cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i) +
 				cf.at(CF_statax,i) + cf.at(CF_fedtax,i) + cf.at(CF_itc_total, i);
-            //	SAM 1308		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
+            //	SAM 1038		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
 
 
 			cf.at(CF_project_return_aftertax_irr,i) = irr(CF_project_return_aftertax,i)*100.0;
@@ -3470,7 +3470,7 @@ public:
 			- cf.at(CF_disbursement_debtservice, i) // note sign is negative for positive disbursement
 			- cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
 			+ cf.at(CF_net_salvage_value, i)// benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
     }
     // year 1 add total ITC (net benefit) so that project return = project revenue - project cost
     //if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -3688,7 +3688,7 @@ public:
 		assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 		assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-        // SAM 1308
+        // SAM 1038
         double itc_fed_total = 0.0;
         double itc_sta_total = 0.0;
         double itc_total = 0.0;
@@ -4407,7 +4407,7 @@ public:
         cfm.check_npv(this, npv_metric);
         cfm.check_debt_percentage(this, debt_fraction);
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_equpartflip.cpp
+++ b/ssc/cmod_equpartflip.cpp
@@ -896,7 +896,7 @@ enum {
 
     CF_utility_bill,
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -1502,7 +1502,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue");
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2152,7 +2152,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -2394,7 +2394,7 @@ public:
 				cf.at(CF_statax,i) +
 				cf.at(CF_ptc_sta,i) +
                 cf.at(CF_itc_sta, i);
-            //	SAM 1308		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
+            //	SAM 1038		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
 
 
 			// pbi in ebitda - so remove if non-taxable
@@ -2407,7 +2407,7 @@ public:
 				cf.at(CF_project_return_aftertax_cash,i) +
 				cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i) +
 				cf.at(CF_statax,i) + cf.at(CF_fedtax,i) + cf.at(CF_itc_total, i);
-            //	SAM 1308		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
+            //	SAM 1038		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
 
 
 			cf.at(CF_project_return_aftertax_irr,i) = irr(CF_project_return_aftertax,i)*100.0;
@@ -2463,7 +2463,7 @@ public:
 						tax_investor_preflip_cash_frac : tax_investor_postflip_cash_frac) * ( cf.at(CF_project_return_aftertax_cash,i) + cf.at(CF_sponsor_capital_recovery_cash,i) );
 			cf.at(CF_tax_investor_aftertax_ptc,i) =  ((cf.at(CF_tax_investor_aftertax_max_irr,i-1) < flip_target_percent) ?
 						tax_investor_preflip_tax_frac : tax_investor_postflip_tax_frac) * (cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i));
-// SAM 1308            if (i == 1)
+// SAM 1038            if (i == 1)
 //                cf.at(CF_tax_investor_aftertax_itc, i) = ((cf.at(CF_tax_investor_aftertax_max_irr, i - 1) < flip_target_percent) ?
 //                    tax_investor_preflip_tax_frac : tax_investor_postflip_tax_frac) * itc_total;
             cf.at(CF_tax_investor_aftertax_itc, i) = ((cf.at(CF_tax_investor_aftertax_max_irr, i - 1) < flip_target_percent) ?
@@ -2501,7 +2501,7 @@ public:
 			cf.at(CF_sponsor_aftertax_cash,i) = cf.at(CF_project_return_aftertax_cash,i) - cf.at(CF_tax_investor_aftertax_cash,i);
 			cf.at(CF_sponsor_pretax,i) = cf.at(CF_sponsor_aftertax_cash,i);
 			cf.at(CF_sponsor_aftertax_ptc,i) = (cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i)) - cf.at(CF_tax_investor_aftertax_ptc,i);
-// SAM 1308            if (i == 1) cf.at(CF_sponsor_aftertax_itc, i) = itc_total - cf.at(CF_tax_investor_aftertax_itc, i);
+// SAM 1038            if (i == 1) cf.at(CF_sponsor_aftertax_itc, i) = itc_total - cf.at(CF_tax_investor_aftertax_itc, i);
             cf.at(CF_sponsor_aftertax_itc, i) = cf.at(CF_itc_total,i) - cf.at(CF_tax_investor_aftertax_itc, i);
             cf.at(CF_sponsor_aftertax_tax,i) = (cf.at(CF_statax,i) + cf.at(CF_fedtax,i)) - cf.at(CF_tax_investor_aftertax_tax,i);
 			cf.at(CF_sponsor_aftertax,i) =
@@ -2677,7 +2677,7 @@ public:
 			+ cf.at(CF_reserve_interest, i)
 			- cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
 			+ cf.at(CF_net_salvage_value, i)// benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
     }
     // year 1 add total ITC (net benefit) so that project return = project revenue - project cost
     //if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -2857,7 +2857,7 @@ public:
 		assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 		assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-        // SAM 1308
+        // SAM 1038
         double itc_fed_total = 0.0;
         double itc_sta_total = 0.0;
         double itc_total = 0.0;
@@ -3486,7 +3486,7 @@ public:
         cfm.check_npv(this, npv_ti);
         cfm.check_npv(this, npv_sp);
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_host_developer.cpp
+++ b/ssc/cmod_host_developer.cpp
@@ -879,7 +879,7 @@ enum {
     CF_utility_bill,
     CF_parasitic_cost,
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -1434,7 +1434,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue");
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2283,7 +2283,7 @@ public:
 
 		itc_sta_qual_total = itc_sta_qual_macrs_5 + itc_sta_qual_macrs_15 + itc_sta_qual_sl_5 +itc_sta_qual_sl_15 +itc_sta_qual_sl_20 + itc_sta_qual_sl_39 + itc_sta_qual_custom;
 
-        // SAM 1308
+        // SAM 1038
         itc_sta_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_sta_percent_amount, k) = min(cf.at(CF_itc_sta_percent_maxvalue, k), cf.at(CF_itc_sta_percent_fraction, k) * itc_sta_qual_total);
@@ -2337,7 +2337,7 @@ public:
 
 		itc_fed_qual_total = itc_fed_qual_macrs_5 + itc_fed_qual_macrs_15 + itc_fed_qual_sl_5 +itc_fed_qual_sl_15 +itc_fed_qual_sl_20 + itc_fed_qual_sl_39 + itc_fed_qual_custom;
 
-        // SAM 1308
+        // SAM 1038
         itc_fed_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed_percent_amount, k) = min(cf.at(CF_itc_fed_percent_maxvalue, k), cf.at(CF_itc_fed_percent_fraction, k) * itc_fed_qual_total);
@@ -2381,7 +2381,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -2633,7 +2633,7 @@ public:
 				cf.at(CF_statax,i) +
 				cf.at(CF_ptc_sta,i) +
                 cf.at(CF_itc_sta, i);
-            //	SAM 1308		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
+            //	SAM 1038		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
 
 
 			// pbi in ebitda - so remove if non-taxable
@@ -2645,7 +2645,7 @@ public:
 				cf.at(CF_project_return_aftertax_cash,i) +
 				cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i) +
 				cf.at(CF_statax,i) + cf.at(CF_fedtax,i) + cf.at(CF_itc_total, i);
-            //	SAM 1308		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
+            //	SAM 1038		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
 
 
 			cf.at(CF_project_return_aftertax_irr,i) = irr(CF_project_return_aftertax,i)*100.0;
@@ -3002,7 +3002,7 @@ public:
 			- cf.at(CF_disbursement_debtservice, i) // note sign is negative for positive disbursement
 			- cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
 			+ cf.at(CF_net_salvage_value, i)// benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
     }
     // year 1 add total ITC (net benefit) so that project return = project revenue - project cost
     //if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -3202,7 +3202,7 @@ public:
 	assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 	assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-    // SAM 1308
+    // SAM 1038
     double itc_fed_total = 0.0;
     double itc_sta_total = 0.0;
     double itc_total = 0.0;
@@ -3800,7 +3800,7 @@ public:
         cfm.check_debt_percentage(this, debt_fraction);
 
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_ippppa.cpp
+++ b/ssc/cmod_ippppa.cpp
@@ -413,7 +413,7 @@ enum {
 	CF_pretax_dscr,
 
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -744,7 +744,7 @@ public:
 			- (as_boolean("cbi_oth_deprbas_fed") ? cbi_oth_amount : 0);
 
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -807,14 +807,14 @@ public:
 
 
 
-        // SAM 1308
+        // SAM 1038
         itc_sta_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_sta_percent_amount, k) = min(cf.at(CF_itc_sta_percent_maxvalue, k), cf.at(CF_itc_sta_percent_fraction, k) * state_itc_basis);
             itc_sta_per += cf.at(CF_itc_sta_percent_amount, k);
         }
 
-        // SAM 1308
+        // SAM 1038
         itc_fed_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed_percent_amount, k) = min(cf.at(CF_itc_fed_percent_maxvalue, k), cf.at(CF_itc_fed_percent_fraction, k) * federal_itc_basis);
@@ -895,7 +895,7 @@ public:
 
 //        itc_fed_total = itc_fed_amount + itc_fed_per;
 //		itc_sta_total = itc_sta_amount + itc_sta_per;
-               // SAM 1308
+               // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -1286,7 +1286,7 @@ public:
 		assign("present_value_insandproptax", var_data((ssc_number_t)(pvInsurance + pvPropertyTax)));
 
 
-        // SAM 1308
+        // SAM 1038
         save_cf(this, cf, CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(this, cf, CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(this, cf, CF_itc_fed, nyears, "cf_itc_fed");
@@ -1899,7 +1899,7 @@ public:
 			cf.at(CF_sta_income_taxes, i) = cf.at(CF_state_tax_frac, i)*cf.at(CF_sta_taxable_income_less_deductions, i);
 
 			cf.at(CF_sta_tax_savings, i) = cf.at(CF_ptc_sta, i) - cf.at(CF_sta_income_taxes, i);
-// SAM 1308            if (i == 1) cf.at(CF_sta_tax_savings, i) += itc_sta_amount + itc_sta_per;
+// SAM 1038            if (i == 1) cf.at(CF_sta_tax_savings, i) += itc_sta_amount + itc_sta_per;
             cf.at(CF_sta_tax_savings, i) += cf.at(CF_itc_sta_amount,i) + cf.at(CF_itc_sta_percent_amount,i);
 
 			// ************************************************
@@ -1923,7 +1923,7 @@ public:
 			cf.at(CF_fed_income_taxes, i) = cf.at(CF_federal_tax_frac, i)*cf.at(CF_fed_taxable_income_less_deductions, i);
 
 			cf.at(CF_fed_tax_savings, i) = cf.at(CF_ptc_fed, i) - cf.at(CF_fed_income_taxes, i);
-// sam 1308			if (i == 1) cf.at(CF_fed_tax_savings, i) += itc_fed_amount + itc_fed_per;
+// SAM 1038			if (i == 1) cf.at(CF_fed_tax_savings, i) += itc_fed_amount + itc_fed_per;
             cf.at(CF_fed_tax_savings, i) += cf.at(CF_itc_fed_amount,i) + cf.at(CF_itc_fed_percent_amount,i);
 
 			// ************************************************

--- a/ssc/cmod_levpartflip.cpp
+++ b/ssc/cmod_levpartflip.cpp
@@ -917,7 +917,7 @@ enum {
 
     CF_utility_bill,
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -1534,7 +1534,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue");
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2470,7 +2470,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -2724,7 +2724,7 @@ public:
 				cf.at(CF_statax,i) +
 				cf.at(CF_ptc_sta,i) +
                 cf.at(CF_itc_sta, i);
-            //	SAM 1308		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
+            //	SAM 1038		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
 
 
 			// pbi in ebitda - so remove if non-taxable
@@ -2736,7 +2736,7 @@ public:
 				cf.at(CF_project_return_aftertax_cash,i) +
 				cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i) +
 				cf.at(CF_statax,i) + cf.at(CF_fedtax,i) + cf.at(CF_itc_total, i);
-            //	SAM 1308		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
+            //	SAM 1038		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
 
 			cf.at(CF_project_return_aftertax_irr,i) = irr(CF_project_return_aftertax,i)*100.0;
 			cf.at(CF_project_return_aftertax_npv,i) = npv(CF_project_return_aftertax,i,nom_discount_rate) +  cf.at(CF_project_return_aftertax,0) ;
@@ -2793,7 +2793,7 @@ public:
 						tax_investor_preflip_cash_frac : tax_investor_postflip_cash_frac) * cf.at(CF_project_return_aftertax_cash,i);
 			cf.at(CF_tax_investor_aftertax_ptc,i) =  ((cf.at(CF_tax_investor_aftertax_max_irr,i-1) < flip_target_percent) ?
 						tax_investor_preflip_tax_frac : tax_investor_postflip_tax_frac) * (cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i));
-            // SAM 1308
+            // SAM 1038
 //            if (i == 1)
 //                cf.at(CF_tax_investor_aftertax_itc, i) = ((cf.at(CF_tax_investor_aftertax_max_irr, i - 1) < flip_target_percent) ?
 //                    tax_investor_preflip_tax_frac : tax_investor_postflip_tax_frac) * itc_total;
@@ -2829,7 +2829,7 @@ public:
 			cf.at(CF_sponsor_pretax_cash, i) = cf.at(CF_sponsor_aftertax_cash, i);
 			cf.at(CF_sponsor_pretax,i) = cf.at(CF_sponsor_pretax_cash,i);
 			cf.at(CF_sponsor_aftertax_ptc,i) = (cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i)) - cf.at(CF_tax_investor_aftertax_ptc,i);
-// SAM 1308            if (i == 1) cf.at(CF_sponsor_aftertax_itc, i) = itc_total - cf.at(CF_tax_investor_aftertax_itc, i);
+// SAM 1038            if (i == 1) cf.at(CF_sponsor_aftertax_itc, i) = itc_total - cf.at(CF_tax_investor_aftertax_itc, i);
             cf.at(CF_sponsor_aftertax_itc, i) = cf.at(CF_itc_total, i) - cf.at(CF_tax_investor_aftertax_itc, i);
             cf.at(CF_sponsor_aftertax_tax,i) = (cf.at(CF_statax,i) + cf.at(CF_fedtax,i)) - cf.at(CF_tax_investor_aftertax_tax,i);
 			cf.at(CF_sponsor_aftertax,i) =
@@ -3007,7 +3007,7 @@ public:
 			- cf.at(CF_disbursement_debtservice, i) // note sign is negative for positive disbursement
 			- cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
 			+ cf.at(CF_net_salvage_value, i)// benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
     }
     // year 1 add total ITC (net benefit) so that project return = project revenue - project cost
     //if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -3219,7 +3219,7 @@ public:
 		assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 		assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-        // SAM 1308
+        // SAM 1038
         double itc_fed_total = 0.0;
         double itc_sta_total = 0.0;
         double itc_total = 0.0;
@@ -3847,7 +3847,7 @@ public:
         cfm.check_debt_percentage(this, debt_fraction);
 
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_merchantplant.cpp
+++ b/ssc/cmod_merchantplant.cpp
@@ -822,7 +822,7 @@ enum {
     CF_annual_cost_lcos,
 
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -1642,7 +1642,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue"); 
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2554,7 +2554,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -2806,7 +2806,7 @@ public:
 				cf.at(CF_statax,i) +
 				cf.at(CF_ptc_sta,i) +
                 cf.at(CF_itc_sta, i);
-            //	SAM 1308		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
+            //	SAM 1038		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
 
 
 			// pbi in ebitda - so remove if non-taxable
@@ -2818,7 +2818,7 @@ public:
 				cf.at(CF_project_return_aftertax_cash,i) +
 				cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i) +
 				cf.at(CF_statax,i) + cf.at(CF_fedtax,i) + cf.at(CF_itc_total, i);
-            //	SAM 1308		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
+            //	SAM 1038		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
 
 
 			cf.at(CF_project_return_aftertax_irr,i) = irr(CF_project_return_aftertax,i)*100.0;
@@ -2916,7 +2916,7 @@ public:
 			- cf.at(CF_disbursement_debtservice, i) // note sign is negative for positive disbursement
 			- cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
 			+ cf.at(CF_net_salvage_value, i)// benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
     }
     // year 1 add total ITC (net benefit) so that project return = project revenue - project cost
     //if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -3112,7 +3112,7 @@ public:
 		assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 		assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-        // SAM 1308
+        // SAM 1038
         double itc_fed_total = 0.0;
         double itc_sta_total = 0.0;
         double itc_total = 0.0;
@@ -3701,7 +3701,7 @@ public:
         cfm.check_npv(this, npv_metric);
         cfm.check_debt_percentage(this, debt_fraction);
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_saleleaseback.cpp
+++ b/ssc/cmod_saleleaseback.cpp
@@ -934,7 +934,7 @@ enum {
 
     CF_utility_bill,
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -1535,7 +1535,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue");
 
-        // SAM 1308
+        // SAM 1038
          // itc fixed
         double itc_fed_amount = 0.0;
         double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2176,7 +2176,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
 
-        // SAM 1308
+        // SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -2576,7 +2576,7 @@ public:
 		cf.at(CF_tax_investor_pretax_npv,0) = cf.at(CF_tax_investor_pretax,0) ;
 
 		cf.at(CF_tax_investor_aftertax_cash,0) = cf.at(CF_tax_investor_pretax,0);
-// SAM 1308        if (nyears > 0) cf.at(CF_tax_investor_aftertax_itc, 1) = itc_total;
+// SAM 1038        if (nyears > 0) cf.at(CF_tax_investor_aftertax_itc, 1) = itc_total;
         double itc_total = 0.0;
         for (size_t k = 0; k < nyears; k++)
             itc_total += cf.at(CF_itc_total, k);
@@ -2608,7 +2608,7 @@ public:
 			if (i==0) cf.at(CF_tax_investor_fedtax_income_prior_incentives, i) = 0;
 			else cf.at(CF_tax_investor_fedtax_income_prior_incentives,i) = cf.at(CF_pretax_operating_cashflow,i) - cf.at(CF_feddepr_total,i) + cf.at(CF_net_salvage_value,i) + cf.at(CF_tax_investor_statax,i) + cf.at(CF_ptc_sta,i);
 
-// SAM 1308            if (i == 1) cf.at(CF_tax_investor_fedtax_income_prior_incentives, i) += itc_sta_total;
+// SAM 1038            if (i == 1) cf.at(CF_tax_investor_fedtax_income_prior_incentives, i) += itc_sta_total;
             cf.at(CF_tax_investor_fedtax_income_prior_incentives, i) += cf.at(CF_itc_sta, i);
             cf.at(CF_tax_investor_fedtax_income_with_incentives,i) = cf.at(CF_tax_investor_fedtax_income_prior_incentives,i) + cf.at(CF_tax_investor_fedtax_taxable_incentives,i);
 			cf.at(CF_tax_investor_fedtax, i) = -cf.at(CF_tax_investor_fedtax_income_with_incentives, i)*cf.at(CF_federal_tax_frac, i);
@@ -2797,7 +2797,7 @@ public:
 			+ cf.at(CF_reserve_interest, i)
 			- cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
 			+ cf.at(CF_net_salvage_value, i)// benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
     }
     // year 1 add total ITC (net benefit) so that project return = project revenue - project cost
     //if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -2977,7 +2977,7 @@ public:
 	assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 	assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-    // SAM 1308
+    // SAM 1038
     double itc_fed_total = 0.0;
     double itc_sta_total = 0.0;
     double itc_total = 0.0;
@@ -3631,7 +3631,7 @@ public:
         cfm.check_npv(this, npv_ti);
         cfm.check_npv(this, npv_sp);
 
-        // SAM 1308
+        // SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -877,7 +877,7 @@ enum {
     CF_util_escal_rate,
 
 
-    // SAM 1308
+    // SAM 1038
     CF_itc_fed_amount,
     CF_itc_fed_percent_fraction,
     CF_itc_fed_percent_amount,
@@ -1643,7 +1643,7 @@ public:
 		double ibi_oth_per = as_double("ibi_oth_percent")*0.01*cost_prefinancing;
 		if (ibi_oth_per > as_double("ibi_oth_percent_maxvalue")) ibi_oth_per = as_double("ibi_oth_percent_maxvalue");
 
-        // SAM 1308
+        // SAM 1038
 		// itc fixed
         double itc_fed_amount = 0.0;
 		double_vec vitc_fed_amount = as_vector_double("itc_fed_amount");
@@ -2499,7 +2499,7 @@ public:
 
 		itc_sta_qual_total = itc_sta_qual_macrs_5 + itc_sta_qual_macrs_15 + itc_sta_qual_sl_5 +itc_sta_qual_sl_15 +itc_sta_qual_sl_20 + itc_sta_qual_sl_39 + itc_sta_qual_custom;
 
-        // SAM 1308
+        // SAM 1038
         itc_sta_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_sta_percent_amount, k) = min(cf.at(CF_itc_sta_percent_maxvalue, k), cf.at(CF_itc_sta_percent_fraction, k) * itc_sta_qual_total);
@@ -2553,7 +2553,7 @@ public:
 
 		itc_fed_qual_total = itc_fed_qual_macrs_5 + itc_fed_qual_macrs_15 + itc_fed_qual_sl_5 +itc_fed_qual_sl_15 +itc_fed_qual_sl_20 + itc_fed_qual_sl_39 + itc_fed_qual_custom;
 
-        // SAM 1308
+        // SAM 1038
         itc_fed_per = 0.0;
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed_percent_amount, k) = min(cf.at(CF_itc_fed_percent_maxvalue, k), cf.at(CF_itc_fed_percent_fraction, k) * itc_fed_qual_total);
@@ -2597,7 +2597,7 @@ public:
 			itc_disallow_fed_fixed_custom = 0;
 		}
        
-// SAM 1308
+// SAM 1038
         for (size_t k = 0; k <= nyears; k++) {
             cf.at(CF_itc_fed, k) = cf.at(CF_itc_fed_amount, k) + cf.at(CF_itc_fed_percent_amount, k);
             cf.at(CF_itc_sta, k) = cf.at(CF_itc_sta_amount, k) + cf.at(CF_itc_sta_percent_amount, k);
@@ -2848,7 +2848,7 @@ public:
 				cf.at(CF_statax,i) +
 				cf.at(CF_ptc_sta,i) +
                 cf.at(CF_itc_sta, i);
-//	SAM 1308		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
+//	SAM 1038		if (i==1) cf.at(CF_fedtax_income_prior_incentives,i) += itc_sta_total;
 
 
 			// pbi in ebitda - so remove if non-taxable
@@ -2860,7 +2860,7 @@ public:
 				cf.at(CF_project_return_aftertax_cash,i) +
 				cf.at(CF_ptc_fed,i) + cf.at(CF_ptc_sta,i) +
 				cf.at(CF_statax,i) + cf.at(CF_fedtax,i) + cf.at(CF_itc_total, i);
-//	SAM 1308		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
+//	SAM 1038		if (i==1) cf.at(CF_project_return_aftertax,i) += itc_total;
 
 			cf.at(CF_project_return_aftertax_irr,i) = irr(CF_project_return_aftertax,i)*100.0;
 			cf.at(CF_project_return_aftertax_max_irr,i) = max(cf.at(CF_project_return_aftertax_max_irr,i-1),cf.at(CF_project_return_aftertax_irr,i));
@@ -3069,7 +3069,7 @@ public:
             - cf.at(CF_disbursement_debtservice, i) // note sign is negative for positive disbursement
             - cf.at(CF_disbursement_om, i) // note sign is negative for positive disbursement
             + cf.at(CF_net_salvage_value, i) // benefit to cost reduction so that project revenue based on PPA revenue and not total revenue per 7/16/15 meeting
-            + cf.at(CF_itc_total, i); // SAM 1308
+            + cf.at(CF_itc_total, i); // SAM 1038
 	}
 	// year 1 add total ITC (net benefit) so that project return = project revenue - project cost
 	//if (nyears >= 1) cf.at(CF_Annual_Costs, 1) += itc_total;
@@ -3268,7 +3268,7 @@ public:
 		assign("cbi_total_oth", var_data((ssc_number_t) cbi_oth_amount));
 		assign("cbi_total_uti", var_data((ssc_number_t) cbi_uti_amount));
 
-        // SAM 1308
+        // SAM 1038
         double itc_fed_total = 0.0;
         double itc_sta_total = 0.0;
         double itc_total = 0.0;
@@ -3868,7 +3868,7 @@ public:
         cfm.check_npv(this, npv_metric);
         cfm.check_debt_percentage(this, debt_fraction);
 
-// SAM 1308
+// SAM 1038
         save_cf(CF_itc_fed_amount, nyears, "cf_itc_fed_amount");
         save_cf(CF_itc_fed_percent_amount, nyears, "cf_itc_fed_percent_amount");
         save_cf(CF_itc_fed, nyears, "cf_itc_fed");

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -418,7 +418,7 @@ var_info vtab_payment_incentives[] = {
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_ptc_fed",                             "Federal PTC income",                 "$",            "",                      "Cash Flow Incentives",      "*",                     "LENGTH_EQUAL=cf_length",                "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_ptc_sta",                             "State PTC income",                   "$",            "",                      "Cash Flow Incentives",      "*",                     "LENGTH_EQUAL=cf_length",                "" },
 { 	SSC_OUTPUT, 	SSC_ARRAY, 	    "cf_ptc_total", 	                      "Total PTC income", 	            "$", 	            "", 	                "Cash Flow Incentives", 	        "", 	"LENGTH_EQUAL=cf_length", 	""},
-// SAM 1308 - make required after other compute module updated - see ssc 910
+// SAM 1038 - make required after other compute module updated - see ssc 910
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_itc_fed_amount",                     "Federal ITC amount income",                 "$",            "",                      "Cash Flow Incentives",      "",                     "LENGTH_EQUAL=cf_length",                "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_itc_sta_amount",                     "State ITC amount income",                   "$",            "",                      "Cash Flow Incentives",      "",                     "LENGTH_EQUAL=cf_length",                "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_itc_fed_percent_amount",             "Federal ITC percent income",                 "$",            "",                      "Cash Flow Incentives",      "",                     "LENGTH_EQUAL=cf_length",                "" },


### PR DESCRIPTION
Fixes #939 The fix for that is in cashloan line 1043. Test file is here, shows correct implementation of depreciation adjustments: 
[cashloan_itc_test.zip](https://github.com/NREL/ssc/files/10034373/cashloan_itc_test.zip)

I audited the other code for similar issues and didn't find any. Additional testing never hurts.

All other changes update the issue number to match https://github.com/NREL/SAM/issues/1038, so future developers aren't looking at the wrong issue.