### PR TITLE
Address confusion and consistency in powerflow variables

### DIFF
--- a/shared/lib_battery_powerflow.cpp
+++ b/shared/lib_battery_powerflow.cpp
@@ -36,6 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lib_power_electronics.h"
 #include "lib_shared_inverter.h"
 
+// 0.005 W when applied to power. Some inverters have a night time loss of 0.01 W
+double powerflow_tolerance = 0.000005;
+
 BatteryPower::BatteryPower(double dtHour) :
 		dtHour(dtHour),
 		powerSystem(0),
@@ -102,7 +105,7 @@ BatteryPower::BatteryPower(double dtHour) :
 		depthOfDischargeMax(1),
         currentChargeMax(0),
         currentDischargeMax(0),
-		tolerance(0.001){}
+		tolerance(powerflow_tolerance){}
 
 BatteryPower::BatteryPower(const BatteryPower& orig) {
     sharedInverter = orig.sharedInverter;

--- a/shared/lib_battery_powerflow.h
+++ b/shared/lib_battery_powerflow.h
@@ -42,6 +42,9 @@ class SharedInverter;
 
 struct BatteryPower;
 
+// Allow for consistent power tolerances between the technology code and utility rate code
+extern double powerflow_tolerance; 
+
 /**
 * \class BatteryPowerFlow
 *

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -1420,6 +1420,10 @@ public:
 					dc_tou_sched[ii] = (ssc_number_t)rate.m_dc_tou_sched[ii];
 					load[ii] = -e_load_cy[ii];
 					e_tofromgrid[ii] = e_grid_cy[ii];
+
+                    if (fabs(e_tofromgrid[ii]) < powerflow_tolerance) { // powerflow_tolerance is defined globally in shared/lib_battery_powerflow.h, set to 0.000005 (Watts or Watt-hrs)
+                        e_tofromgrid[ii] = 0.0;
+                    }
 					if (e_tofromgrid[ii] > 0)
 					{
 						year1_hourly_e_togrid[ii] = e_tofromgrid[ii];
@@ -1430,7 +1434,7 @@ public:
 						year1_hourly_e_togrid[ii] = 0.0;
 						year1_hourly_e_fromgrid[ii] = -e_tofromgrid[ii];
 					}
-					p_tofromgrid[ii] = p_grid_cy[ii];
+					p_tofromgrid[ii] = fabs(p_grid_cy[ii]) > powerflow_tolerance ? p_grid_cy[ii] : 0.0;
 					salespurchases[ii] = revenue_w_sys[ii];
 				}
 				assign("year1_hourly_ec_tou_schedule", var_data(&ec_tou_sched[0], (int)m_num_rec_yearly));

--- a/ssc/common_financial.cpp
+++ b/ssc/common_financial.cpp
@@ -3338,7 +3338,7 @@ var_info vtab_lcos_inputs[] = {
     { SSC_INPUT, SSC_MATRIX, "net_billing_credits_ym", "Net billing credit", "$", "", "Charges by Month", "", "", "COL_LABEL=MONTHS,FORMAT_SPEC=CURRENCY,GROUP=UR_AM" },
 
     // fix for running financial compute modules tests
-    { SSC_INOUT,       SSC_ARRAY,       "gen_purchases",                              "Electricity from grid",                                    "kW",      "",                       "System Output",       "",                           "",                              "" },
+    { SSC_INOUT,       SSC_ARRAY,       "gen_purchases",                              "Electricity from grid to system",                         "kW",      "",                       "System Output",       "",                           "",                              "" },
     { SSC_INPUT,        SSC_ARRAY,      "rate_escalation",          "Annual electricity rate escalation",   "%/year",   "",                      "Electricity Rates",       "",              "",                             "" },
 
     

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -1144,7 +1144,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialACBatteryModelGridOu
     ssc_number_t expectedEnergy = 8521.00;
     ssc_number_t expectedBatteryChargeEnergy = 3290.77;
     ssc_number_t expectedBatteryDischargeEnergy = 2974.91;
-    ssc_number_t expectedCritLoadUnmet = 485.18;
+    ssc_number_t expectedCritLoadUnmet = 488.14;
 
     ssc_number_t peakKwCharge = -3.4;
     ssc_number_t peakKwDischarge = 1.964;


### PR DESCRIPTION
- Use same tolerance in powerflow code and utility rate code, which both generate "electricity from grid to x varaibles"
- Rename gen_purchases so it's clear that it does not include load it btm models

Fixes https://github.com/NREL/SAM/issues/1684, see the issue for test file.