### PR TITLE
Throw an error if duplicate entries in the voltage table produce zero slope

### DIFF
--- a/shared/lib_battery_voltage.cpp
+++ b/shared/lib_battery_voltage.cpp
@@ -123,6 +123,9 @@ void voltage_table_t::initialize() {
             double V0 = params->voltage_table[i - 1][1];
             slope = (V - V0) / (DOD - DOD0);
             intercept = V0 - (slope * DOD0);
+
+            if (fabs(slope) < 1e-7)
+                throw std::runtime_error("voltage_table_t error: Battery voltage matrix cannot have two identical voltages.");
         }
         slopes.emplace_back(slope);
         intercepts.emplace_back(intercept);

--- a/test/shared_test/lib_battery_voltage_test.h
+++ b/test/shared_test/lib_battery_voltage_test.h
@@ -134,7 +134,7 @@ protected:
 
     // Additional test case based on voltage table from a user. documented in SSC issue 412
     void CreateModel_SSC_412(double dt_hr) {
-        std::vector<double> voltage_vals = { 0, 1.7, 4, 1.7, 5, 1.58, 60, 1.5, 85, 1.4, 90, 1.3, 93, 1.2, 95, 1, 96, 0.9 };
+        std::vector<double> voltage_vals = { 0, 1.7, 4, 1.69, 5, 1.58, 60, 1.5, 85, 1.4, 90, 1.3, 93, 1.2, 95, 1, 96, 0.9 };
         util::matrix_t<double> voltage_table(9, 2, &voltage_vals);
 
         voltage_nom = 1.5;


### PR DESCRIPTION
Fixes https://github.com/NREL/ssc/issues/1007

Testing with the case in the issue should produce an error message, testing with the defaults should not.