### PR TITLE
Refactor adjust losses to use vartable instead of cmod 

### DIFF
--- a/ssc/cmod_biomass.cpp
+++ b/ssc/cmod_biomass.cpp
@@ -953,7 +953,7 @@ public:
 		rated_eff += press_adj;
 
 
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup())
 			throw exec_error("biopower", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_etes_electric_resistance.cpp
+++ b/ssc/cmod_etes_electric_resistance.cpp
@@ -1096,7 +1096,7 @@ public:
         ssc_number_t* p_time_final_hr = as_array("time_hr", &count);
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(n_steps_fixed))
             throw exec_error("etes_electric_resistance", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_etes_ptes.cpp
+++ b/ssc/cmod_etes_ptes.cpp
@@ -1249,7 +1249,7 @@ public:
         ssc_number_t* p_time_final_hr = as_array("time_hr", &count);
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(count))
             throw exec_error("etes_electric_resistance", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_fresnel_physical.cpp
+++ b/ssc/cmod_fresnel_physical.cpp
@@ -1785,7 +1785,7 @@ public:
             throw exec_error("fresnel_physical", "The number of fixed steps does not match the length of output data arrays");
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(n_steps_fixed))
             throw exec_error("fresnel_physical", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_fresnel_physical_iph.cpp
+++ b/ssc/cmod_fresnel_physical_iph.cpp
@@ -1531,7 +1531,7 @@ public:
             throw exec_error("fresnel_physical", "The number of fixed steps does not match the length of output data arrays");
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(n_steps_fixed))
             throw exec_error("fresnel_physical", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_generic_system.cpp
+++ b/ssc/cmod_generic_system.cpp
@@ -118,7 +118,7 @@ public:
 	    sys_degradation.reserve(nyears);
 		double derate = (1 - (double)as_number("derate") / 100);
 
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup(nrec_load, nyears))
 			throw exec_error("generic system", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_geothermal.cpp
+++ b/ssc/cmod_geothermal.cpp
@@ -523,7 +523,7 @@ public:
 			ssc_number_t * p_gen = allocate("gen", n_rec);
 
 			// TODO - implement performance factors 
-			adjustment_factors haf(this, "adjust");
+			adjustment_factors haf(this->get_var_table(), "adjust");
 			if (!haf.setup(8760, geo_inputs.mi_ProjectLifeYears))
 				throw exec_error("geothermal", "failed to setup adjustment factors: " + haf.error());
             std::vector<double> haf_input;

--- a/ssc/cmod_hcpv.cpp
+++ b/ssc/cmod_hcpv.cpp
@@ -401,7 +401,7 @@ public:
         double ac_loss_tracker = 0;
 
 
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup())
             throw exec_error("hcpv", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_linear_fresnel_dsg_iph.cpp
+++ b/ssc/cmod_linear_fresnel_dsg_iph.cpp
@@ -583,7 +583,7 @@ public:
 			throw exec_error("linear_fresnel_dsg_iph", "The number of fixed steps does not match the length of output data arrays");
 
 		// 'adjustment_factors' class stores factors in hourly array, so need to index as such
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if( !haf.setup(n_steps_fixed) )
 			throw exec_error("linear_fresnel_dsg_iph", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_mhk_tidal.cpp
+++ b/ssc/cmod_mhk_tidal.cpp
@@ -240,7 +240,7 @@ public:
             ssc_number_t* p_gen = allocate("gen", number_records);
             int power_bin = 0;
 
-            adjustment_factors haf(this, "adjust");
+            adjustment_factors haf(this->get_var_table(), "adjust");
             if (!haf.setup(number_records, 1))
                 throw exec_error("mhk_tidal", "Failed to set up adjustment factors: " + haf.error());
 

--- a/ssc/cmod_mhk_wave.cpp
+++ b/ssc/cmod_mhk_wave.cpp
@@ -578,7 +578,7 @@ public:
                 sys_degradation.push_back(1); // single year mode - degradation handled in financial models.
             }
 
-            adjustment_factors haf(this, "adjust");
+            adjustment_factors haf(this->get_var_table(), "adjust");
             if (!haf.setup(number_records, nyears))
                 throw exec_error("mhk_wave", "Failed to set up adjustment factors: " + haf.error());
 

--- a/ssc/cmod_mspt_iph.cpp
+++ b/ssc/cmod_mspt_iph.cpp
@@ -1428,7 +1428,7 @@ public:
         heliostatfield.ms_params.mv_clearsky_data = clearsky_data;
 
         //Load the solar field adjustment factors
-        adjustment_factors sf_haf(this, "sf_adjust");
+        adjustment_factors sf_haf(this->get_var_table(), "sf_adjust");
         if (!sf_haf.setup((int)n_steps_full))
             throw exec_error("mspt_iph", "failed to setup sf adjustment factors: " + sf_haf.error());
         //allocate array to pass to tcs
@@ -2290,7 +2290,7 @@ public:
         ssc_number_t* p_q_dot_heat_sink = as_array("q_dot_to_heat_sink", &count);
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(count))
             throw exec_error("mspt_iph", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1225,12 +1225,12 @@ void cm_pvsamv1::exec()
     //dc hourly adjustment factors
     int nyears_haf = nyears;
     if (!system_use_lifetime_output) nyears_haf = 1;
-    adjustment_factors dc_haf(this, "dc_adjust");
+    adjustment_factors dc_haf(this->get_var_table(), "dc_adjust");
     if (!dc_haf.setup((int)nrec, nyears_haf))
         throw exec_error("pvsamv1", "failed to setup DC adjustment factors: " + dc_haf.error());
 
     // hourly adjustment factors
-    adjustment_factors haf(this, "adjust");
+    adjustment_factors haf(this->get_var_table(), "adjust");
     if (!haf.setup((int)nrec, nyears_haf))
         throw exec_error("pvsamv1", "failed to setup AC adjustment factors: " + haf.error());
 

--- a/ssc/cmod_pvwattsv5.cpp
+++ b/ssc/cmod_pvwattsv5.cpp
@@ -471,7 +471,7 @@ public:
         size_t nrec = wdprov->nrecords();
         size_t nlifetime = nrec * nyears;
 
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(nrec, nyears))
             throw exec_error("pvwattsv5", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_pvwattsv7.cpp
+++ b/ssc/cmod_pvwattsv7.cpp
@@ -687,7 +687,7 @@ public:
         size_t nrec = wdprov->nrecords();
         size_t nlifetime = nrec * nyears;
 
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(nrec, nyears))
             throw exec_error("pvwattsv7", "Failed to set up adjustment factors: " + haf.error());
 

