### PR TITLE
Ssc 1259 scale w pv ac

### DIFF
--- a/ssc/cmod_fresnel_physical.cpp
+++ b/ssc/cmod_fresnel_physical.cpp
@@ -92,8 +92,6 @@ static var_info _cm_vtab_fresnel_physical[] = {
     { SSC_INPUT,    SSC_NUMBER,         "SCA_drives_elec",             "Tracking power in Watts per SCA drive",                                                 "W/module",            "",                             "Solar_Field",          "*",                "",                 "" },
     { SSC_INPUT,    SSC_NUMBER,         "land_mult",                   "Non-solar field land area multiplier",                                                  "-",                   "",                             "Solar_Field",          "*",                "",                 "" },
     { SSC_INPUT,    SSC_NUMBER,         "T_startup",                   "Power block startup temperature",                                                       "C",                   "",                             "Solar_Field",          "*",                "",                 "" },
-    { SSC_INPUT,    SSC_NUMBER,         "rec_su_delay",                "Fixed startup delay time for the receiver",                                             "hr",                  "",                             "Solar_Field",          "*",                "",                 "" },
-    { SSC_INPUT,    SSC_NUMBER,         "rec_qf_delay",                "Energy-based receiver startup delay (fraction of rated thermal power)",                 "-",                   "",                             "Solar_Field",          "*",                "",                 "" },
     { SSC_INPUT,    SSC_NUMBER,         "p_start",                     "Collector startup energy, per SCA",                                                     "kWhe",                "",                             "Solar_Field",          "*",                "",                 "" },
     { SSC_INPUT,    SSC_NUMBER,         "L_rnr_pb",                    "Length of runner pipe in power block",                                                  "m",                   "",                             "Solar_Field",          "*",                "",                 "" },
 
@@ -234,7 +232,8 @@ static var_info _cm_vtab_fresnel_physical[] = {
     { SSC_INPUT,    SSC_NUMBER,         "q_rec_standby",               "Receiver standby energy consumption",                                                   "kWt",                 "",                             "tou",                  "?=9e99",                  "",          "SIMULATION_PARAMETER" },
     { SSC_INPUT,    SSC_NUMBER,         "q_rec_heattrace",             "Receiver heat trace energy consumption during startup",                                 "kWhe",                "",                             "tou",                  "?=0.0",                   "",          "SIMULATION_PARAMETER" },
 
-
+    { SSC_INPUT,    SSC_NUMBER,         "rec_su_delay",                "Fixed startup delay time for the receiver",                                             "hr",                  "",                             "Sys_Control",          "*",                "",                 "" },
+    { SSC_INPUT,    SSC_NUMBER,         "rec_qf_delay",                "Energy-based receiver startup delay (fraction of rated thermal power)",                 "-",                   "",                             "Sys_Control",          "*",                "",                 "" },
 
     // Financials
     {SSC_INPUT,    SSC_NUMBER,          "csp_financial_model",         "",                                                                                      "1-8",                 "",                             "Financial Model",      "?=1",              "INTEGER,MIN=0",    ""},

--- a/ssc/cmod_hybrid.cpp
+++ b/ssc/cmod_hybrid.cpp
@@ -155,10 +155,6 @@ public:
 
                 ssc_module_exec_with_error(module, input, compute_module);
 
-                ssc_number_t system_capacity = compute_module_inputs->table.lookup("system_capacity")->num;
-                hybridSystemCapacity += system_capacity;
-                hybridTotalInstalledCost += compute_module_inputs->table.lookup("total_installed_cost")->num;
-
                 ssc_data_t compute_module_outputs = ssc_data_create();
 
                 int pidx = 0;
@@ -173,6 +169,13 @@ public:
                 bool system_use_lifetime_output = false;
                 if (compute_module_inputs->table.lookup("system_use_lifetime_output"))
                     system_use_lifetime_output = compute_module_inputs->table.lookup("system_use_lifetime_output")->num;
+
+                ssc_number_t system_capacity = compute_module_inputs->table.lookup("system_capacity")->num;
+                if ((compute_module == "pvsamv1") || (compute_module == "pvwattsv8")) {
+                    ssc_data_get_number(compute_module_outputs, "system_capacity_ac", &system_capacity);
+                }
+                hybridSystemCapacity += system_capacity;
+                hybridTotalInstalledCost += compute_module_inputs->table.lookup("total_installed_cost")->num;
 
                 // get minimum timestep from gen vector
                 ssc_number_t* curGen = ssc_data_get_array(compute_module_outputs, "gen", &len);

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1031,6 +1031,8 @@ static var_info _cm_vtab_pvsamv1[] = {
                 //miscellaneous outputs
                 { SSC_OUTPUT,        SSC_NUMBER,     "ts_shift_hours",                            "Sun position time offset",   "hours",  "",  "Miscellaneous", "",                       "",                          "" },
                 { SSC_OUTPUT,        SSC_NUMBER,     "nameplate_dc_rating",                        "System nameplate DC rating", "kW",     "",  "Miscellaneous",       "*",                    "",                              "" },
+                { SSC_OUTPUT,       SSC_NUMBER,      "system_capacity_ac",             "System nameplate AC rating", "kWac",     "",                                             "Miscellaneous", "",                        "",                          "" },
+
 
 
                 // test outputs
@@ -3594,6 +3596,7 @@ void cm_pvsamv1::exec()
             kWhACperkWAC = annual_energy / nameplate_ac_kW;
         }
         assign("capacity_factor_ac", var_data((ssc_number_t)(kWhACperkWAC / 87.6)));
+        assign("system_capacity_ac", var_data((ssc_number_t)nameplate_ac_kW));
 
         if (is_assigned("load"))
         {

--- a/ssc/cmod_pvwattsv8.cpp
+++ b/ssc/cmod_pvwattsv8.cpp
@@ -229,6 +229,7 @@ static var_info _cm_vtab_pvwattsv8[] = {
 
         { SSC_OUTPUT,       SSC_NUMBER,      "ts_shift_hours",                 "Time offset for interpreting time series outputs", "hours","",                                             "Miscellaneous", "*",                       "",                          "" },
         { SSC_OUTPUT,       SSC_NUMBER,      "percent_complete",               "Estimated percent of total completed simulation", "%",     "",                                             "Miscellaneous", "",                        "",                          "" },
+        { SSC_OUTPUT,       SSC_NUMBER,      "system_capacity_ac",             "System nameplate AC rating", "kWac",     "",                                             "Miscellaneous", "",                        "",                          "" },
 
         var_info_invalid };
 
@@ -1442,6 +1443,7 @@ public:
 
         // for battery model, specify a number of inverters
         assign("inverter_efficiency", var_data((ssc_number_t)(as_double("inv_eff"))));
+        assign("system_capacity_ac", var_data((ssc_number_t)pv.ac_nameplate / 1000.0));
 
         if (en_snowloss && snowmodel.badValues > 0)
             log(util::format("The snow model has detected %d bad snow depth values (less than 0 or greater than 610 cm). These values have been set to zero.", snowmodel.badValues), SSC_WARNING);

--- a/ssc/cmod_trough_physical.cpp
+++ b/ssc/cmod_trough_physical.cpp
@@ -166,8 +166,6 @@ static var_info _cm_vtab_trough_physical[] = {
     { SSC_INPUT,        SSC_MATRIX,      "Shadowing",                 "Receiver bellows shadowing loss factor",                                           "none",         "",               "solar_field",    "*",                       "",                      "" },
     { SSC_INPUT,        SSC_MATRIX,      "Dirt_HCE",                  "Loss due to dirt on the receiver envelope",                                        "none",         "",               "solar_field",    "*",                       "",                      "" },
     { SSC_INPUT,        SSC_MATRIX,      "Design_loss",               "Receiver heat loss at design",                                                     "W/m",          "",               "solar_field",    "*",                       "",                      "" },
-    { SSC_INPUT,        SSC_NUMBER,      "rec_su_delay",              "Fixed startup delay time for the receiver",                                        "hr",           "",               "solar_field",    "*",                       "",                      "" },
-    { SSC_INPUT,        SSC_NUMBER,      "rec_qf_delay",              "Energy-based receiver startup delay (fraction of rated thermal power)",            "-",            "",               "solar_field",    "*",                       "",                      "" },
     { SSC_INPUT,        SSC_NUMBER,      "p_start",                   "Collector startup energy, per SCA",                                                "kWhe",         "",               "solar_field",    "*",                       "",                      "" },
 
     // Power Cycle
@@ -297,6 +295,10 @@ static var_info _cm_vtab_trough_physical[] = {
     { SSC_INPUT,        SSC_NUMBER,      "q_rec_standby",             "Receiver standby energy consumption",                                              "kWt",          "",               "tou",            "?=9e99",                  "",                      "SIMULATION_PARAMETER" },
     { SSC_INPUT,        SSC_NUMBER,      "q_rec_heattrace",           "Receiver heat trace energy consumption during startup",                            "kWhe",         "",               "tou",            "?=0.0",                   "",                      "SIMULATION_PARAMETER" },
     { SSC_INPUT,        SSC_ARRAY,       "f_turb_tou_periods",        "Dispatch logic for turbine load fraction",                                         "-",            "",               "tou",            "*",                       "",                      "" },
+
+    { SSC_INPUT,        SSC_NUMBER,      "rec_su_delay",              "Fixed startup delay time for the receiver",                                        "hr",           "",               "System Control", "*",                       "",                      "" },
+    { SSC_INPUT,        SSC_NUMBER,      "rec_qf_delay",              "Energy-based receiver startup delay (fraction of rated thermal power)",            "-",            "",               "System Control", "*",                       "",                      "" },
+
 
     { SSC_INPUT,        SSC_NUMBER,      "csp_financial_model",       "",                                                                                 "1-8",          "",               "Financial Model",        "?=1",                                                      "INTEGER,MIN=0",  "" },
     { SSC_INPUT,        SSC_NUMBER,      "ppa_multiplier_model",      "PPA multiplier model 0: dispatch factors dispatch_factorX, 1: hourly multipliers dispatch_factors_ts", "0/1", "0=diurnal,1=timestep", "tou",   "?=0",  /*need a default so this var works in required_if*/ "INTEGER,MIN=0",  "SIMULATION_PARAMETER" },

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1326,7 +1326,7 @@ var_info vtab_hybrid_fin_om[] = {
     /*   VARTYPE           DATATYPE         NAME                           LABEL                UNITS     META                      GROUP           REQUIRED_IF      CONSTRAINTS     UI_HINTS*/
     { SSC_INPUT,          SSC_NUMBER,     "is_hybrid",              "hybrid configuration",      "0/1", "0=singletech,1=hybrid",    "HybridFin",       "?=0",      "",             "" },
     { SSC_INPUT,          SSC_ARRAY,      "cf_hybrid_om_sum",       "Hybrid O&M costs",          "$",   "",                         "HybridFin",       "",         "",             "" },
-    { SSC_INOUT,          SSC_ARRAY,      "monthly_energy",         "Monthly AC energy in Year 1",            "kWh", "",                         "Monthly",         "",         "LENGTH = 12",  "" },
+    { SSC_INPUT,          SSC_ARRAY,      "monthly_energy",         "Monthly AC energy in Year 1",            "kWh", "",                         "Monthly",         "",         "LENGTH = 12",  "" },
 
 var_info_invalid };
 

--- a/test/ssc_test/cmod_hybrid_test.cpp
+++ b/test/ssc_test/cmod_hybrid_test.cpp
@@ -100,10 +100,10 @@ TEST_F(CmodHybridTest, PVWattsv8WindBatterySingleOwner) {
         auto om_expenses = ssc_data_get_array(hybrid_outputs, "cf_operating_expenses", &len);
         ssc_data_get_number(hybrid_outputs, "project_return_aftertax_npv", &npv);
 
-        EXPECT_NEAR(om_expenses[1], 10772001, 1);
+        EXPECT_NEAR(om_expenses[1], 10425847, 1);
         EXPECT_NEAR(revenue[1], 33062516, 1);
-        EXPECT_NEAR(ebitda[1], 22290515, 1);
-        EXPECT_NEAR(npv, -233836157, 246312045 * 0.001);
+        EXPECT_NEAR(ebitda[1], 22636669, 1);
+        EXPECT_NEAR(npv, -227222606, 227222606 * 0.001);
 
         EXPECT_NEAR(total_energy, battannualenergy, total_energy * 0.001);
         EXPECT_NEAR(total_energy, pvannualenergy + windannualenergy - battchargeenergy[1] + battdischargeenergy[1], total_energy * 0.001);
@@ -167,7 +167,7 @@ TEST_F(CmodHybridTest, PVWattsv8WindBatteryHostDeveloper) {
 
         auto hybrid_outputs = ssc_data_get_table(outputs, "Hybrid");
         ssc_data_get_number(hybrid_outputs, "project_return_aftertax_npv", &npv);
-        EXPECT_NEAR(npv, -191914, 191914 * 0.001);
+        EXPECT_NEAR(npv, -168769, 168769 * 0.001);
 
         ssc_data_get_number(hybrid_outputs, "annual_energy", &total_energy);
 
@@ -251,10 +251,10 @@ TEST_F(CmodHybridTest, CustomGenerationPVWattsWindFuelCellBatteryHybrid_SingleOw
         EXPECT_NEAR(total_energy, battannualenergy, total_energy * 0.001);
         EXPECT_NEAR(total_energy, pvannualenergy + windannualenergy + genericannualenergy + fuelcellannualenergy - battchargeenergy[1] + battdischargeenergy[1], total_energy * 0.001);
         
-        EXPECT_NEAR(om_expenses[1], 90570832., 1e5);
+        EXPECT_NEAR(om_expenses[1], 90224679., 1e5);
         EXPECT_NEAR(revenue[1], 66590988., 1e5);
-        EXPECT_NEAR(ebitda[1], -23979844., 1e5);
-        EXPECT_NEAR(npv, -1756154696., 1e6);
+        EXPECT_NEAR(ebitda[1], -23633690., 1e5);
+        EXPECT_NEAR(npv, -1750593259., 1e6);
     }
     ssc_data_free(dat);
     dat = nullptr;


### PR DESCRIPTION
Add system_capacity_ac outputs to PVSAMV1 and PVWattsV8 to have consistent variables to work with in the hybrids module

Use ac nameplate capacity in the hybrids module for consistency with other models.

Fixes #1259 

Can merge into other hybrids branch, or can merge into develop after that one goes first.