### PR TITLE
Ensure key variables in the powerflow code have a minimum of zero

### DIFF
--- a/shared/lib_battery_powerflow.cpp
+++ b/shared/lib_battery_powerflow.cpp
@@ -884,7 +884,6 @@ void BatteryPowerFlow::calculateDCConnected()
         }
 
         if (m_BatteryPower->isOutageStep) {
-            P_pv_to_load_ac = P_pv_ac;
             if (P_pv_ac >= P_crit_load_ac + P_ac_losses)
             {
                 P_pv_to_load_ac = P_crit_load_ac;
@@ -895,7 +894,8 @@ void BatteryPowerFlow::calculateDCConnected()
                 P_interconnection_loss_ac = P_pv_ac - P_pv_to_load_ac - P_ac_losses;
             }
             else {
-                P_batt_to_load_ac = std::fmin(P_battery_ac_post_loss, P_crit_load_ac - P_pv_to_load_ac);
+                P_pv_to_load_ac = std::fmax(0, std::fmin(P_pv_ac, P_crit_load_ac));
+                P_batt_to_load_ac = std::fmax(0, std::fmin(P_battery_ac_post_loss, P_crit_load_ac - P_pv_to_load_ac));
                 P_batt_to_grid_ac = P_battery_ac_post_loss - P_batt_to_load_ac; 
             }
             


### PR DESCRIPTION
Fixes https://github.com/NREL/SAM/issues/1324

The specific combination of factors in the test file was driving batt_to_load_ac negative, which lead to a positive batt_to_grid_ac, which caused an infinite loop between the powerflow code and the dispatch code. Fix this by preventing these variables from going negative.