### PR TITLE
Add errors for length mismatch between critical load and electric load

### DIFF
--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -2277,9 +2277,11 @@ public:
             // Need to grab the crit load before battstor assigns it as an output
             if (is_assigned("crit_load")) {
                 p_crit_load = as_vector_ssc_number_t("crit_load");
-                size_t nload = p_crit_load.size();
-                if (nload != n_rec_single_year)
-                    throw exec_error("battery", "Electric load profile must have same number of values as weather file, or 8760.");
+                size_t n_crit_load = p_crit_load.size();
+                if (n_crit_load != n_rec_single_year && n_crit_load != 8760)
+                    throw exec_error("battery", "Critical electric load profile must have same number of values as weather file, or 8760.");
+                if (n_crit_load != nload)
+                    throw exec_error("battery", "Critical load profile must have same number of values as load file.");
 
             }
 

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -694,7 +694,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
                         target_power = batt_vars->target_power;
 
                     if (target_power.size() != nrec)
-                        throw exec_error("battery", "Invalid number of target powers, must be equal to number of records in weather file.");
+                        throw exec_error("battery", "Length of target_power must equal number of records in weather file.");
 
                     // extend target power to lifetime internally
                     for (size_t y = 1; y < nyears; y++) {
@@ -859,7 +859,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
 
         // If outage is all zeroes we don't care about the length, make sure if an outage is specified that it matches the weather file
         if (analyze_outage && batt_vars->grid_outage_steps.size() < step_per_hour * 8760) {
-            throw exec_error("Battery", "Length of grid_outage did not match number of steps in one year of simulation");
+            throw exec_error("Battery", "Length of grid_outage must equal number of steps in one year of simulation.");
         }
     }
 
@@ -938,7 +938,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
 
     if (!batt_vars->system_use_lifetime_output) {
         if (batt_vars->batt_replacement_option > 0)
-            throw exec_error("battery", "Battery replacements are enabled with single year simulation. You must enable lifetime simulations to model battery replacements.");
+            throw exec_error("battery", "Battery replacements are enabled with single year simulation. You must enable lifetime simulations (system_use_lifetime_output = 1) to model battery replacements.");
     }
     chem = batt_vars->batt_chem;
 
@@ -1094,12 +1094,12 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
         lifetime_model = new lifetime_lmolto_t(dt_hr);
     }
     else {
-        throw exec_error("battery", "Unrecognized `batt_life_model` option. Valid options are 0 for separate calendar & cycle models; "
-                                    "1 for NMC (Smith 2017) life model; 2 for LMO/LTO life model");
+        throw exec_error("battery", "Unrecognized batt_life_model option. Valid options are 0 for separate calendar and cycle models, "
+                                    "1 for NMC (Smith 2017) life model, 2 for LMO/LTO life model.");
     }
 
     if (batt_vars->T_room.size() != nrec) {
-        throw exec_error("battery", "Environment temperature input length must equal number of weather file and/or electric load data records.");
+        throw exec_error("battery", "Length of battery environment temperature batt_room_temperature_celsius must equal number of weather file and/or electric load data records.");
     }
 
     if (batt_vars->batt_life_model == lifetime_params::NMC) {
@@ -1155,16 +1155,16 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
         if (*std::min_element(batt_vars->batt_losses_charging.begin(), batt_vars->batt_losses_charging.end()) < 0
             || *std::min_element(batt_vars->batt_losses_discharging.begin(), batt_vars->batt_losses_discharging.end()) < 0
             || *std::min_element(batt_vars->batt_losses_idle.begin(), batt_vars->batt_losses_idle.end()) < 0) {
-            throw exec_error("battery", "System loss inputs cannot include negative numbers.");
+            throw exec_error("battery", "Battery loss inputs batt_losses_charging, batt_losses_discharging, and batt_losses_idle cannot include negative numbers.");
         }
         losses_model = new losses_t(batt_vars->batt_losses_charging, batt_vars->batt_losses_discharging, batt_vars->batt_losses_idle);
     }
     else if (batt_vars->batt_loss_choice == losses_params::SCHEDULE) {
         if (!(batt_vars->batt_losses.size() == 1 || batt_vars->batt_losses.size() == nrec)) {
-            throw exec_error("battery", "System loss input length must be 1 or equal to weather file length for time series input mode.");
+            throw exec_error("battery", "Length of battery loss input batt_losses must be 1 or equal to weather file length for time series input mode.");
         }
         if (*std::min_element(batt_vars->batt_losses.begin(), batt_vars->batt_losses.end()) < 0) {
-            throw exec_error("battery", "System loss inputs cannot include negative numbers.");
+            throw exec_error("battery", "Battery loss input batt_losses cannot include negative numbers.");
         }
         losses_model = new losses_t(batt_vars->batt_losses);
     }
