### PR TITLE
Fix SAM issue 1927

### DIFF
--- a/ssc/cmod_singleowner_heat.cpp
+++ b/ssc/cmod_singleowner_heat.cpp
@@ -3496,7 +3496,7 @@ public:
 //		save_cf(CF_energy_curtailed, nyears, "cf_energy_curtailed");
 //        const double MMBTU_TO_KWh = 293.07107; // 1
         save_cf(CF_ppa_price, nyears, "cf_ppa_price");
-        for (size_t i = 0; i < nyears; i++)
+        for (size_t i = 0; i <= nyears; i++)
             cf.at(CF_ppa_price_heat_btu, i) = cf.at(CF_ppa_price, i) * MMBTU_TO_KWh;
     	save_cf( CF_ppa_price_heat_btu, nyears, "cf_ppa_price_heat_btu" );
 		save_cf( CF_om_fixed_expense, nyears, "cf_om_fixed_expense" );


### PR DESCRIPTION
Fixes missing value for PPA price in cents/MMBtu for analysis period year - see https://github.com/NREL/SAM/issues/1927
![image](https://github.com/user-attachments/assets/1a5474ac-776e-4904-ab14-311070853ecb)
