### PR TITLE
Fixes to availability losses

### DIFF
--- a/ssc/cmod_hcpv.cpp
+++ b/ssc/cmod_hcpv.cpp
@@ -403,7 +403,7 @@ public:
 
         adjustment_factors haf(this, "adjust");
         if (!haf.setup())
-            throw exec_error("pvwattsv5", "failed to setup adjustment factors: " + haf.error());
+            throw exec_error("hcpv", "failed to setup adjustment factors: " + haf.error());
 
 
 

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -313,7 +313,7 @@ void cm_windpower::exec()
 	if (wpc.nTurbines > wpc.GetMaxTurbines())
 		throw exec_error("windpower", util::format("the wind model is only configured to handle up to %d turbines.", wpc.GetMaxTurbines()));
 
-	// create adjustment factors and losses
+	// create adjustment factors and losses - set them up initially here for the Weibull distribution method, rewrite them later with nrec for the time series method
 	adjustment_factors haf(this, "adjust");
 	if (!haf.setup())
 		throw exec_error("windpower", "failed to setup adjustment factors: " + haf.error());
@@ -501,6 +501,10 @@ void cm_windpower::exec()
 	size_t steps_per_hour = nstep / 8760;
 	if (steps_per_hour * 8760 != nstep  && !contains_leap_day)
 		throw exec_error("windpower", util::format("invalid number of data records (%d): must be an integer multiple of 8760", (int)nstep));
+
+    // overwrite adjustment factors setup using the correct value for nrec, which we don't have until this part of the code
+    if (!haf.setup(nstep))
+        throw exec_error("windpower", "failed to setup adjustment factors: " + haf.error());
 
 	// allocate output data
 	ssc_number_t *farmpwr = allocate("gen", nstep);

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1093,11 +1093,15 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
                         m_factors[nsteps * a + i] *= (1.0 - p[0]/100.0); //input as factors not percentage
                 }
             }
-            else if (n == (size_t)(nsteps * analysis_period)) { //Hourly or subhourly
+            else if (n == (size_t)(nsteps * analysis_period)) { //Hourly or subhourly- must match weather file resolution
                 for (int a = 0; a < analysis_period; a++) {
                     for (int i = 0; i < nsteps; i++)
                         m_factors[nsteps * a + i] *= (1.0 - p[a*nsteps + i]/100.0); //convert from percentages to factors
                 }
+            }
+            else if ((n % 8760 == 0) && n != (size_t)(nsteps * analysis_period)) // give a helpful error for timestep mismatch
+            {
+                m_error = util::format("Availability losses must be the same timestep as the weather file, if they are not daily/weekly/monthly.");
             }
             else if (n == (size_t)( 12 * analysis_period)) { //Monthly 
                 for (int a = 0; a < analysis_period; a++) {
@@ -1131,10 +1135,6 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
                     for (int i = 0; i < nsteps; i++)
                         m_factors[nsteps * a + i] *= (1.0 - p[a]/100.0); //input as factors not percentage
                 }
-            }
-            else if (n > (size_t)(nsteps * analysis_period)) // more helpful error for timestep mismatch
-            {
-                m_error = util::format("Lifetime availability losses timestep cannot be more granular than weather file timestep.");
             }
             else {
                 m_error = util::format("Error in length of lifetime availability losses.");

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1099,7 +1099,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
                         m_factors[nsteps * a + i] *= (1.0 - p[a*nsteps + i]/100.0); //convert from percentages to factors
                 }
             }
