### PR TITLE
Fix broken SDKTool with rapid json in wex/utils

### DIFF
--- a/sdktool/CMakeLists.txt
+++ b/sdktool/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 #####################################################################################################################
 
-include_directories(. $ENV{WEXDIR}/include $ENV{LKDIR}/include ../ssc ../shared ../splinter)
+include_directories(. $ENV{WEXDIR}/include $ENV{LKDIR}/include ../ssc ../shared ../splinter $ENV{SSCDIR})
 
 set(SDKTOOL_SRC
 	dataview.cpp


### PR DESCRIPTION
Wanted to get the ssc changes for rapidJSON in wex into patch to prevent continuously merging patch into SAM_504 branch until wex and SAM are finished.
This should be the only change in ssc necessary for SAM issue 504.