### PR TITLE
Add support for elevation in WIND Toolkit CSV files

### DIFF
--- a/shared/lib_windfile.cpp
+++ b/shared/lib_windfile.cpp
@@ -499,6 +499,10 @@ bool windfile::open( const std::string &file )
             {
                 lon = col_or_nan(hdr[i + 1]);
             }
+            else if (hdr_item == "elevation" || hdr_item == "el" || hdr_item == "elev" || hdr_item == "site elevation")
+            {
+                elev = col_or_nan(hdr[i + 1]);
+            }
             else if (hdr_item == "siteid" || hdr_item == "id" || hdr_item == "location" || hdr_item == "location id" || hdr_item == "station" || hdr_item == "station id" || hdr_item == "wban" || hdr_item == "wban#" || hdr_item == "site")
             {
                 locid = hdr[i + 1];


### PR DESCRIPTION
This supplements https://github.com/NREL/ssc/pull/985 by adding support for elevation data in the new SAM CSV format for wind. Example file with elevation data in header:

[wtk-download-elevation-added.zip](https://github.com/NREL/ssc/files/10759008/wtk-download-elevation-added.zip)

Note that the WIND Toolkit API does not currently return elevation data. Elevation data is available, there has been some discussion with the API team to add it a future update to the API.

For now, users will have to manually edit the file to add elevation data to the header after downloading it from the API.

Example of header row (Row 1) with elevation data:

```
SiteID,338822,Site Timezone,-8,Data Timezone,-8,Longitude,-120.76,Latitude,45.72,Elevation,920
```

Acceptable labels for latitude are the same as for the SAM CSV for Solar format:

* elevation
* el
* elev
* site elevation

A description of SAM CSV format for Wind will be in [SAM Help](https://sam.nrel.gov/help) system for SAM 2022.11.21 r1.

https://github.com/NREL/SAM/issues/962

https://github.com/NREL/SAM/issues/815