### PR TITLE
Add max constraint to geothermal resource temperature

### DIFF
--- a/ssc/cmod_geothermal.cpp
+++ b/ssc/cmod_geothermal.cpp
@@ -53,7 +53,7 @@ static var_info _cm_vtab_geothermal[] = {
     { SSC_INPUT,        SSC_STRING,      "file_name",                          "local weather file path",                      "",               "",             "GeoHourly",        "ui_calculations_only=0",   "LOCAL_FILE",      "" },
     { SSC_INPUT,        SSC_NUMBER,      "resource_potential",                 "Resource Potential",                           "MW",             "",             "GeoHourly",        "ui_calculations_only=0",   "",                "" },
     { SSC_INPUT,        SSC_NUMBER,      "resource_type",                      "Type of Resource",                             "",               "",             "GeoHourly",        "*",                        "INTEGER",         "" },
-    { SSC_INPUT,        SSC_NUMBER,      "resource_temp",                      "Resource Temperature",                         "C",              "",             "GeoHourly",        "*",                        "",                "" },
+    { SSC_INPUT,        SSC_NUMBER,      "resource_temp",                      "Resource Temperature",                         "C",              "",             "GeoHourly",        "*",                        "MAX=373",                "" },
     { SSC_INPUT,        SSC_NUMBER,      "resource_depth",                     "Resource Depth",                               "m",              "",             "GeoHourly",        "*",                        "",                "" },
 										
     // Other inputs						 								       											   				     


### PR DESCRIPTION
-Update var table for max resource temperature in SDK
-Captured in UI with https://github.com/NREL/SAM/pull/1341
-Max temperature of 373
-Fixes https://github.com/NREL/SAM/issues/1340
