### PR TITLE
Changing runner to macos-latest to address pvsmoothing test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             ${{env.SSCDIR}}/build/ssc/ssc.so
       
   build-on-mac:
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
     - name: Setup cmake


### PR DESCRIPTION
macos-11 runner seems to have some resource issues. The PVSmoothing tests are one of the most memory intensive tests. The tests run locally on Intel mac and M1 mac. macos-latest runner succeeded with push. Now testing with this pull request.