-            else if (n % 12 == 0) { //Monthly 
+            else if (n == (size_t)( 12 * analysis_period)) { //Monthly 
                 for (int a = 0; a < analysis_period; a++) {
                     for (int i = 0; i < nsteps; i++) {
                         month = util::month_of(int(i / steps_per_hour))-1;
@@ -1108,7 +1108,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
 
                 }
             }
-            else if (n % 365 == 0) { //Daily
+            else if (n == (size_t)( 365 * analysis_period)) { //Daily
                 for (int a = 0; a < analysis_period; a++) {
                     for (int i = 0; i < nsteps; i++) {
                         day = util::day_of_year(int(i / steps_per_hour));
@@ -1117,7 +1117,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
 
                 }
             }
-            else if (n % 52 == 0) { //Weekly
+            else if (n == (size_t)( 52 * analysis_period)) { //Weekly
                 for (int a = 0; a < analysis_period; a++) {
                     for (int i = 0; i < nsteps; i++) {
                         week = util::week_of(int(i / steps_per_hour));
@@ -1132,8 +1132,12 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
                         m_factors[nsteps * a + i] *= (1.0 - p[a]/100.0); //input as factors not percentage
                 }
             }
+            else if (n > (size_t)(nsteps * analysis_period)) // more helpful error for timestep mismatch
+            {
+                m_error = util::format("Lifetime availability losses timestep cannot be more granular than weather file timestep.");
+            }
             else {
-                m_error = util::format("Error with lifetime loss data inputs");
+                m_error = util::format("Error in length of lifetime availability losses.");
             }
         }
     }

--- a/test/input_cases/pvsamv1_battery_common_data.h
+++ b/test/input_cases/pvsamv1_battery_common_data.h
@@ -415,7 +415,7 @@ void pvsamv1_battery_defaults(ssc_data_t& data) {
     ssc_data_set_number(data, "dc_adjust_constant", 0.0);
     ssc_data_set_number(data, "dc_adjust_en_periods", 1);
     ssc_data_set_matrix(data, "dc_adjust_periods", p_dc_adjust_periods, 1, 3);
-    ssc_data_set_number(data, "dc_adjust_en_timeindex", 1);
+    ssc_data_set_number(data, "dc_adjust_en_timeindex", 0);
     ssc_data_set_array(data, "dc_adjust_timeindex", p_dc_adjust_hourly, 8760);
 
 	ssc_data_set_number(data, "batt_chem", 1);
@@ -1167,7 +1167,7 @@ void commercial_multiarray_default(ssc_data_t& data) {
     ssc_data_set_number(data, "dc_adjust_constant", 0.0);
     ssc_data_set_number(data, "dc_adjust_en_periods", 1);
     ssc_data_set_matrix(data, "dc_adjust_periods", p_dc_adjust_periods, 1, 3);
-    ssc_data_set_number(data, "dc_adjust_en_timeindex", 1);
+    ssc_data_set_number(data, "dc_adjust_en_timeindex", 0);
     ssc_data_set_array(data, "dc_adjust_timeindex", p_dc_adjust_hourly, 8760);
 
 

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -422,10 +422,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, LossAdjustmentNonLifetime) {
     ssc_data_set_array(data, "adjust_timeindex", timeindex_subhourly, 17520);
 
     pvsam_errors = run_module(data, "pvsamv1");
-    ssc_data_get_number(data, "annual_energy", &annual_energy);
-    EXPECT_NEAR(annual_energy, 8833.8, m_error_tolerance_hi);
-    ssc_data_get_number(data, "kwh_per_kw", &kwh_per_kw);
-    EXPECT_NEAR(kwh_per_kw, 1883, m_error_tolerance_hi) << "Energy yield"; // Same as 1 year because year 2 has 0 production
+    EXPECT_TRUE(pvsam_errors); //this should throw an error because we are not allowing losses at a more granular timestep than weather
 }
 
 


### PR DESCRIPTION
This PR fixes the setup of availability losses to properly determine the loss timestep. It updates the error messages to give more helpful information (and fixes a mislabeled error message in hcpv). It also updates the battery tests for these losses, which had the loss enabled when it wasn't being used. Fixes #181 . This does need one UI update to the widget in the wind model in the SAM repo, which I will wait until @cpaulgilman is finished doing his UI review to complete.