### PR TITLE
Standalone battery  metrics

### DIFF
--- a/shared/lib_battery_dispatch.cpp
+++ b/shared/lib_battery_dispatch.cpp
@@ -924,6 +924,7 @@ battery_metrics_t::battery_metrics_t(double dt_hour)
     _average_efficiency = 100.;
     _average_roundtrip_efficiency = 100.;
     _pv_charge_percent = 0.;
+    _grid_charge_percent = 0.;
 
     // annual metrics
     _e_charge_from_pv_annual = 0.;
@@ -938,6 +939,7 @@ battery_metrics_t::battery_metrics_t(double dt_hour)
 double battery_metrics_t::average_battery_conversion_efficiency() { return _average_efficiency; }
 double battery_metrics_t::average_battery_roundtrip_efficiency() { return _average_roundtrip_efficiency; }
 double battery_metrics_t::pv_charge_percent() { return _pv_charge_percent; }
+double battery_metrics_t::grid_charge_percent() { return _grid_charge_percent; }
 double battery_metrics_t::energy_pv_charge_annual() { return _e_charge_from_pv_annual; }
 double battery_metrics_t::energy_grid_charge_annual() { return _e_charge_from_grid_annual; }
 double battery_metrics_t::energy_charge_annual() { return _e_charge_annual; }
