### PR TITLE
Allow more flexible SAM CSV for solar weather file format

### DIFF
--- a/shared/lib_weatherfile.h
+++ b/shared/lib_weatherfile.h
@@ -105,6 +105,7 @@ struct weather_header {
 	std::string source;
 	std::string description;
 	std::string url;
+    std::string version;
 	bool hasunits;
 	double tz;
 	double lat;

--- a/ssc/cmod_wfcheck.cpp
+++ b/ssc/cmod_wfcheck.cpp
@@ -115,8 +115,6 @@ public:
                 // don't do checks on less than 200 W/m2, errors are too big to really check
             }
 
-
-
             if (!std::isnan(wf.dn) && wf.dn > 1500) warn("beam irradiance (%lg) at record %d is greater than 1500", wf.dn, i);
             if (!std::isnan(wf.dn) && wf.dn < 0) warn("beam irradiance (%lg) at record %d is negative", wf.dn, i);
 
@@ -159,7 +157,6 @@ public:
             if (wf.pres < 200) warn("pressure (%lg) less than 200 millibar at record %d", wf.pres, i);
             if (wf.pres > 1100) warn("pressure greater than 1100 millibar at record %d", wf.pres, i);
 
-
             if (nwarnings >= 99)
             {
                 warn("bailing... too many warnings.");
@@ -168,10 +165,8 @@ public:
 
         }
 
-
-
         assign("nwarnings", var_data((ssc_number_t)nwarnings));
     }
 };
 
-DEFINE_MODULE_ENTRY(wfcheck, "Weather file checker.", 1);
+DEFINE_MODULE_ENTRY(wfcheck, "Weather file checker for solar resource data.", 1);

--- a/ssc/cmod_wfcsv.cpp
+++ b/ssc/cmod_wfcsv.cpp
@@ -134,4 +134,4 @@ public:
 	}
 };
 
-DEFINE_MODULE_ENTRY( wfcsvconv, "Converter for TMY2, TMY3, INTL, EPW, SMW weather files to standard CSV format", 1 )
+DEFINE_MODULE_ENTRY( wfcsvconv, "Converter for TMY2, TMY3, INTL, EPW, SMW weather files with solar resource data to SAM CSV format", 1 )


### PR DESCRIPTION
- Allow files that have minimum required metadata, regardless of number of columns in metadata header rows.
- Add Version to list of metadata columns to support NSRDB version numbers.
- Test with files from NSRDB, PVWatts API, and hand-edited to have different metadata row lengths.

Fixes #937

Weather files for testing on Solar Resource  input page with any solar tech in SAM UI: Should add all of these files to solar resource library and run a simulation, except WIND Toolkit file, which should be ignored: [ssc-937-test-weather-files.zip](https://github.com/NREL/ssc/files/11326254/ssc-937-test-weather-files.zip)

Update SAM CSV for Solar Help topic to add version to table of accepted metadata items. (Done in local branch for Patch 2 release in separate PR.)