--- a/ssc/cmod_pvwattsv8.cpp
+++ b/ssc/cmod_pvwattsv8.cpp
@@ -746,7 +746,7 @@ public:
         size_t nrec = wdprov->nrecords();
         size_t nlifetime = nrec * nyears;
 
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if (!haf.setup(nrec, nyears))
             throw exec_error("pvwattsv8", "Failed to set up adjustment factors: " + haf.error());
 

--- a/ssc/cmod_swh.cpp
+++ b/ssc/cmod_swh.cpp
@@ -344,7 +344,7 @@ public:
 		double ts_hour = 1.0/step_per_hour;
 		double ts_sec = 3600.0/step_per_hour;
 
-        adjustment_factors haf( this, "adjust" );
+        adjustment_factors haf( this->get_var_table(), "adjust" );
 		if ( !haf.setup(nrec) )
 			throw exec_error("swh", "failed to setup adjustment factors: " + haf.error() );
 

--- a/ssc/cmod_tcsdish.cpp
+++ b/ssc/cmod_tcsdish.cpp
@@ -517,7 +517,7 @@ public:
 		ssc_number_t *po8 = allocate("hourly_Q_rec_losses", count);
 
 
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup(count))
 			throw exec_error("dish", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_tcsgeneric_solar.cpp
+++ b/ssc/cmod_tcsgeneric_solar.cpp
@@ -377,7 +377,7 @@ public:
         size_t hours = 8760;
 
         //Load the solar field adjustment factors
-        adjustment_factors sf_haf(this, "sf_adjust");
+        adjustment_factors sf_haf(this->get_var_table(), "sf_adjust");
         if (!sf_haf.setup(hours))
 			throw exec_error("tcsgeneric_solar", "failed to setup sf adjustment factors: " + sf_haf.error());
         //allocate array to pass to tcs
@@ -400,7 +400,7 @@ public:
 		if (!enet || count != 8760)
 			throw exec_error("tcsgeneric_solar", "Failed to retrieve hourly net energy");
 
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup(count))
 			throw exec_error("tcsgeneric_solar", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_tcslinear_fresnel.cpp
+++ b/ssc/cmod_tcslinear_fresnel.cpp
@@ -569,7 +569,7 @@ public:
 			throw exec_error( "tcslinear_fresnel", util::format("there was a problem returning the results from the simulation.") );
 
 		// performance adjustement factors
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup())
 			throw exec_error("tcstrough_physical", "failed to setup adjustment factors: " + haf.error());
 	