@@ -996,6 +998,7 @@ void battery_metrics_t::accumulate_battery_charge_components(double P_tofrom_bat
     _average_efficiency = 100. * (_e_discharge_accumulated / _e_charge_accumulated);
     _average_roundtrip_efficiency = 100. * (_e_discharge_accumulated / (_e_charge_accumulated + _e_loss_system));
     _pv_charge_percent = 100. * (_e_charge_from_pv / _e_charge_accumulated);
+    _grid_charge_percent = 100. * (_e_charge_from_grid / _e_charge_accumulated);
 }
 void battery_metrics_t::accumulate_grid_annual(double P_tofrom_grid)
 {

--- a/shared/lib_battery_dispatch.h
+++ b/shared/lib_battery_dispatch.h
@@ -474,6 +474,7 @@ public:
 	double average_battery_conversion_efficiency();
 	double average_battery_roundtrip_efficiency();
 	double pv_charge_percent();
+    double grid_charge_percent();
 
 protected:
 
@@ -492,6 +493,7 @@ protected:
 
 	/*! This is the percentage of energy charge from the PV system [%] */
 	double _pv_charge_percent;
+    double _grid_charge_percent;
 
 	// annual metrics
 	double _e_charge_from_pv_annual;   // [Kwh]

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -337,6 +337,7 @@ var_info vtab_battery_outputs[] = {
     { SSC_OUTPUT,        SSC_NUMBER,     "average_battery_conversion_efficiency",      "Battery average cycle conversion efficiency",           "%",        "",                      "Annual",        "",                           "",                               "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "average_battery_roundtrip_efficiency",       "Battery average roundtrip efficiency",                  "%",        "",                      "Annual",        "",                           "",                               "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "batt_system_charge_percent",                 "Battery charge energy charged from system",             "%",        "",                      "Annual",        "",                           "",                               "" },
+    { SSC_OUTPUT,        SSC_NUMBER,     "batt_grid_charge_percent",                 "Battery charge energy charged from grid",             "%",        "",                      "Annual",        "",                           "",                               "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "batt_bank_installed_capacity",               "Battery bank installed capacity",                       "kWh",      "",                      "Annual",        "",                           "",                               "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "annual_crit_load",                           "Critical load energy (year 1)",                    "kWh",      "",                           "Battery",       "",                           "",                              "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "annual_crit_load_unmet",                     "Critical load energy unmet (year 1)",                    "kWh",      "",                      "Battery",       "",                           "",                              "" },
@@ -926,6 +927,7 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
     outUnmetLosses = 0;
     outAverageCycleEfficiency = 0;
     outSystemChargePercent = 0;
+    outGridChargePercent = 0;
     outAnnualSystemChargeEnergy = 0;
     outAnnualGridChargeEnergy = 0;
     outAnnualChargeEnergy = 0;
@@ -1731,6 +1733,7 @@ battstor::battstor(const battstor& orig) {
     outAverageCycleEfficiency = orig.outAverageCycleEfficiency;
     outAverageRoundtripEfficiency = orig.outAverageRoundtripEfficiency;
     outSystemChargePercent = orig.outSystemChargePercent;
+    outGridChargePercent = orig.outGridChargePercent;
 
     // copy models
     if (orig.batt_vars) batt_vars = orig.batt_vars;
@@ -1997,6 +2000,14 @@ void battstor::metrics()
         outSystemChargePercent = 100;
     else if (outSystemChargePercent < 0)
         outSystemChargePercent = 0;
+
+    // Grid charge ratio
+    outGridChargePercent = (ssc_number_t)battery_metrics->grid_charge_percent();
+    if (outGridChargePercent > 100)
+        outGridChargePercent = 100;
+    else if (outGridChargePercent < 0)
+        outGridChargePercent = 0;
+
 }
 
 // function needed to correctly calculate P_grid due to additional losses in P_gen post battery like wiring, curtailment, availablity
@@ -2070,6 +2081,7 @@ void battstor::calculate_monthly_and_annual_outputs(compute_module& cm)
     cm.assign("average_battery_conversion_efficiency", var_data((ssc_number_t)outAverageCycleEfficiency));
     cm.assign("average_battery_roundtrip_efficiency", var_data((ssc_number_t)outAverageRoundtripEfficiency));
     cm.assign("batt_system_charge_percent", var_data((ssc_number_t)outSystemChargePercent));
+    cm.assign("batt_grid_charge_percent", var_data((ssc_number_t)outGridChargePercent));
     cm.assign("batt_bank_installed_capacity", (ssc_number_t)batt_vars->batt_kwh);
 
     cm.assign("batt_year1_charge_from_grid", var_data((ssc_number_t)outAnnualGridChargeEnergy[0]));

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -342,6 +342,8 @@ var_info vtab_battery_outputs[] = {
     { SSC_OUTPUT,        SSC_NUMBER,     "annual_crit_load_unmet",                     "Critical load energy unmet (year 1)",                    "kWh",      "",                      "Battery",       "",                           "",                              "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "annual_crit_load_unmet_percentage",          "Critical load unmet percentage (year 1)",                "%",        "",                      "Battery",       "",                           "",                              "" },
     { SSC_OUTPUT,        SSC_NUMBER,     "annual_outage_losses_unmet",                 "Battery and system losses unmet energy (year 1)",        "kWh",      "",                      "Battery",       "",                           "",                              "" },
+    { SSC_OUTPUT,        SSC_NUMBER,      "batt_year1_charge_from_system",             "Battery annual energy charged from system (year 1)",                 "kWh",      "",                      "Battery",       "",                           "",                               "" },
+    { SSC_OUTPUT,        SSC_NUMBER,      "batt_year1_charge_from_grid",               "Battery annual energy charged from grid (year 1)",               "kWh",      "",                      "Battery",       "",                           "",                               "" },
 
     // test matrix output
     { SSC_OUTPUT,        SSC_MATRIX,     "batt_dispatch_sched",                        "Battery dispatch schedule",                              "",        "",                     "Battery",       "",                           "",                               "ROW_LABEL=MONTHS,COL_LABEL=HOURS_OF_DAY"  },
@@ -2069,6 +2071,9 @@ void battstor::calculate_monthly_and_annual_outputs(compute_module& cm)
     cm.assign("average_battery_roundtrip_efficiency", var_data((ssc_number_t)outAverageRoundtripEfficiency));
     cm.assign("batt_system_charge_percent", var_data((ssc_number_t)outSystemChargePercent));
     cm.assign("batt_bank_installed_capacity", (ssc_number_t)batt_vars->batt_kwh);
+
+    cm.assign("batt_year1_charge_from_grid", var_data((ssc_number_t)outAnnualGridChargeEnergy[0]));
+    cm.assign("batt_year1_charge_from_system", var_data((ssc_number_t)outAnnualSystemChargeEnergy[0]));
 
     // monthly outputs
     cm.accumulate_monthly_for_year("system_to_batt", "monthly_system_to_batt", _dt_hour, step_per_hour);

--- a/ssc/cmod_battery.h
+++ b/ssc/cmod_battery.h
@@ -454,6 +454,7 @@ struct battstor
 	double outAverageCycleEfficiency;
 	double outAverageRoundtripEfficiency;
 	double outSystemChargePercent;
+    double outGridChargePercent;
 
     //output variables for self-consumption dispatch
     double outTimestepsLoadMetBySystemYear1;


### PR DESCRIPTION
-Adds year 1 energy charged from system, grid metrics to report in standalone battery metrics table
-See (https://github.com/NREL/SAM/issues/1589)