### PR TITLE
Fix adjustment factor daily timeseries option

### DIFF
--- a/shared/lib_util.cpp
+++ b/shared/lib_util.cpp
@@ -821,6 +821,14 @@ int util::day_of(double time)
 	return (daynum % 7);
 }
 
+int util::day_of_year(double time)
+{
+    /* returns day number 0..6 (Monday..Sunday) given
+       time: hour index in year 0..8759 */
+    int daynum = (((int)(time / 24.0)));   // day goes 0-364
+    return daynum;
+}
+
 int util::week_of(double time)
 {
 	/* returns week number 0..51 given

--- a/shared/lib_util.h
+++ b/shared/lib_util.h
@@ -135,6 +135,7 @@ namespace util
 	double percent_of_year(int month, int hours); /* returns the fraction of a year, based on months and hours */
 	int month_of(double time); /* hour: 0 = jan 1st 12am-1am, returns 1-12 */
 	int day_of(double time); /* hour: 0 = jan 1st Monday 12am-1am, returns 0-6 */
+    int day_of_year(double time); /* hour: 0 jan 1st monday 12am-1am returns 0-364 */
 	int week_of(double time); /* hour: 0 = jan 1st Monday 12am-1am, returns 0-6 */
 	int day_of_month(int month, double time); /* month: 1-12 time: hours, starting 0=jan 1st 12am, returns 1-nday*/
 	int days_in_month(int month); /*month: 0-11, return 0-30, depending on the month*/

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1060,7 +1060,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
             else if (n % 365 == 0) { //Daily
                 for (int a = 0; a < analysis_period; a++) {
                     for (int i = 0; i < nsteps; i++) {
-                        day = util::day_of(int(i / steps_per_hour));
+                        day = util::day_of_year(int(i / steps_per_hour));
                         m_factors[nsteps*a + i] *= (1.0 - p[a * 365 + day]/100.0); //input as factors not percentage
                     }
 

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -365,9 +365,9 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, LossAdjustmentNonLifetime) {
     ssc_data_set_array(data, "adjust:timeindex", (ssc_number_t*)timeindex_daily, 365); //365days * 2
     pvsam_errors = run_module(data, "pvsamv1");
     ssc_data_get_number(data, "annual_energy", &annual_energy);
-    EXPECT_NEAR(annual_energy, 8833.8, m_error_tolerance_hi);
+    EXPECT_NEAR(annual_energy, 4503.2, m_error_tolerance_hi);
     ssc_data_get_number(data, "kwh_per_kw", &kwh_per_kw);
-    EXPECT_NEAR(kwh_per_kw, 1883, m_error_tolerance_hi) << "Energy yield"; // Same as 1 year because year 2 has 0 production
+    EXPECT_NEAR(kwh_per_kw, 959.6, m_error_tolerance_hi) << "Energy yield"; // Same as 1 year because year 2 has 0 production
 
     //Hourly
     double timeindex_hourly[8760];


### PR DESCRIPTION
-Daily mode of adjustment factor widget was returning 0-6 for Monday-Sunday rather than 0-364
-Change function to correct indexing for adjustment factor