@@ -1192,7 +1192,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
             throw exec_error("battery", "Invalid manual dispatch control vector length, must be length 6.");
 
         if (batt_vars->batt_discharge_schedule_weekday.nrows() != 12 || batt_vars->batt_discharge_schedule_weekday.ncols() != 24)
-            throw exec_error("battery", "Invalid manual dispatch schedule matrix dimensions, must be 12 x 24.");
+            throw exec_error("battery", "Invalid manual dispatch schedule matrix batt_discharge_schedule dimensions, must be 12 x 24.");
 
         size_t max_period = 6;
         size_t* discharge_schedule_vec = batt_vars->batt_discharge_schedule_weekday.data();
@@ -1219,7 +1219,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
             }
 
             if (batt_vars->batt_dispatch_batt_system_charge_first && batt_vars->batt_dispatch_charge_only_system_exceeds_load) {
-                throw exec_error("Battery", "Invalid charging priority choices. Only enable dispatch_manual_system_charge_first if batt_dispatch_charge_only_system_exceeds_load is false");
+                throw exec_error("Battery", "Invalid charging priority choices. Only enable dispatch_manual_system_charge_first if batt_dispatch_charge_only_system_exceeds_load is false.");
             }
         }
 
@@ -1310,7 +1310,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
                 if (dispatch_automatic_front_of_meter_t* dispatch_fom = dynamic_cast<dispatch_automatic_front_of_meter_t*>(dispatch_model))
                 {
                     if (batt_vars->batt_custom_dispatch.size() != 8760 * step_per_hour) {
-                        throw exec_error("battery", "Invalid custom dispatch length, must be 8760 * steps_per_hour.");
+                        throw exec_error("battery", "Length of batt_custom_dispatch must be 8760 * steps_per_hour.");
                     }
                     dispatch_fom->set_custom_dispatch(batt_vars->batt_custom_dispatch);
                 }
@@ -1341,7 +1341,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
             if (dispatch_automatic_behind_the_meter_t* dispatch_btm = dynamic_cast<dispatch_automatic_behind_the_meter_t*>(dispatch_model))
             {
                 if (batt_vars->batt_custom_dispatch.size() != 8760 * step_per_hour) {
-                    throw exec_error("battery", "Invalid custom dispatch, must be 8760 * steps_per_hour.");
+                    throw exec_error("battery", "Length of batt_custom_dispach must be 8760 * steps_per_hour.");
                 }
                 dispatch_btm->set_custom_dispatch(batt_vars->batt_custom_dispatch);
             }
@@ -2266,7 +2266,7 @@ public:
                 nload = load_year_one.size();
                 // Array length for non-lifetime mode, lifetime mode, and hourly load
                 if (nload != n_rec_lifetime && nload != n_rec_lifetime / analysis_period && nload != 8760)
-                    throw exec_error("battery", "The electric load profile must have either the same time step as the weather file, or 8760 time steps.");
+                    throw exec_error("battery", "Electric load must have either the same time step as the weather file, or 8760 time steps.");
             }
 
             // resilience metrics for battery
@@ -2279,9 +2279,9 @@ public:
                 p_crit_load = as_vector_ssc_number_t("crit_load");
                 size_t n_crit_load = p_crit_load.size();
                 if (n_crit_load != n_rec_single_year && n_crit_load != 8760)
-                    throw exec_error("battery", "Critical electric load profile must have same number of values as weather file, or 8760.");
+                    throw exec_error("battery", "Critical load crit_load must have same number of values as weather file, or 8760.");
                 if (n_crit_load != nload)
-                    throw exec_error("battery", "Critical load profile must have same number of values as load file.");
+                    throw exec_error("battery", "Critical load crit_load must have same number of values as load.");
 
             }
 
@@ -2298,11 +2298,11 @@ public:
                         }
                     }
                     else {
-                        throw exec_error("battery", "If run_resiliency_calcs is 1, crit_load must have length > 0 and values > 0");
+                        throw exec_error("battery", "If run_resiliency_calcs is 1, crit_load must have length > 0 and values > 0.");
                     }
                 }
                 if (!crit_load_specified && batt->analyze_outage) {
-                    throw exec_error("battery", "If grid_outage is specified in any time step, crit_load must have length > 0 and values > 0");
+                    throw exec_error("battery", "If grid_outage is specified in any time step, crit_load must have length > 0 and values > 0.");
                 }
             }
 