--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -1884,7 +1884,7 @@ public:
         heliostatfield.ms_params.mv_clearsky_data = clearsky_data;
 
         //Load the solar field adjustment factors
-        adjustment_factors sf_haf(this, "sf_adjust");
+        adjustment_factors sf_haf(this->get_var_table(), "sf_adjust");
         if (!sf_haf.setup((int)n_steps_full))
             throw exec_error("tcsmolten_salt", "failed to setup sf adjustment factors: " + sf_haf.error());
         //allocate array to pass to tcs
@@ -2979,7 +2979,7 @@ public:
         ssc_number_t *p_time_final_hr = as_array("time_hr", &count);
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if( !haf.setup(n_steps_full) )
             throw exec_error("tcsmolten_salt", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_tcsmslf.cpp
+++ b/ssc/cmod_tcsmslf.cpp
@@ -800,7 +800,7 @@ public:
         std::copy(sgs_P_dsn, sgs_P_dsn + nv, sgs_P_dsn_cm);
 
 		// performance adjustement factors
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup())
 			throw exec_error("tcsmslf", "failed to setup adjustment factors: " + haf.error());
 		

--- a/ssc/cmod_tcstrough_empirical.cpp
+++ b/ssc/cmod_tcstrough_empirical.cpp
@@ -553,7 +553,7 @@ public:
 		assign("conversion_factor", convfactor);
 
 		// performance adjustement factors
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup())
 			throw exec_error("tcstrough_empirical", "failed to setup adjustment factors: " + haf.error());
 		// hourly_energy output

--- a/ssc/cmod_tcstrough_physical.cpp
+++ b/ssc/cmod_tcstrough_physical.cpp
@@ -981,7 +981,7 @@ public:
         std::copy(sgs_P_dsn, sgs_P_dsn + nv, sgs_P_dsn_cm);
 		
 		// performance adjustment factors
