### PR TITLE
Address SAM issue #1733 while keeping functionality of SAM issue #1184

### DIFF
--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -171,10 +171,10 @@ var_info_invalid
 
 var_info vtab_depreciation[] = {
 { SSC_INPUT,SSC_NUMBER  , "depr_fed_type"                        , "Federal depreciation type"                                      , ""                                       , "0=none,1=macrs_half_year,2=sl,3=custom", "Depreciation"         , "?=0"            , "INTEGER,MIN=0,MAX=3"   , ""},
-{ SSC_INPUT,SSC_NUMBER  , "depr_fed_sl_years"                    , "Federal depreciation straight-line Years"                       , "years"                                  , ""                                      , "Depreciation"         , "depr_fed_type=2", "INTEGER,POSITIVE"      , ""},
+{ SSC_INPUT,SSC_NUMBER  , "depr_fed_sl_years"                    , "Federal depreciation straight-line Years"                       , "years"                                  , ""                                      , "Depreciation"         , "depr_fed_type=2", "INTEGER,POSITIVE"      , "SKIP_CONSTRAINT_CHECK"},
 { SSC_INPUT,SSC_ARRAY   , "depr_fed_custom"                      , "Federal custom depreciation"                                    , "%/year"                                 , ""                                      , "Depreciation"         , "depr_fed_type=3", ""                      , ""},
 { SSC_INPUT,SSC_NUMBER  , "depr_sta_type"                        , "State depreciation type"                                        , ""                                       , "0=none,1=macrs_half_year,2=sl,3=custom", "Depreciation"         , "?=0"            , "INTEGER,MIN=0,MAX=3"   , ""},
-{ SSC_INPUT,SSC_NUMBER  , "depr_sta_sl_years"                    , "State depreciation straight-line years"                         , "years"                                  , ""                                      , "Depreciation"         , "depr_sta_type=2", "INTEGER,POSITIVE"      , ""},
+{ SSC_INPUT,SSC_NUMBER  , "depr_sta_sl_years"                    , "State depreciation straight-line years"                         , "years"                                  , ""                                      , "Depreciation"         , "depr_sta_type=2", "INTEGER,POSITIVE"      , "SKIP_CONSTRAINT_CHECK"},
 { SSC_INPUT,SSC_ARRAY   , "depr_sta_custom"                      , "State custom depreciation"                                      , "%/year"                                 , ""                                      , "Depreciation"         , "depr_sta_type=3", ""                      , ""},
 var_info_invalid };
 

--- a/ssc/core.cpp
+++ b/ssc/core.cpp
@@ -311,7 +311,8 @@ bool compute_module::verify(const std::string &phase, int check_var_type) {
                     ret =  false;
                 }
             }
-            else { // SAM issue 1184 - if variable present check constraints even if not required - can check type. too.
+            else if (vi->ui_hint != "SKIP_CONSTRAINT_CHECK") // SAM issue 1733 added for depr_fed_sl_years and depr_sta_sl_years
+            { // SAM issue 1184 - if variable present check constraints even if not required - can check type. too.
                 if (var_data* dat = lookup(vi->name)) {
                     std::string fail_text;
                     if (!check_constraints(vi->name, fail_text)) {


### PR DESCRIPTION
To test:
1. pull SAM_1733 branch of ssc and patch branches of other repos and build
2. create PVWatts/Commercial case
3. Financial parameters page - set straight line depreciation years to 0
4. select straight line depreciation and run - error as expected
5. select different depreciation method and run - no error as expected.

See https://github.com/NREL/SAM/issues/1733 for simulation error in current release.