### PR TITLE
Set upper limit of one for diffuse sky shading non-linear factor

### DIFF
--- a/shared/lib_pvshade.cpp
+++ b/shared/lib_pvshade.cpp
@@ -201,6 +201,7 @@ void diffuse_reduce(
 
     // sky diffuse reduction
     Fskydiff = skydiffderates.lookup(stilt);
+    Fskydiff = fmin(Fskydiff, 1.0);
     reduced_skydiff = Fskydiff * poa_sky;
 
 	double solalt = 90 - solzen;


### PR DESCRIPTION
-Fixes #1122 
-Outlier values seem to be due to high gcr + high tilt angle, don't see a use case where value should ever be greater than 1.0