### PR TITLE
Avoid giving free energy at the end of a grid outage

### DIFF
--- a/shared/lib_battery_capacity.cpp
+++ b/shared/lib_battery_capacity.cpp
@@ -162,8 +162,11 @@ void capacity_t::check_SOC() {
 
             // do not switch to discharging
             state->cell_current = fmin(0, state->cell_current);
+
+            // Correct state given current change
+            state->q0 = q_upper;
         }
-        state->q0 = q_upper;
+        
     }
     else if (state->q0 < q_lower - tolerance) {
         // if undercharged then reduce discharhing
@@ -172,6 +175,8 @@ void capacity_t::check_SOC() {
 
             // do not switch to charging
             state->cell_current = fmax(0, state->cell_current);
+
+            // Correct state given current change
             state->q0 = q_lower;
         }
     }

--- a/shared/lib_battery_capacity.cpp
+++ b/shared/lib_battery_capacity.cpp
@@ -172,8 +172,8 @@ void capacity_t::check_SOC() {
 
             // do not switch to charging
             state->cell_current = fmax(0, state->cell_current);
+            state->q0 = q_lower;
         }
-        state->q0 = q_lower;
     }
 }
 

--- a/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
@@ -1217,9 +1217,9 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutagePeakShavingEmp
     dispatchAutoBTM->dispatch(0, h-1, 0);
     h++;
 
-    EXPECT_NEAR(batteryPower->powerBatteryDC, 2.68, 0.5) << " error in expected at hour " << h;
+    EXPECT_NEAR(batteryPower->powerBatteryDC, 2.08, 0.5) << " error in expected at hour " << h;
 
-    EXPECT_NEAR(batteryModel->SOC(), 95, 0.01);
+    EXPECT_NEAR(batteryModel->SOC(), 96.31, 0.01);
 
     // Battery cannot charge above max SOC
     batteryPower->powerLoad = 700;
@@ -1454,14 +1454,14 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageCustomEmptyAnd
     EXPECT_EQ(h, 17);
 
     // Show that the battery can discharge above max SOC after outage
-    batteryPower->powerLoad = 5;
+    batteryPower->powerLoad = 8;
     batteryPower->powerSystem = 0;
     batteryPower->isOutageStep = false;
-    batteryPower->powerCritLoad = 5;
+    batteryPower->powerCritLoad = 8;
     dispatchAutoBTM->dispatch(0, h, 0);
     h++;
 
-    EXPECT_NEAR(batteryPower->powerBatteryDC, 5.25, 0.5) << " error in expected at hour " << h;
+    EXPECT_NEAR(batteryPower->powerBatteryDC, 9.45, 0.5) << " error in expected at hour " << h;
 
     EXPECT_NEAR(batteryModel->SOC(), 95.01, 0.01);
 

--- a/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_automatic_btm_test.cpp
@@ -867,7 +867,7 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutagePeakShavingDai
     // Battery will discharge as much as possible for the outage, charge when PV is available, then discharge when load increases at 7 pm
     std::vector<double> expectedPower = { 52.1, 52.1, 52.1, 52.1, 39.4, 3.7, // 0 - 5
                                            0, -48, -48, -48, -48, -48, // Able to charge when SOC at 0, 6- 11
-                                        -48, -48, -48, -48.0, -11, 0, // 12 - 17
+                                        -48, -48, -48, -48.0, -48, -38.57, // 12 - 17
                                         0, 52.1, 52.1, 52.1, 52.1, 52.1, // 18 - 23
                                         52.1, 52.1, 52.1, 52.1 };
 
