### PR TITLE
Initialize ground clearance height for IEC module model

### DIFF
--- a/shared/lib_pv_io_manager.cpp
+++ b/shared/lib_pv_io_manager.cpp
@@ -1354,6 +1354,8 @@ Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)
         referenceArea = elevenParamSingleDiodeModel.Area;
         selfShadingFillFactor = elevenParamSingleDiodeModel.Vmp0 * elevenParamSingleDiodeModel.Imp0 / elevenParamSingleDiodeModel.Voc0 / elevenParamSingleDiodeModel.Isc0;
         voltageMaxPower = elevenParamSingleDiodeModel.Vmp0;
+
+        groundClearanceHeight = 1.0; //No input as there is no bifacial option for IEC 61853 model
     }
     else if (modulePowerModel == MODULE_PVYIELD)
     {


### PR DESCRIPTION
Fixes https://github.com/NREL/ssc/issues/1190

Should be good to go if SSC tests pass