@@ -2330,7 +2330,7 @@ public:
                 // Annual simulation is enforced above
                 if (p_pv_ac_forecast.size() < dt_hour_gen * 8760) {
                     if (batt_forecast_choice == dispatch_t::WEATHER_FORECAST_CHOICE::WF_CUSTOM && batt->uses_forecast()) {
-                        throw exec_error("battery", "batt_pv_ac_forecast forecast length is " + std::to_string(p_pv_ac_forecast.size()) + " when custom weather file forecast is selected. Change batt_dispatch_wf_forecast_choice or provide a forecast of at least length " + std::to_string(dt_hour_gen * 8760));
+                        throw exec_error("battery", "Length of batt_pv_ac_forecast is " + std::to_string(p_pv_ac_forecast.size()) + " when custom weather file forecast is selected. Change batt_dispatch_wf_forecast_choice or provide a forecast of at least length " + std::to_string(dt_hour_gen * 8760) + ".");
                     }
                     else {
                         // Using look ahead or look behind, and need to clear inputs from lk
@@ -2355,7 +2355,7 @@ public:
                 }
                 // Array length for non-lifetime mode, lifetime mode, and hourly load
                 else if (nload != n_rec_lifetime && nload != n_rec_lifetime / analysis_period && nload != 8760) {
-                        throw exec_error("battery", "The electric load forecast must have either the same time step as the weather file, or 8760 time steps.");
+                        throw exec_error("battery", "Electric load forecast must have either the same time step as the weather file, or 8760 time steps.");
                 }
             }
             if (p_load_forecast_in.size() > 0) {
@@ -2386,7 +2386,7 @@ public:
                 throw exec_error("battery", "Load length does not match system generation length.");
             }
             if (batt->batt_vars->batt_topology == ChargeController::DC_CONNECTED) {
-                throw exec_error("battery", "Generic System must be AC connected to battery.");
+                throw exec_error("battery", "Generic system requires AC-connected battery.");
             }
 
             // compute critical load (electric demand) annual escalation multipliers
@@ -2445,7 +2445,7 @@ public:
                         float techs = 3;
                         percent = percent_complete + 100.0f * ((float)lifetime_idx + 1) / ((float)n_rec_lifetime) / techs;
                         if (!update("", percent, (float)hour)) {
-                            throw exec_error("battery", "Simulation canceled at hour " + util::to_string(hour + 1.0));
+                            throw exec_error("battery", "Simulation canceled at hour " + util::to_string(hour + 1.0) + ".");
                         }
                     }
 

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1162,16 +1162,16 @@ void cm_pvsamv1::exec()
         p_load_in = as_vector_ssc_number_t("load");
         nload = p_load_in.size();
         if (nload != nrec && nload != 8760)
-            throw exec_error("pvsamv1", "The electric load profile must have either the same time step as the weather file, or 8760 time steps.");
+            throw exec_error("pvsamv1", "Load must have either the same time step as the weather file, or 8760 time steps.");
     }
     if (is_assigned("crit_load"))
     {
         p_crit_load_in = as_vector_ssc_number_t("crit_load");
         size_t n_crit_load = p_crit_load_in.size();
         if (n_crit_load != nrec && n_crit_load != 8760)
-            throw exec_error("pvsamv1", "Critical electric load profile must have same number of values as weather file, or 8760.");
+            throw exec_error("pvsamv1", "Critical load crit_load must have either the same time step as the weather file, or 8760 time steps.");
         if (n_crit_load != nload)
-            throw exec_error("pvsamv1", "Critical load profile must have same number of values as load file.");
+            throw exec_error("pvsamv1", "Critical load crit_load must have same number of values as load.");
     }
 
     // resilience metrics for battery
@@ -1185,7 +1185,7 @@ void cm_pvsamv1::exec()
 
         // Single timestep or non-annual simulations are not enabled with batteries
         if (!Simulation->annualSimulation)
-            throw exec_error("pvsamv1", "The PV+Battery configuration requires a simulation period that is continuous over one or more years.");
+            throw exec_error("pvsamv1", "The PV Battery configuration requires a simulation period that is continuous over one or more years.");
 
         batt = std::make_shared<battstor>(*m_vartab, en_batt, nrec, ts_hour);
         batt->setSharedInverter(sharedInverter);

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1167,9 +1167,11 @@ void cm_pvsamv1::exec()
     if (is_assigned("crit_load"))
     {
         p_crit_load_in = as_vector_ssc_number_t("crit_load");
-        nload = p_crit_load_in.size();
-        if (nload != nrec && nload != 8760)
-            throw exec_error("pvsamv1", "The critical electric load profile must have either same number of time steps as the weather file, or 8760 time steps.");
+        size_t n_crit_load = p_crit_load_in.size();
+        if (n_crit_load != nrec && n_crit_load != 8760)
+            throw exec_error("pvsamv1", "Critical electric load profile must have same number of values as weather file, or 8760.");
+        if (n_crit_load != nload)
+            throw exec_error("pvsamv1", "Critical load profile must have same number of values as load file.");
     }
 
     // resilience metrics for battery


### PR DESCRIPTION
Add checks for critical load length as compared to load length. Fixes https://github.com/NREL/ssc/issues/1015 - SAM branch [load_ui_checks](https://github.com/NREL/SAM/tree/load_ui_checks) required to test. (pull request forthcoming)

Test should get error messages in the file in the issue.