### PR TITLE
Correct size versus iprofile index for manual dispatch

### DIFF
--- a/shared/lib_battery_dispatch_manual.cpp
+++ b/shared/lib_battery_dispatch_manual.cpp
@@ -116,11 +116,11 @@ void dispatch_manual_t::prepareDispatch(size_t hour_of_year, size_t )
 	m_batteryPower->canGridCharge = _gridcharge_array[iprofile - 1];
     m_batteryPower->canClipCharge = _can_clip_charge;
 
-	if (iprofile < _fuelcellcharge_array.size()) {
+	if (iprofile <= _fuelcellcharge_array.size()) {
 		m_batteryPower->canFuelCellCharge = _fuelcellcharge_array[iprofile - 1];
 	}
 
-    if (iprofile < _discharge_grid_array.size()) {
+    if (iprofile <= _discharge_grid_array.size()) {
         m_batteryPower->canDischargeToGrid = _discharge_grid_array[iprofile - 1];
     }
 


### PR DESCRIPTION
Fix #1112, see issue for test instructions. Expect the two SAM cases in that file to match their dispatch output.

No milestone since it's not clear whether this will land in the release or patch 1 - for discussion at today's meeting.