### PR TITLE
Sam 1806 make tolerances more consistent

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 
 #include "lib_battery.h"
+#include "lib_battery_powerflow.h"
 
 /*
 Define Thermal Model
@@ -522,7 +523,7 @@ double battery_t::calculate_max_charge_kw(double *max_current_A) {
     double power_W = 0;
     double current = 0;
     size_t its = 0;
-    while (std::abs(power_W - voltage->calculate_max_charge_w(q, qmax, thermal->T_battery(), &current)) > tolerance
+    while (std::abs(power_W - voltage->calculate_max_charge_w(q, qmax, thermal->T_battery(), &current)) > powerflow_tolerance
            && its++ < 10) {
         power_W = voltage->calculate_max_charge_w(q, qmax, thermal->T_battery(), &current);
         thermal->updateTemperature(current, state->last_idx + 1);
@@ -541,7 +542,7 @@ double battery_t::calculate_max_discharge_kw(double *max_current_A) {
     double power_W = 0;
     double current = 0;
     size_t its = 0;
-    while (std::abs(power_W - voltage->calculate_max_discharge_w(q, qmax, thermal->T_battery(), &current)) > tolerance
+    while (std::abs(power_W - voltage->calculate_max_discharge_w(q, qmax, thermal->T_battery(), &current)) > powerflow_tolerance
            && its++ < 5) {
         power_W = voltage->calculate_max_discharge_w(q, qmax, thermal->T_battery(), &current);
         thermal->updateTemperature(current, state->last_idx + 1);

--- a/shared/lib_battery_capacity.cpp
+++ b/shared/lib_battery_capacity.cpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lib_battery_capacity.h"
 
 double low_tolerance = 0.01;
-double tolerance = 0.002; // Used for capacity calcs. Please use powerflow_tolerance for units of W
+double tolerance = 0.002; // Used for capacity calcs. Please use powerflow_tolerance for units of kW
 
 /*
 Define Capacity Model

--- a/shared/lib_battery_capacity.cpp
+++ b/shared/lib_battery_capacity.cpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lib_battery_capacity.h"
 
 double low_tolerance = 0.01;
-double tolerance = 0.002;
+double tolerance = 0.002; // Used for capacity calcs. Please use powerflow_tolerance for units of W
 
 /*
 Define Capacity Model

--- a/shared/lib_battery_dispatch_manual.cpp
+++ b/shared/lib_battery_dispatch_manual.cpp
@@ -173,7 +173,7 @@ bool dispatch_manual_t::check_constraints(double &I, size_t count)
 			I <= 0)											// and battery was not discharging
 		{
 			double dI = 0;
-			if (std::abs(m_batteryPower->powerBatteryDC) < tolerance)
+			if (std::abs(m_batteryPower->powerBatteryDC) < powerflow_tolerance)
 				dI = (m_batteryPower->powerSystemToGrid  * util::kilowatt_to_watt / _Battery->V());
 			else
 				dI = (m_batteryPower->powerSystemToGrid  / std::abs(m_batteryPower->powerBatteryAC)) * std::abs(I);
@@ -194,7 +194,7 @@ bool dispatch_manual_t::check_constraints(double &I, size_t count)
 			}
 
 			double dI = 0;
-			if (dP < tolerance)
+			if (dP < powerflow_tolerance)
 				dI = dP / _Battery->V();
 			else
 				dI = (dP / std::abs(m_batteryPower->powerBatteryAC)) * std::abs(I);
@@ -204,7 +204,7 @@ bool dispatch_manual_t::check_constraints(double &I, size_t count)
 		// Don't let battery export to the grid if behind the meter
 		else if (m_batteryPower->meterPosition == dispatch_t::BEHIND && !m_batteryPower->canDischargeToGrid && I > 0 && m_batteryPower->powerBatteryToGrid > tolerance)
 		{
-			if (std::abs(m_batteryPower->powerBatteryAC) < tolerance)
+			if (std::abs(m_batteryPower->powerBatteryAC) < powerflow_tolerance)
 				I -= (m_batteryPower->powerBatteryToGrid * util::kilowatt_to_watt / _Battery->V());
 			else
 				I -= (m_batteryPower->powerBatteryToGrid / std::abs(m_batteryPower->powerBatteryAC)) * std::abs(I);

--- a/shared/lib_resilience.cpp
+++ b/shared/lib_resilience.cpp
@@ -79,7 +79,7 @@ bool dispatch_resilience::run_outage_step_ac(double crit_load_kwac, double pv_kw
     double met_load = m_batteryPower->powerBatteryToLoad + m_batteryPower->powerSystemToLoad + m_batteryPower->powerFuelCellToLoad;
     double unmet_load = m_batteryPower->powerCritLoadUnmet;
     met_loads_kw += met_load;
-    bool survived = unmet_load < tolerance;
+    bool survived = unmet_load < powerflow_tolerance;
     if (survived)
         current_outage_index += 1;
     return survived;
@@ -101,7 +101,7 @@ bool dispatch_resilience::run_outage_step_dc(double crit_load_kwac, double pv_kw
     double met_load = m_batteryPower->powerBatteryToLoad + m_batteryPower->powerSystemToLoad + m_batteryPower->powerFuelCellToLoad;
     double unmet_load = m_batteryPower->powerCritLoadUnmet;
     met_loads_kw += met_load;
-    bool survived = unmet_load < tolerance;
+    bool survived = unmet_load < powerflow_tolerance;
     if (survived)
         current_outage_index += 1;
     return survived;

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -1144,7 +1144,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialACBatteryModelGridOu
     ssc_number_t expectedEnergy = 8521.00;
     ssc_number_t expectedBatteryChargeEnergy = 3290.77;
     ssc_number_t expectedBatteryDischargeEnergy = 2974.91;
-    ssc_number_t expectedCritLoadUnmet = 488.14;
+    ssc_number_t expectedCritLoadUnmet = 494.59;
 
     ssc_number_t peakKwCharge = -3.4;
     ssc_number_t peakKwDischarge = 1.964;

--- a/test/ssc_test/cmod_battery_test.cpp
+++ b/test/ssc_test/cmod_battery_test.cpp
@@ -99,11 +99,11 @@ TEST_F(CMBattery_cmod_battery, ResilienceMetricsFullLoad){
 
     EXPECT_EQ(resilience_hours[0], 0); // Max current restrictions prevent this battery from meeting the outage until day 2 (hr 46)
     EXPECT_EQ(resilience_hours[46], 5);
-    EXPECT_NEAR(avg_critical_load, 701.8, 0.1);
-    EXPECT_NEAR(resilience_hrs_avg, 1.17, 0.01);
+    EXPECT_NEAR(avg_critical_load, 686.02, 0.1);
+    EXPECT_NEAR(resilience_hrs_avg, 1.11, 0.01);
     EXPECT_EQ(resilience_hrs_min, 0);
     EXPECT_EQ(outage_durations[0], 0);
-    EXPECT_EQ(resilience_hrs_max, 24);
+    EXPECT_EQ(resilience_hrs_max, 17);
     EXPECT_EQ(outage_durations[17], 17);
     EXPECT_NEAR(pdf_of_surviving[0], 0.756, 1e-3);
     EXPECT_NEAR(pdf_of_surviving[1], 0.0314, 1e-3);
@@ -155,11 +155,11 @@ TEST_F(CMBattery_cmod_battery, ResilienceMetricsFullLoadLifetime){
 
     EXPECT_EQ(resilience_hours[0], 0); // Max current restrictions prevent this battery from meeting the outage until day 2 (hr 46)
     EXPECT_EQ(resilience_hours[46], 5);
-    EXPECT_NEAR(avg_critical_load, 698.3, 0.1);
-    EXPECT_NEAR(resilience_hrs_avg, 1.16, 0.01);
+    EXPECT_NEAR(avg_critical_load, 683.06, 0.1);
+    EXPECT_NEAR(resilience_hrs_avg, 1.103, 0.01);
     EXPECT_EQ(resilience_hrs_min, 0);
     EXPECT_EQ(outage_durations[0], 0);
-    EXPECT_EQ(resilience_hrs_max, 24);
+    EXPECT_EQ(resilience_hrs_max, 17);
     EXPECT_EQ(outage_durations[17], 17);
     EXPECT_NEAR(pdf_of_surviving[0], 0.754, 1e-3);
     EXPECT_NEAR(pdf_of_surviving[1], 0.0314, 1e-3);


### PR DESCRIPTION
Consistently use the powerflow tolerance throughout the battery issue to mitigate issues caused by inconsistent tolerances. Results of the parametric run after changes:

![image](https://github.com/user-attachments/assets/70b5bbaf-daba-4099-b6a2-9c86e0beb589)

See https://github.com/NREL/SAM/issues/1806 for test file. See https://github.com/NREL/ssc/pull/1132 for history on powerflow tolerance.

Test changes for grid outage and resilience code were required to accommodate tighter tolerances. Reported resilience metrics have decreased due to changing tolerance from 2 W to 0.005 W. 