-		adjustment_factors haf(this, "adjust");
+		adjustment_factors haf(this->get_var_table(), "adjust");
 		if (!haf.setup(nrec))
 			throw exec_error("tcstrough_physical", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_trough_physical.cpp
+++ b/ssc/cmod_trough_physical.cpp
@@ -2138,7 +2138,7 @@ public:
             throw exec_error("trough_physical", "The number of fixed steps does not match the length of output data arrays");
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if( !haf.setup(n_steps_full) )
             throw exec_error("trough_physical", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_trough_physical_iph.cpp
+++ b/ssc/cmod_trough_physical_iph.cpp
@@ -1826,7 +1826,7 @@ public:
             throw exec_error("trough_physical", "The number of fixed steps does not match the length of output data arrays");
 
         // 'adjustment_factors' class stores factors in hourly array, so need to index as such
-        adjustment_factors haf(this, "adjust");
+        adjustment_factors haf(this->get_var_table(), "adjust");
         if( !haf.setup(n_steps_fixed) )
             throw exec_error("trough_physical", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -348,7 +348,7 @@ void cm_windpower::exec()
 		throw exec_error("windpower", util::format("the wind model is only configured to handle up to %d turbines.", wpc.GetMaxTurbines()));
 
 	// create adjustment factors and losses - set them up initially here for the Weibull distribution method, rewrite them later with nrec for the time series method
-	adjustment_factors haf(this, "adjust");
+	adjustment_factors haf(this->get_var_table(), "adjust");
 	if (!haf.setup())
 		throw exec_error("windpower", "failed to setup adjustment factors: " + haf.error());
 

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1063,22 +1063,22 @@ var_info vtab_utility_rate_common[] = {
     var_info_invalid
 };
 
-adjustment_factors::adjustment_factors( compute_module *cm, const std::string &prefix )
-: m_cm(cm), m_prefix(prefix)
+adjustment_factors::adjustment_factors(var_table* vt, const std::string &prefix )
+: m_vt(vt), m_prefix(prefix)
 {
 }
 
 //adjustment factors changed from derates to percentages jmf 1/9/15
 bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set to 8760 in this declaration function in common.h
 {
-    ssc_number_t f = m_cm->as_number(m_prefix + "_constant");
+    ssc_number_t f = m_vt->as_number(m_prefix + "_constant");
     f = 1.0 - f / 100.0; //convert from percentage to factor
 	m_factors.resize( nsteps * analysis_period, f);
 
-    if (m_cm->is_assigned(m_prefix + "_en_hourly")) {
-        if (m_cm->as_boolean(m_prefix + "_en_hourly")) {
+    if (m_vt->is_assigned(m_prefix + "_en_hourly")) {
+        if (m_vt->as_boolean(m_prefix + "_en_hourly")) {
             size_t n;
-            ssc_number_t* p = m_cm->as_array(m_prefix + "_hourly", &n);
+            ssc_number_t* p = m_vt->as_array(m_prefix + "_hourly", &n);
             if (p != 0 && n == 8760)
             {
                 for (int i = 0; i < 8760; i++)
@@ -1089,14 +1089,14 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
             }
         }
     }
-    if (m_cm->as_boolean(m_prefix +  "_en_timeindex"))
+    if (m_vt->as_boolean(m_prefix +  "_en_timeindex"))
     {
         size_t n;
         double steps_per_hour = nsteps / 8760.0;
         int month = 0;
         int day = 0;
         int week = 0;
-        ssc_number_t* p = m_cm->as_array(m_prefix + "_timeindex", &n);
+        ssc_number_t* p = m_vt->as_array(m_prefix + "_timeindex", &n);
         if (p != 0) {
             if (n == 1) {
                 for (int a = 0; a < analysis_period; a++) {
@@ -1152,10 +1152,10 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
             }
         }
     }
-    if (m_cm->as_boolean(m_prefix + "_en_periods"))
+    if (m_vt->as_boolean(m_prefix + "_en_periods"))
     {
 		size_t nr, nc;
-        ssc_number_t* mat = m_cm->as_matrix(m_prefix + "_periods", &nr, &nc);
+        ssc_number_t* mat = m_vt->as_matrix(m_prefix + "_periods", &nr, &nc);
         double ts_mult = nsteps / 8760.0;
 		if ( mat != 0 && nc == 3 )
 		{

--- a/ssc/common.h
+++ b/ssc/common.h
@@ -81,12 +81,12 @@ void prepend_to_output(compute_module* cm, std::string var_name, size_t count, s
 
 class adjustment_factors
 {
-	compute_module *m_cm;
+	var_table *m_vt;
 	std::vector<ssc_number_t> m_factors;
 	std::string m_error;
 	std::string m_prefix;
 public:
-	adjustment_factors(compute_module *cm, const std::string &prefix);
+	adjustment_factors(var_table *vt, const std::string &prefix);
 	bool setup(int nsteps=8760, int analysis_period=1);
 	ssc_number_t operator()(size_t time);
     size_t size();


### PR DESCRIPTION
Refactor adjust losses to make them more accessible to the battery. We expect no changes, but need to test to make sure this approach is threadsafe. My initial runs with parameterics looked reasonable.