### PR TITLE
Fix wind adjustment factor double-counting

### DIFF
--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -692,7 +692,7 @@ void cm_windpower::exec()
 
 			farmp *= lossMultiplier;
 			// apply and track cutoff losses
-            withoutCutOffLosses += farmp * haf(hr) / (ssc_number_t)steps_per_hour;
+            withoutCutOffLosses += farmp * haf(i) / (ssc_number_t)steps_per_hour;
 
             if (lowTempCutoff){
 				if (temp < lowTempCutoffValue) farmp = 0.0;
@@ -710,7 +710,7 @@ void cm_windpower::exec()
                 }
 			}
 
-            farmpwr[i] = (ssc_number_t)farmp * haf(hr); //adjustment factors are constrained to be hourly, not sub-hourly, so it's correct for this to be indexed on the hour
+            farmpwr[i] = (ssc_number_t)farmp * haf(i);
             wspd[i] = (ssc_number_t)wind;
 			wdir[i] = (ssc_number_t)dir;
 			air_temp[i] = (ssc_number_t)temp;

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -483,7 +483,7 @@ void cm_windpower::exec()
 
         // set up adjustment factors for constant wake loss option
         if (!haf.setup())
-            throw exec_error("windpower", "failed to set up adjustment factors for constant loss wake model: " + haf.error());
+            throw exec_error("windpower", "failed to set up adjustment factors for wind resource probability table: " + haf.error());
 
         int nstep = 8760;
         ssc_number_t farm_kw = farmPower / (ssc_number_t)nstep;
@@ -574,7 +574,7 @@ void cm_windpower::exec()
 
     // set up adjustment factors for time series simulation
     if (!haf.setup(nstep))
-        throw exec_error("windpower", "failed to set up adjustment factors for simulation: " + haf.error());
+        throw exec_error("windpower", "failed to set up adjustment factors for time series wind resource data: " + haf.error());
 
 	// allocate output data
 	ssc_number_t *farmpwr = allocate("gen", nstep);

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -1430,7 +1430,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
                     m_factors[i] *= (1.0 - p[i] / 100.0); //convert from percentages to factors
             }
             else {
-                m_error = util::format("Hourly loss factor array length %d does not equal length of weather file %d", (int)n, nsteps);
+                m_error = util::format("Adjustment factor hourly loss array length (%d) does not equal length of weather file (%d) ", (int)n, (int)nsteps);
             }
         }
     }
@@ -1457,7 +1457,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
             }
             else if ((n % 8760 == 0 || n % 2920 == 0) && n != (size_t)(nsteps * analysis_period)) // give a helpful error for timestep mismatch
             {
-                m_error = util::format("Time series availability losses must have the same time step as the simulation time step unless losses are daily, weekly, monthly, annual, or single value.");
+                m_error = util::format("Adjustment factor number of time series loss time steps (%d) must be the same as the number of simulation time steps (%d) unless losses were defined as daily, weekly, monthly, annual, or single values.",(int)n,(int)nsteps*(int)analysis_period);
             }
             else if (n == (size_t)( 12 * analysis_period)) { //Monthly 
                 for (int a = 0; a < analysis_period; a++) {
@@ -1493,7 +1493,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
                 }
             }
             else {
-                m_error = util::format("Error in length of lifetime availability losses.");
+                m_error = util::format("Adjustment factor number of lifetime availability loss values (%d) must be time series, daily, weekly, monthly, annual or single value.", (int)n);
             }
         }
     }
@@ -1512,7 +1512,7 @@ bool adjustment_factors::setup(int nsteps, int analysis_period) //nsteps is set 
 
 				if ( start < 0 || start >= nsteps || end < start )
 				{
-					m_error = util::format( "period %d is invalid ( start: %d, end %d )", (int)r, start, end );
+					m_error = util::format( "Adjustment factor period %d is invalid ( start: %d, end %d )", (int)r, start, end );
 					continue;
 				}
 


### PR DESCRIPTION
Fix #1283

To test, run a default Wind / No Financial case with and without time series adjustment factors. The difference between the two runs should be the adjustment factor applied once, not twice as reported in #1283.

![image](https://github.com/user-attachments/assets/efbeae41-1b24-49cb-b2d3-b68d48a2c3e2)

The adjustment factors should work correctly for the following combinations:

* Hourly weather file with hourly losses
* Subhourly weather file with subhourly losses
* Weibull distribution with hourly losses
* Wind resource probability table with hourly losses
* Constant loss wake model option with hourly or subhourly simulations/losses

A simulation error should be generated with the wrong combination of wind data time step and loss time step.

The attached file has .sam file with cases set up for these tests and a 15-minute wind file:  
[windpower-adj-test.zip](https://github.com/user-attachments/files/18974762/windpower-adj-test.zip)

This PR also fixes time series adjustment losses (`haf`) indexed to `hr` instead of time step `i`: Subhourly loss supported as of https://github.com/NREL/SAM/pull/1164.  