### PR TITLE
MSPT design point w/ field layout design selected

### DIFF
--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -899,6 +899,10 @@ public:
         // 3 = user performance maps vs solar position
         int field_model_type = as_integer("field_model_type");
 
+        if (sim_type == 2 && field_model_type < 2) {
+            field_model_type = 2;
+        }
+
         int rec_type = as_integer("receiver_type");
 
         // Run solarpilot right away to update values as needed


### PR DESCRIPTION
Problem: When one of the "optimize field" boxes is checked on the MSPT Solar Field page, design point calculations fail and the blue boxes display -789

Background: The MSPT model defines all calculated values by calling the cmod in “design point mode”, designated by cmod input sim_type = 2. The point of the checkboxes is to run the layout routines during the annual simulation, not before (otherwise, the user would just click the macro options). However, that means that the design point that the model will calculate at the beginning of the annual simulation doesn’t exist yet. In the current code, the cmod design-point routine will skip the heliostat field layout, which results in a crash downstream because subsequent design point calculations want these values defined.

Solution:
I think it’s clear we don’t want to call the layout model in these scenarios. This pull request checks if 1) the cmod is being called in design point mode and 2) one of the layout options is selected. If both are true, then the design-point code acts as if the layout boxes are not selected, and it uses the field layout (and possible tower/receiver dimensions) from the UI. This resolves the issue below, albeit with a “fake” design point. This solution adds logic to the cmod that we can’t capture through the “required_if” restrictions on the field layout and tower dimensions inputs in the cmod, but that downside is probably worth it to fix the design point crash.
