### PR TITLE
Use calculated DNI for Allen method when there is no DNI in weather file

### DIFF
--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1974,6 +1974,10 @@ void cm_pvsamv1::exec()
                         if (!isnan(Irradiance->p_weatherFileDNI[idx])) {
                             PVSystem->p_DNIIndex[nn][idx] = (ssc_number_t)(Irradiance->p_weatherFileDNI[idx] / dni_cs);
                         }
+                        else if (isnan(Irradiance->p_weatherFileDNI[idx]) && (radmode == irrad::DN_DF || radmode == irrad::DN_GH))
+                        {
+                            PVSystem->p_DNIIndex[nn][idx] = 0; //Simulation should exit when looking for DNI but no DNI found
+                        }
                         else {
                             PVSystem->p_DNIIndex[nn][idx] = (ssc_number_t)(Irradiance->p_IrradianceCalculated[2][idx] / dni_cs);
                         }

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1971,7 +1971,12 @@ void cm_pvsamv1::exec()
                     PVSystem->p_poaDiffuseFrontCS[nn][idx] = (ssc_number_t)(ignddiff_csky);
                     PVSystem->p_poaRearCS[nn][idx] = (ssc_number_t)(ipoa_rear_after_losses_cs[nn]);
                     if (dni_cs != 0) {
-                        PVSystem->p_DNIIndex[nn][idx] = (ssc_number_t)(Irradiance->p_weatherFileDNI[idx] / dni_cs);
+                        if (!isnan(Irradiance->p_weatherFileDNI[idx])) {
+                            PVSystem->p_DNIIndex[nn][idx] = (ssc_number_t)(Irradiance->p_weatherFileDNI[idx] / dni_cs);
+                        }
+                        else {
+                            PVSystem->p_DNIIndex[nn][idx] = (ssc_number_t)(Irradiance->p_IrradianceCalculated[2][idx] / dni_cs);
+                        }
                     }
                     else {
                         PVSystem->p_DNIIndex[nn][idx] = 0;


### PR DESCRIPTION
-Fixes #1123 
-Fixes https://github.com/NREL/SAM/issues/1685
-Check for nan for weather file DNI, use calculated DNI as alternative
