### PR TITLE
Better handling of floating point numbers for tier tolerences

### DIFF
--- a/shared/lib_utility_rate_equations.cpp
+++ b/shared/lib_utility_rate_equations.cpp
@@ -678,7 +678,7 @@ void rate_data::setup_energy_rates(ssc_number_t* ec_weekday, ssc_number_t* ec_we
                             tier_check.push_back(m_month[m].ec_tou_ub.at(i, j));
                             tier_units.push_back(m_month[m].ec_tou_units.at(i, j));
                         }
-                        else if ((std::fabs(tier_check[tier - 1] - m_month[m].ec_tou_ub.at(i, j)) > 1e-7)) {
+                        else if ((std::fabs(tier_check[tier - 1] - m_month[m].ec_tou_ub.at(i, j)) > 1e-7 * std::fmin(tier_check[tier - 1], m_month[m].ec_tou_ub.at(i, j)))) {
                             std::string original_units = get_units_text(tier_units[tier - 1]);
                             std::string new_units = get_units_text(m_month[m].ec_tou_units.at(i, j));
 
@@ -843,7 +843,7 @@ void rate_data::setup_demand_charges(ssc_number_t* dc_weekday, ssc_number_t* dc_
                         if (tier_check.size() < tier) {
                             tier_check.push_back(m_month[m].dc_tou_ub.at(i, j));
                         }
-                        else if (std::fabs(tier_check[tier - 1] - m_month[m].dc_tou_ub.at(i, j)) > 1e-7) {
+                        else if (std::fabs(tier_check[tier - 1] - m_month[m].dc_tou_ub.at(i, j)) > 1e-7 * std::fmin(tier_check[tier - 1], m_month[m].dc_tou_ub.at(i, j))) {
                             std::ostringstream ss;
                             ss << "Demand tier " << tier << " Max. Usage for " << util::schedule_int_to_month(m) << " period " << period << " was expected to be ";
                             ss << tier_check[tier - 1] << " kW but was ";


### PR DESCRIPTION
The tier tolerances code (from https://github.com/NREL/ssc/pull/1207) didn't work well with large numbers other than 1e+38. Improve handling of floating point tolerances in that code.

To test: 
[rates-1e14-max.zip](https://github.com/user-attachments/files/17667454/rates-1e14-max.zip)
should run.