### PR TITLE
Fix SSC 785 hourly variables

### DIFF
--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -55,6 +55,10 @@ static var_info vtab_utility_rate5[] = {
 
 	// input from user as kW and output as kW
 	{ SSC_INOUT, SSC_ARRAY, "load", "Electricity load (year 1)", "kW", "", "Load", "", "", "" },
+
+    // Optional input, only provided by battery cases
+    { SSC_INPUT, SSC_ARRAY, "grid_outage", "Grid outage in this time step", "0/1", "0=GridAvailable,1=GridUnavailable,Length=load", "Load",    "",                       "",                               "" },
+
 	//  output as kWh - same as load (kW) for hourly simulations
 	{ SSC_OUTPUT, SSC_ARRAY, "bill_load", "Bill load (year 1)", "kWh", "", "Load", "*", "", "" },
 
@@ -546,6 +550,11 @@ public:
 		}
 //		ssc_number_t ts_hour_load = 1.0f / step_per_hour_load;
 
+        std::vector<bool> grid_outage(m_num_rec_yearly, false);
+        if (is_assigned("grid_outage")) {
+            grid_outage = as_vector_bool("grid_outage");
+        }
+
 		// prepare timestep arrays for load and grid values
 		std::vector<ssc_number_t>
 			e_sys_cy(m_num_rec_yearly), p_sys_cy(m_num_rec_yearly),
@@ -937,35 +946,53 @@ public:
 				e_load_cy[j] = p_load[j] * load_scale[i] * ts_hour_gen;
 				p_load_cy[j] = p_load[j] * load_scale[i];
 
-
-				// update e_sys per year if lifetime output
-				if ((as_integer("system_use_lifetime_output") == 1) && ( idx < nrec_gen ))
-				{
-//					e_sys[j] = p_sys[j] = 0.0;
-//					ts_power = (idx < nrec_gen) ? pgen[idx] : 0;
-//					e_sys[j] = ts_power * ts_hour_gen;
-//					p_sys[j] = ((ts_power > p_sys[j]) ? ts_power : p_sys[j]);
-					e_sys_cy[j] = pgen[idx] * ts_hour_gen;
-					p_sys_cy[j] = pgen[idx];
-					// until lifetime load fully implemented
-					// report lifetime load in kW and not kWh
-					lifetime_load[idx] = -e_load_cy[j] / ts_hour_gen;
-					idx++;
-				}
-				else
-				{
-					e_sys_cy[j] = pgen[j] * ts_hour_gen;
-					p_sys_cy[j] = pgen[j];
-				}
-				e_sys_cy[j] *= sys_scale[i];
-				p_sys_cy[j] *= sys_scale[i];
-				// calculate e_grid value (e_sys + e_load)
+                if (grid_outage[j]) {
+                    // update e_sys per year if lifetime output
+                    if ((as_integer("system_use_lifetime_output") == 1) && (idx < nrec_gen))
+                    {
+                        e_sys_cy[j] = 0.0;
+                        p_sys_cy[j] = 0.0;
+                        // until lifetime load fully implemented
+                        // report lifetime load in kW and not kWh
+                        lifetime_load[idx] = 0.0;
+                        idx++;
+                    }
+                    else
+                    {
+                        e_sys_cy[j] = 0.0;
+                        p_sys_cy[j] = 0.0;
+                    }
+                }
+                else {
+                    // update e_sys per year if lifetime output
+                    if ((as_integer("system_use_lifetime_output") == 1) && (idx < nrec_gen))
+                    {
+                        //					e_sys[j] = p_sys[j] = 0.0;
+                        //					ts_power = (idx < nrec_gen) ? pgen[idx] : 0;
+                        //					e_sys[j] = ts_power * ts_hour_gen;
+                        //					p_sys[j] = ((ts_power > p_sys[j]) ? ts_power : p_sys[j]);
+                        e_sys_cy[j] = pgen[idx] * ts_hour_gen;
+                        p_sys_cy[j] = pgen[idx];
+                        // until lifetime load fully implemented
+                        // report lifetime load in kW and not kWh
+                        lifetime_load[idx] = -e_load_cy[j] / ts_hour_gen;
+                        idx++;
+                    }
+                    else
+                    {
+                        e_sys_cy[j] = pgen[j] * ts_hour_gen;
+                        p_sys_cy[j] = pgen[j];
+                    }
+                }
+                e_sys_cy[j] *= sys_scale[i];
+                p_sys_cy[j] *= sys_scale[i];
+                // calculate e_grid value (e_sys + e_load)
 //				e_sys_cy[j] = e_sys[j] * sys_scale[i];
 //				p_sys_cy[j] = p_sys[j] * sys_scale[i];
-				// note: load is assumed to have negative sign
-				e_grid_cy[j] = e_sys_cy[j] + e_load_cy[j];
-				p_grid_cy[j] = p_sys_cy[j] + p_load_cy[j];
-			}
+                // note: load is assumed to have negative sign
+                e_grid_cy[j] = e_sys_cy[j] + e_load_cy[j];
+                p_grid_cy[j] = p_sys_cy[j] + p_load_cy[j];
+            }
 
 
 			// now calculate revenue without solar system (using load only)


### PR DESCRIPTION
Fixes #785 

Add grid_outage as an optional input to utility_rate 5. When there is a grid outage, set grid use to zero. While cmod_grid handled this effectively for the load, these additional changes are required to preserve the data in gen while not accumulating net metering credits during an outage.

To test:
1. Open a PV+Battery behind the meter case
2. Set up a full year grid outage (file with 8760 ones for testing) with any critical load percentage: 
[_8760_ones.csv](https://github.com/NREL/ssc/files/13491312/_8760_ones.csv)
3. Run the case
4. Hourly to/from grid variables should be zero, net metering credits should not be earned.

Testing other compensation methods would be good rigor.
