### PR TITLE
Size the collector loop mass flow based on n_collectors

### DIFF
--- a/ssc/cmod_swh.cpp
+++ b/ssc/cmod_swh.cpp
@@ -277,7 +277,7 @@ public:
 		double test_flow = as_double("test_flow"); // collector test flow rate (kg/s)
 
 		/* collector properties */
-		double mdot_total = as_double("mdot"); // total system mass flow rate (kg/s)
+        double mdot_total = as_double("test_flow") * as_integer("ncoll"); // total system mass flow rate (kg/s)
 		double area_total = as_double("area_coll") * as_integer("ncoll"); // total solar collector area (m2)
 		double area_coll = as_double("area_coll");
 


### PR DESCRIPTION
Fixes the collector loop solar water heating mass flow as this is not currently dependent on the number of collectors, with the value currently being a constant sized for two collectors.

@cpaulgilman Can you please make sure I'm not misunderstanding what is going on here? I think the UI originally sized this parameter but no longer does.

Closes #1003 