### PR TITLE
Incorperate inverter losses into grid limits code

### DIFF
--- a/shared/lib_battery_powerflow.cpp
+++ b/shared/lib_battery_powerflow.cpp
@@ -581,7 +581,7 @@ void BatteryPowerFlow::calculateACConnected()
         P_grid_ac = P_gen_ac - P_load_ac;
 
         if (P_grid_ac > P_grid_limit_ac) {
-            double grid_diff = P_grid_ac - P_grid_limit_ac;
+            double grid_diff = P_grid_ac - P_grid_limit_ac - P_inverter_draw_ac;
             // Update grid variables first
             P_grid_ac -= grid_diff;
             P_interconnection_loss_ac += grid_diff;
@@ -1035,6 +1035,9 @@ void BatteryPowerFlow::calculateDCConnected()
         P_crit_load_unmet_ac = 0;
     if (std::abs(P_interconnection_loss_ac) < m_BatteryPower->tolerance) {
         P_interconnection_loss_ac = 0;
+    }
+    if (std::abs(P_batt_to_grid_ac) < m_BatteryPower->tolerance) {
+        P_batt_to_grid_ac = 0;
     }
 
 	// assign outputs


### PR DESCRIPTION
The previous grid limits code did not properly account for inverter night time losses, this code corrects that issue.

Note that there are still some issues with power to grid below 10% battery SOC. Those might be better solved as a part of https://github.com/NREL/ssc/issues/1202

Fixes https://github.com/NREL/SAM/issues/1982