### PR TITLE
Create functions for battery parameters that were accessed in the code.

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -758,6 +758,12 @@ double battery_t::V_nominal() { return voltage->battery_voltage_nominal(); }
 
 double battery_t::SOC() { return capacity->SOC(); }
 
+double battery_t::SOC_max() { return capacity->SOC_max(); }
+
+double battery_t::SOC_min() { return capacity->SOC_min(); }
+
+double battery_t::nominal_energy() { return params->nominal_energy; }
+
 double battery_t::I() { return capacity->I(); }
 
 double battery_t::calculate_loss(double power, size_t lifetimeIndex) {

--- a/shared/lib_battery.h
+++ b/shared/lib_battery.h
@@ -405,6 +405,12 @@ public:
 
     double SOC();
 
+    double SOC_max();
+
+    double SOC_min();
+
+    double nominal_energy();
+
     double V(); // the actual battery voltage
 
     double V_nominal(); // the nominal battery voltage

--- a/shared/lib_battery_dispatch_automatic_btm.cpp
+++ b/shared/lib_battery_dispatch_automatic_btm.cpp
@@ -906,7 +906,7 @@ void dispatch_automatic_behind_the_meter_t::costToCycle()
     {
         if (curr_year < m_battReplacementCostPerKWH.size()) {
             double capacityPercentDamagePerCycle = _Battery->estimateCycleDamage();
-            m_cycleCost = 0.01 * capacityPercentDamagePerCycle * m_battReplacementCostPerKWH[curr_year] * _Battery->get_params().nominal_energy;
+            m_cycleCost = 0.01 * capacityPercentDamagePerCycle * m_battReplacementCostPerKWH[curr_year] * _Battery->nominal_energy();
         }
         else {
             // Should only apply to BattWatts. BattWatts doesn't have retal rate dispatch, so this is fine.
@@ -915,13 +915,13 @@ void dispatch_automatic_behind_the_meter_t::costToCycle()
     }
     else if (m_battCycleCostChoice == dispatch_t::INPUT_CYCLE_COST)
     {
-        m_cycleCost = cycle_costs_by_year[curr_year] * _Battery->get_params().nominal_energy;
+        m_cycleCost = cycle_costs_by_year[curr_year] * _Battery->nominal_energy();
     }
 }
 
 double dispatch_automatic_behind_the_meter_t::cost_to_cycle_per_kwh()
 {
-    return m_cycleCost / _Battery->get_params().nominal_energy;
+    return m_cycleCost / _Battery->nominal_energy();
 }
 
 double dispatch_automatic_behind_the_meter_t::omCost()

--- a/shared/lib_battery_dispatch_pvsmoothing_fom.cpp
+++ b/shared/lib_battery_dispatch_pvsmoothing_fom.cpp
@@ -250,8 +250,8 @@ void dispatch_pvsmoothing_front_of_meter_t::update_dispatch(size_t year, size_t 
             ssc_number_t battery_energy = _Battery->energy_nominal();
             ssc_number_t batt_half_round_trip_eff = sqrt(m_etaDischarge * m_etaPVCharge);
             ssc_number_t battery_power = m_batteryPower->getMaxACChargePower();
-            ssc_number_t soc_min = _Battery->get_params().capacity->minimum_SOC * 0.01;
-            ssc_number_t soc_max = _Battery->get_params().capacity->maximum_SOC * 0.01;
+            ssc_number_t soc_min = _Battery->SOC_min() * 0.01;
+            ssc_number_t soc_max = _Battery->SOC_max() * 0.01;
             // scale by nameplate per ERPI code
             battery_energy = m_batt_dispatch_pvs_nameplate_ac > 0 ? battery_energy / m_batt_dispatch_pvs_nameplate_ac : battery_energy;
             battery_power = m_batt_dispatch_pvs_nameplate_ac > 0 ? battery_power / m_batt_dispatch_pvs_nameplate_ac : battery_power;


### PR DESCRIPTION
This prevents copying the entire params object multiple times each step. Improves battery runtimes, especially for PV smoothing.

Happy to add const pointer changes to this PR as well if we want to do that too.