### PR TITLE
Improve REopt error messages for invalid dgrules values

### DIFF
--- a/ssc/ssc_equations.h
+++ b/ssc/ssc_equations.h
@@ -168,7 +168,7 @@ static ssc_equation_entry ssc_equation_table [] = {
             true, false},
 
         // Utility Rate
-        {"ElectricityRates_format_as_URDBv7", ElectricityRates_format_as_URDBv8,
+        {"ElectricityRates_format_as_URDBv8", ElectricityRates_format_as_URDBv8,
             "UtilityRate5", ElectricityRates_format_as_URDBv8_doc,
             false, true},
 


### PR DESCRIPTION
Fixes https://github.com/NREL/SAM/issues/1621

Goes with https://github.com/NREL/SAM/pull/1641

Improve error message when SAM `net_metering` option is not available in URDB `dgrules` so that UI callback error in SAM makes more sense.

Rename URDB V7 to V8 in labels.