@@ -938,7 +938,7 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageWithAvailabili
     std::vector<double> expectedPower = { 52.1, 52.1, 52.1, 52.1, 39.4, 3.7,
                                             0, 0, 0, 0, 0, 0,
                                         0, -48, -48, -48.0, -48.0, -48.0,
-                                        0, 52.1, 52.1, 52.28, 52.48, 27.6 };
+                                        0, 52.22, 52.34, 52.28, 4.47, 0 };
 
     std::vector<double> expectedCritLoadUnmet = { 0, 0, 0, 0, 12.19, 46.46,
                                                 50, 50, 50, 50, 50, 50, // Losses below prevent any crit load from being met in hrs 6 - 12 while battery is discharged
@@ -1085,7 +1085,7 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageWithInverterLo
     // Battery will discharge as much as possible for the outage, charge when PV is available, then discharge when load increases at 7 pm
     std::vector<double> expectedPower = { 52.1, 52.1, 52.1, 52.1, 39.4, 3.7,
                                             0, -48, -48, -48, -48, -48,
-                                        -48, -48, -48, -48.0, -11, 0,
+                                        -48, -48, -48, -48.0, -48, -38.57,
                                         0, 52.16, 52.16, 52.16, 52.16, 52.16, 52.16, };
 
     std::vector<double> expectedCritLoadUnmet = { 50, 50, 50, 50, 50, 50, // Losses below prevent any crit load from being met in first hours
@@ -1206,18 +1206,18 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutagePeakShavingEmp
         SOC = batteryModel->SOC();
     }
 
-    EXPECT_NEAR(batteryModel->SOC(), 100, 0.01);
-    EXPECT_EQ(h, 17);
+    EXPECT_NEAR(batteryModel->SOC(), 96.67, 0.01);
+    EXPECT_EQ(h, 18);
 
     // Show that the battery can discharge above max SOC after outage
-    batteryPower->powerLoad = 680;
+    batteryPower->powerLoad = 670;
     batteryPower->powerSystem = 0;
     batteryPower->isOutageStep = false;
     batteryPower->powerCritLoad = 14;
-    dispatchAutoBTM->dispatch(0, h, 0);
+    dispatchAutoBTM->dispatch(0, h-1, 0);
     h++;
 
-    EXPECT_NEAR(batteryPower->powerBatteryDC, 12.84, 0.5) << " error in expected at hour " << h;
+    EXPECT_NEAR(batteryPower->powerBatteryDC, 2.68, 0.5) << " error in expected at hour " << h;
 
     EXPECT_NEAR(batteryModel->SOC(), 95, 0.01);
 
@@ -1327,7 +1327,7 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageRetailRAteEmpt
         SOC = batteryModel->SOC();
     }
 
-    EXPECT_NEAR(batteryModel->SOC(), 100, 0.01);
+    EXPECT_NEAR(batteryModel->SOC(), 96.67, 0.01);
     EXPECT_EQ(h, 18);
 
     // Show that the battery can discharge above max SOC after outage
@@ -1338,9 +1338,9 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageRetailRAteEmpt
     dispatchAutoBTM->dispatch(0, h, 0);
     h++;
 
-    EXPECT_NEAR(batteryPower->powerBatteryDC, 14.6, 0.5) << " error in expected at hour " << h;
+    EXPECT_NEAR(batteryPower->powerBatteryDC, 9.80, 0.5) << " error in expected at hour " << h;
 
-    EXPECT_NEAR(batteryModel->SOC(), 95, 0.01);
+    EXPECT_NEAR(batteryModel->SOC(), 94.93, 0.01);
 
     // Battery cannot charge above max SOC
     batteryPower->powerLoad = 700;
@@ -1450,20 +1450,20 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageCustomEmptyAnd
         SOC = batteryModel->SOC();
     }
 
-    EXPECT_NEAR(batteryModel->SOC(), 100, 0.01);
+    EXPECT_NEAR(batteryModel->SOC(), 96.67, 0.01);
     EXPECT_EQ(h, 17);
 
     // Show that the battery can discharge above max SOC after outage
-    batteryPower->powerLoad = 700;
+    batteryPower->powerLoad = 5;
     batteryPower->powerSystem = 0;
     batteryPower->isOutageStep = false;
-    batteryPower->powerCritLoad = 50;
+    batteryPower->powerCritLoad = 5;
     dispatchAutoBTM->dispatch(0, h, 0);
     h++;
 
-    EXPECT_NEAR(batteryPower->powerBatteryDC, 14.8, 0.5) << " error in expected at hour " << h;
+    EXPECT_NEAR(batteryPower->powerBatteryDC, 5.25, 0.5) << " error in expected at hour " << h;
 
-    EXPECT_NEAR(batteryModel->SOC(), 95, 0.01);
+    EXPECT_NEAR(batteryModel->SOC(), 95.01, 0.01);
 
     // Battery cannot charge above max SOC
     batteryPower->powerLoad = 700;
