### PR TITLE
Helpful error messages when cell temperature heat transfer method is missing data

### DIFF
--- a/shared/lib_cec6par.cpp
+++ b/shared/lib_cec6par.cpp
@@ -480,7 +480,7 @@ bool mcsp_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &module, double 
 
 	// convert to kelvin
 	double TA = input.Tdry+273.15;
-    if (isnan(input.Patm)) {
+    if (std::isnan(input.Patm)) {
         m_err = "Atmospheric pressure (millibar) is required for this temperature model.";
         Tcell = std::numeric_limits<double>::quiet_NaN();
         return false;
@@ -510,7 +510,7 @@ bool mcsp_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &module, double 
 	Fcs        = 1. - Fcg;              // !view factor between top of tilted plate and everything else (sky)
 	Fbs        = Fcg;                   // !view factor bewteen top and ground = bottom and sky
 	Fbg        = Fcs;                   // !view factor bewteen bottom and ground = top and sky
-    if (isnan(input.Tdew)) {
+    if (std::isnan(input.Tdew)) {
         m_err = "Dew point temperature (degC) is required for this temperature model.";
         Tcell = std::numeric_limits<double>::quiet_NaN();
         return false;

--- a/shared/lib_cec6par.cpp
+++ b/shared/lib_cec6par.cpp
@@ -480,6 +480,11 @@ bool mcsp_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &module, double 
 
 	// convert to kelvin
 	double TA = input.Tdry+273.15;
+    if (isnan(input.Patm)) {
+        m_err = "Atmospheric pressure (millibar) is required for this temperature model.";
+        Tcell = std::numeric_limits<double>::quiet_NaN();
+        return false;
+    }
 	double Patm = input.Patm*100; // convert millibar into Pascal
 
 	double EFFREF = 1e-3;
@@ -505,6 +510,11 @@ bool mcsp_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &module, double 
 	Fcs        = 1. - Fcg;              // !view factor between top of tilted plate and everything else (sky)
 	Fbs        = Fcg;                   // !view factor bewteen top and ground = bottom and sky
 	Fbg        = Fcs;                   // !view factor bewteen bottom and ground = top and sky
+    if (isnan(input.Tdew)) {
+        m_err = "Dew point temperature (degC) is required for this temperature model.";
+        Tcell = std::numeric_limits<double>::quiet_NaN();
+        return false;
+    }
 	T_sky      = TA*pow(0.711+0.0056*input.Tdew+0.000073*pow(input.Tdew,2)+0.013*cosd(input.HourOfDay), 0.25);   // !Sky Temperature: Berdahl and Martin  
 	T_ground   = TA;                    // !Set ground temp equal to ambient temp
 	T_rw       = TA;                    // !Initial guess for roof or wall temp

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -2188,6 +2188,7 @@ void cm_pvsamv1::exec()
                             tcell = Subarrays[nn]->customCellTempArray[inrec];
                         else {
                             (*Subarrays[nn]->Module->cellTempModel)(in[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell);
+                            if (isnan(tcell)) throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
                             (*Subarrays[nn]->Module->cellTempModel)(in_cs[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell_cs);
                         }
                         // begin Transient Thermal model

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -2188,7 +2188,7 @@ void cm_pvsamv1::exec()
                             tcell = Subarrays[nn]->customCellTempArray[inrec];
                         else {
                             (*Subarrays[nn]->Module->cellTempModel)(in[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell);
-                            if (isnan(tcell)) throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                            if (std::isnan(tcell)) throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
                             (*Subarrays[nn]->Module->cellTempModel)(in_cs[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell_cs);
                         }
                         // begin Transient Thermal model


### PR DESCRIPTION
-Throw error in pvsamv1 when ambient pressure and dew point (or wet bulb) is missing from the weather file
-Make tcell nan when this happens to make sure calculation does not continue as normal
-Fixes https://github.com/NREL/sam/issues/1428