### PR TITLE
Add placeholder variables for IPH physical heat sink model

### DIFF
--- a/ssc/cmod_fresnel_physical_iph.cpp
+++ b/ssc/cmod_fresnel_physical_iph.cpp
@@ -922,7 +922,7 @@ public:
 
         // Heat Sink
         int hs_type = as_integer("hs_type");
-        C_csp_power_cycle* c_heat_sink_pointer;
+        C_csp_power_cycle* c_heat_sink_pointer = nullptr;
         C_pc_heat_sink c_heat_sink;
         
         // Ideal heat sink
@@ -961,6 +961,11 @@ public:
         else
         {
             throw exec_error("fresnel_physical_iph", "hs_type != 0; other heat sink models are not currently supported");
+        }
+
+        if (c_heat_sink_pointer == nullptr)
+        {
+            throw exec_error("fresnel_physical_iph", "Heat sink pointer not assigned");
         }
 
         // Electricity pricing schedule

--- a/ssc/cmod_fresnel_physical_iph.cpp
+++ b/ssc/cmod_fresnel_physical_iph.cpp
@@ -153,7 +153,17 @@ static var_info _cm_vtab_fresnel_physical_iph[] = {
 
     // Heat Sink
 
-    {SSC_INPUT,     SSC_NUMBER,         "pb_pump_coef",                "Pumping power to move 1kg of HTF through PB loop",                                      "kW/kg",               "",                              "Heat Sink",           "*",                "",                 ""},
+    { SSC_INPUT,    SSC_NUMBER,         "pb_pump_coef",                "Pumping power to move 1kg of HTF through PB loop",                                      "kW/kg",               "",                             "Heat Sink",            "*",                "",                 "" },
+
+    { SSC_INPUT,    SSC_NUMBER,         "hs_type",                     "0: ideal model, 1: physical steam model",                                               "",                    "",                             "Heat Sink",            "?=0",              "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_N_sub",               "Number physical heat sink HX nodes",                                                    "",                    "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_tol",                 "Physical heat sink solve tolerance",                                                    "",                    "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_f_mdot_steam_min",    "Min steam mdot fraction for physical heat sink",                                        "",                    "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_f_mdot_steam_max",    "Max steam mdot fraction for physical heat sink",                                        "",                    "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_T_steam_cold_des",    "Steam inlet temperature for physical heat sink",                                        "C",                   "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_P_steam_hot_des",     "Steam outlet (and inlet) pressure for physical heat sink",                              "bar",                 "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "hs_phys_Q_steam_hot_des",     "Steam outlet quality for physical heat sink",                                           "",                    "",                             "Heat Sink",            "hs_type=1",        "",                 "" },
+
 
     // TES   
 
@@ -911,7 +921,12 @@ public:
         }
 
         // Heat Sink
+        int hs_type = as_integer("hs_type");
+        C_csp_power_cycle* c_heat_sink_pointer;
         C_pc_heat_sink c_heat_sink;
+        
+        // Ideal heat sink
+        if (hs_type == 0)
         {
             //size_t n_f_turbine1 = 0;
             //ssc_number_t* p_f_turbine1 = as_array("f_turb_tou_periods", &n_f_turbine1);   // heat sink, not turbine
@@ -940,6 +955,12 @@ public:
             c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_M_DOT_HTF, allocate("m_dot_htf_heat_sink", n_steps_fixed), n_steps_fixed);
             c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_T_HTF_IN, allocate("T_heat_sink_in", n_steps_fixed), n_steps_fixed);
             c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_T_HTF_OUT, allocate("T_heat_sink_out", n_steps_fixed), n_steps_fixed);
+
+            c_heat_sink_pointer = &c_heat_sink;
+        }
+        else
+        {
+            throw exec_error("fresnel_physical_iph", "hs_type != 0; other heat sink models are not currently supported");
         }
 
         // Electricity pricing schedule