@@ -1716,7 +1716,7 @@ TEST_F(AutoBTMTest_lib_battery_dispatch, DispatchAutoBTMGridOutageWithBatteryAva
     std::vector<double> expectedPower = { 0, 0, 0, 0, 0, 0,
                                             52.1, 52.1, 52.1, 52.1, 39.4, 3.7,
                                         0, -48, -48, -48.0, -48.0, -48.0,
-                                        0, 52.1, 52.1, 52.28, 52.48, 27.6 };
+                                        0, 52.22, 52.34, 52.28, 4.46, 0 };
 
     std::vector<double> expectedCritLoadUnmet = { 50, 50, 50, 50, 50, 50, // Losses below prevent any crit load from being met in hrs 0 - 5 while battery is unavailable
                                                 0, 0, 0, 0, 12.2, 46.5, // Battery meets losses until it runs out of SOC

--- a/test/shared_test/lib_battery_dispatch_manual_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_manual_test.cpp
@@ -680,7 +680,7 @@ TEST_F(ManualTest_lib_battery_dispatch, OutageWithManualDispatch) {
     batteryPower->powerLoad = 50;
     dispatchManual->dispatch(year, hour_of_year, step_of_hour);
     hour_of_year += 1;
-    EXPECT_NEAR(batteryPower->powerBatteryDC, -50.0, 0.1);
+    EXPECT_NEAR(batteryPower->powerBatteryDC, -47.7, 0.1);
 
     // Turn outage back on, should charge to 100%
     batteryPower->powerSystem = 700; batteryPower->voltageSystem = 600; batteryPower->powerLoad = 50;
@@ -691,7 +691,7 @@ TEST_F(ManualTest_lib_battery_dispatch, OutageWithManualDispatch) {
         soc = dispatchManual->battery_soc();
     }
     EXPECT_NEAR(100, dispatchManual->battery_soc(), 0.1);
-    EXPECT_NEAR(17, hour_of_year, 0.1);
+    EXPECT_NEAR(19, hour_of_year, 0.1);
 
     // With outage off, can discharge above max SOC
     batteryPower->powerSystem = 0; batteryPower->voltageSystem = 600; batteryPower->powerLoad = 14;
@@ -701,7 +701,7 @@ TEST_F(ManualTest_lib_battery_dispatch, OutageWithManualDispatch) {
     EXPECT_NEAR(batteryPower->powerBatteryDC, 14.6, 0.1);
 
     // With outage off, cannot charge above max soc
-    EXPECT_NEAR(95, dispatchManual->battery_soc(), 0.1);
+    EXPECT_NEAR(97.42, dispatchManual->battery_soc(), 0.1);
     batteryPower->powerSystem = 700; batteryPower->voltageSystem = 600; batteryPower->powerLoad = 14;
     batteryPower->powerCritLoad = 14; batteryPower->isOutageStep = false;
     dispatchManual->dispatch(year, hour_of_year, step_of_hour);

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -124,7 +124,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, ResidentialACBatteryModelIntegr
     ssc_number_t peakKwCharge[4] = { -2.91, -2.66, -2.25, -3.30 };
     ssc_number_t peakKwDischarge[4] = { 1.39, 1.73, 0.97, 1.96 };
     ssc_number_t peakCycles[4] = { 1, 1, 1, 3 };
-    ssc_number_t avgCycles[4] = { 1, 1, 0.4904, 1.0110 };
+    ssc_number_t avgCycles[4] = { 1, 1, 0.4822, 1.0110 };
 
     // Test peak shaving look ahead, peak shaving look behind, and automated grid power target, and self-consumption. Others require additional input data
     for (int i = 0; i < 4; i++) {

--- a/test/ssc_test/cmod_hybrid_test.cpp
+++ b/test/ssc_test/cmod_hybrid_test.cpp
@@ -101,8 +101,8 @@ TEST_F(CmodHybridTest, PVWattsv8WindBatterySingleOwner) {
         ssc_data_get_number(hybrid_outputs, "project_return_aftertax_npv", &npv);
 
         EXPECT_NEAR(om_expenses[1], 10425847, 1);
-        EXPECT_NEAR(revenue[1], 33062516, 1);
-        EXPECT_NEAR(ebitda[1], 22636669, 1);
+        EXPECT_NEAR(revenue[1], 33062517, 1);
+        EXPECT_NEAR(ebitda[1], 22636670, 1);
         EXPECT_NEAR(npv, -227222606, 227222606 * 0.001);
 
         EXPECT_NEAR(total_energy, battannualenergy, total_energy * 0.001);


### PR DESCRIPTION
The check_SOC() function in capacity_t was written before the grid outage code, and didn't expect the SOC limits to change dynamically during the simulation. Therefore at the end of the grid outage, the check_SOC() function granted the battery some free energy.

Changing the function means that the charge value is only adjusted when the current is adjusted, and the battery doesn't spontaneously gain energy without charging.

Test file here: [ssc_1270_test_case (2).zip](https://github.com/user-attachments/files/18828139/ssc_1270_test_case.2.zip)
Expectation is that the grid outage will end a few hours before the battery recharges above 10% (even though the minimum SOC is 30%.

Fixes #1270 