### PR TITLE
Remove total PTC output from all models

### DIFF
--- a/ssc/cmod_cashloan.cpp
+++ b/ssc/cmod_cashloan.cpp
@@ -241,7 +241,6 @@ enum {
 	
 	CF_ptc_fed,
 	CF_ptc_sta,
-	CF_ptc_total,
 	
 	CF_sta_depr_sched,
 	CF_sta_depreciation,
@@ -987,8 +986,6 @@ public:
 			
 			// compute pbi total		
 			cf.at(CF_pbi_total, i) = cf.at(CF_pbi_fed, i) + cf.at(CF_pbi_sta, i) + cf.at(CF_pbi_uti, i) + cf.at(CF_pbi_oth, i);
-			// compute ptc total		
-			cf.at(CF_ptc_total, i) = cf.at(CF_ptc_fed, i) + cf.at(CF_ptc_sta, i);
 			
 			// compute depreciation from basis and precalculated schedule
 			cf.at(CF_sta_depreciation,i) = cf.at(CF_sta_depr_sched,i)*state_depr_basis;
@@ -1435,7 +1432,6 @@ public:
 	
 		save_cf( CF_ptc_fed, nyears, "cf_ptc_fed" );
 		save_cf( CF_ptc_sta, nyears, "cf_ptc_sta" );
-		save_cf( CF_ptc_total, nyears, "cf_ptc_total" );
 
 
         // SAM 1038

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -428,7 +428,6 @@ var_info vtab_payment_incentives[] = {
 
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_ptc_fed",                             "Federal PTC income",                 "$",            "",                      "Cash Flow Incentives",      "*",                     "LENGTH_EQUAL=cf_length",                "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_ptc_sta",                             "State PTC income",                   "$",            "",                      "Cash Flow Incentives",      "*",                     "LENGTH_EQUAL=cf_length",                "" },
-{ 	SSC_OUTPUT, 	SSC_ARRAY, 	    "cf_ptc_total", 	                      "Total PTC income", 	            "$", 	            "", 	                "Cash Flow Incentives", 	        "", 	"LENGTH_EQUAL=cf_length", 	""},
 // SAM 1038 - make required after other compute module updated - see ssc 910
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_itc_fed_amount",                     "Federal ITC amount income",                 "$",            "",                      "Cash Flow Incentives",      "",                     "LENGTH_EQUAL=cf_length",                "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_itc_sta_amount",                     "State ITC amount income",                   "$",            "",                      "Cash Flow Incentives",      "",                     "LENGTH_EQUAL=cf_length",                "" },


### PR DESCRIPTION
Fixes #644

Remove cf_ptc_total from cashloan and common. 

Ignoring legacy cmod_ippppa.