@@ -1087,7 +1108,7 @@ public:
         // Instantiate Solver
         C_csp_solver csp_solver(weather_reader,
             c_fresnel,
-            c_heat_sink,
+            *c_heat_sink_pointer,
             storage,
             tou,
             dispatch,

--- a/ssc/cmod_mspt_iph.cpp
+++ b/ssc/cmod_mspt_iph.cpp
@@ -1219,7 +1219,7 @@ public:
         // ***********************************************
 
         int hs_type = as_integer("hs_type");
-        C_csp_power_cycle* c_heat_sink_pointer;
+        C_csp_power_cycle* c_heat_sink_pointer = nullptr;
         C_pc_heat_sink c_heat_sink;
 
         size_t n_f_turbine1 = 0;
@@ -1256,7 +1256,10 @@ public:
         {
             throw exec_error("mspt_iph", "hs_type != 0; other heat sink models are not currently supported");
         }
-        
+        if (c_heat_sink_pointer == nullptr)
+        {
+            throw exec_error("mspt_iph", "Heat sink pointer not assigned");
+        }
 
         //// *********************************************************
         //// *********************************************************

--- a/ssc/cmod_mspt_iph.cpp
+++ b/ssc/cmod_mspt_iph.cpp
@@ -224,6 +224,16 @@ static var_info _cm_vtab_mspt_iph[] = {
 // Heat Sink
 { SSC_INPUT,     SSC_NUMBER, "pb_pump_coef",                       "Pumping power to move 1kg of HTF through PB loop",                                                                                        "kW/kg",        "",                                  "Heat Sink",                                "*",                                                                "",              "" },
 
+{ SSC_INPUT,     SSC_NUMBER, "hs_type",                            "0: ideal model, 1: physical steam model",                                                                                                 "",             "",                                  "Heat Sink",                                "?=0",                                                              "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_N_sub",                      "Number physical heat sink HX nodes",                                                                                                      "",             "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_tol",                        "Physical heat sink solve tolerance",                                                                                                      "",             "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_f_mdot_steam_min",           "Min steam mdot fraction for physical heat sink",                                                                                          "",             "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_f_mdot_steam_max",           "Max steam mdot fraction for physical heat sink",                                                                                          "",             "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_T_steam_cold_des",           "Steam inlet temperature for physical heat sink",                                                                                          "C",            "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_P_steam_hot_des",            "Steam outlet (and inlet) pressure for physical heat sink",                                                                                "bar",          "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+{ SSC_INPUT,     SSC_NUMBER, "hs_phys_Q_steam_hot_des",            "Steam outlet quality for physical heat sink",                                                                                             "",             "",                                  "Heat Sink",                                "hs_type=1",                                                        "",              "" },
+
+
 // Aux and Balance of Plant
 { SSC_INPUT,     SSC_NUMBER, "pb_fixed_par",                       "Fixed parasitic load - runs at all times",                                                                                                "MWe/MWcap",    "",                                  "System Control",                           "*",                                                                "",              "" },
 { SSC_INPUT,     SSC_NUMBER, "aux_par",                            "Aux heater, boiler parasitic",                                                                                                            "MWe/MWcap",    "",                                  "System Control",                           "*",                                                                "",              "" },
@@ -1208,6 +1218,10 @@ public:
         // ***********************************************
         // ***********************************************
 
+        int hs_type = as_integer("hs_type");
+        C_csp_power_cycle* c_heat_sink_pointer;
+        C_pc_heat_sink c_heat_sink;
+
         size_t n_f_turbine1 = 0;
         ssc_number_t* p_f_turbine1 = as_array("f_turb_tou_periods", &n_f_turbine1);   // heat sink, not turbine
         double f_turbine_max1 = 1.0;
@@ -1215,24 +1229,34 @@ public:
             f_turbine_max1 = max(f_turbine_max1, p_f_turbine1[i]);
         }
 
-        C_pc_heat_sink c_heat_sink;
-        c_heat_sink.ms_params.m_T_htf_hot_des = T_htf_hot_des;		//[C] FIELD design outlet temperature
-        c_heat_sink.ms_params.m_T_htf_cold_des = T_htf_cold_des;	//[C] FIELD design inlet temperature
-        c_heat_sink.ms_params.m_q_dot_des = q_dot_pc_des;			//[MWt] HEAT SINK design thermal power (could have field solar multiple...)
-        // 9.18.2016 twn: assume for now there's no pressure drop though heat sink
-        c_heat_sink.ms_params.m_htf_pump_coef = as_double("pb_pump_coef");		//[kWe/kg/s]
-        c_heat_sink.ms_params.m_max_frac = f_turbine_max1;
+            // Ideal heat sink
+        if (hs_type == 0)
+        {
+            c_heat_sink.ms_params.m_T_htf_hot_des = T_htf_hot_des;		//[C] FIELD design outlet temperature
+            c_heat_sink.ms_params.m_T_htf_cold_des = T_htf_cold_des;	//[C] FIELD design inlet temperature
+            c_heat_sink.ms_params.m_q_dot_des = q_dot_pc_des;			//[MWt] HEAT SINK design thermal power (could have field solar multiple...)
+            // 9.18.2016 twn: assume for now there's no pressure drop though heat sink
+            c_heat_sink.ms_params.m_htf_pump_coef = as_double("pb_pump_coef");		//[kWe/kg/s]
+            c_heat_sink.ms_params.m_max_frac = f_turbine_max1;
 
-        c_heat_sink.ms_params.m_pc_fl = as_integer("rec_htf");
-        c_heat_sink.ms_params.m_pc_fl_props = as_matrix("field_fl_props");
+            c_heat_sink.ms_params.m_pc_fl = as_integer("rec_htf");
+            c_heat_sink.ms_params.m_pc_fl_props = as_matrix("field_fl_props");
 
 
-        // Allocate heat sink outputs
-        c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_Q_DOT_HEAT_SINK, allocate("q_dot_to_heat_sink", n_steps_fixed), n_steps_fixed);
-        c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_W_DOT_PUMPING, allocate("W_dot_pc_pump", n_steps_fixed), n_steps_fixed);
-        c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_M_DOT_HTF, allocate("m_dot_htf_heat_sink", n_steps_fixed), n_steps_fixed);
-        c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_T_HTF_IN, allocate("T_heat_sink_in", n_steps_fixed), n_steps_fixed);
-        c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_T_HTF_OUT, allocate("T_heat_sink_out", n_steps_fixed), n_steps_fixed);
+            // Allocate heat sink outputs
+            c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_Q_DOT_HEAT_SINK, allocate("q_dot_to_heat_sink", n_steps_fixed), n_steps_fixed);
+            c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_W_DOT_PUMPING, allocate("W_dot_pc_pump", n_steps_fixed), n_steps_fixed);
+            c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_M_DOT_HTF, allocate("m_dot_htf_heat_sink", n_steps_fixed), n_steps_fixed);
+            c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_T_HTF_IN, allocate("T_heat_sink_in", n_steps_fixed), n_steps_fixed);
+            c_heat_sink.mc_reported_outputs.assign(C_pc_heat_sink::E_T_HTF_OUT, allocate("T_heat_sink_out", n_steps_fixed), n_steps_fixed);
+
+            c_heat_sink_pointer = &c_heat_sink;
+        }
+        else
+        {
+            throw exec_error("mspt_iph", "hs_type != 0; other heat sink models are not currently supported");
+        }
+        
 
         //// *********************************************************
         //// *********************************************************
@@ -1741,7 +1765,7 @@ public:
         // Instantiate Solver       
         C_csp_solver csp_solver(weather_reader,
             collector_receiver,
-            c_heat_sink,
+            *c_heat_sink_pointer,
             storage,
             tou,
             dispatch,

--- a/ssc/cmod_trough_physical_iph.cpp
+++ b/ssc/cmod_trough_physical_iph.cpp
@@ -1502,7 +1502,7 @@ public:
 
         // Heat Sink
         int hs_type = as_integer("hs_type");
-        C_csp_power_cycle* c_heat_sink_pointer;
+        C_csp_power_cycle* c_heat_sink_pointer = nullptr;
         C_pc_heat_sink c_heat_sink;
 
             // Ideal heat sink
@@ -1542,6 +1542,11 @@ public:
         else
         {
             throw exec_error("trough_physical_iph", "hs_type != 0; other heat sink models are not currently supported");
+        }
+
+        if (c_heat_sink_pointer == nullptr)
+        {
+            throw exec_error("trough_physical_iph", "Heat sink pointer not assigned");
         }
 
         // Electricity pricing schedule


### PR DESCRIPTION
Added placeholder variables to tower, trough, and mslf IPH cmods for use by future physical heat sink model. 