### PR TITLE
Add Github Action to Export Test Times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,6 @@ jobs:
       shell: bash
       # Turn off fast fail for when the landbosse tests write to cerr
       run: |
-        cd ${SSCDIR}/build/test/Release
         ./Test.exe > ${SSCDIR}/build/test/gtest.log
         pip install pandas requests
         python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
@@ -270,7 +269,7 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-          name: SSC Windows Test Times CSV
+          name: SSC Windows Test Time Elapsed
           path: |
             ${{env.SSCDIR}}\build\ssc\test\gtest_elapsed_times.csv
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
       shell: bash
       # Turn off fast fail for when the landbosse tests write to cerr
       run: |
+        cd ${SSCDIR}/build/test/Release
         ./Test.exe > ${SSCDIR}/build/test/gtest.log
         pip install pandas requests
         python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
       shell: bash
       run: |
         set -e
-        ${SSCDIR}/build/test/Test
+        ${SSCDIR}/build/test/Test > ${SSCDIR}/build/test/gtest.log
+        pip install pandas
+        python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
     
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
@@ -84,6 +86,7 @@ jobs:
           path: |
             ${{env.SSCDIR}}/build/ssc/libssc.so
             ${{env.SSCDIR}}/build/ssc/ssc.so
+            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv
       
   build-on-mac:
     runs-on: ${{ matrix.os }}
@@ -151,7 +154,9 @@ jobs:
       # Turn off fast fail for when the landbosse tests write to cerr
       run: |
         set -e
-        ${SSCDIR}/build/test/Test
+        ${SSCDIR}/build/test/Test > ${SSCDIR}/build/test/gtest.log
+        pip install pandas
+        python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
       shell: bash      
     
     - name: Upload Artifacts
@@ -162,6 +167,7 @@ jobs:
           path: |
             ${{env.SSCDIR}}/build/ssc/libssc.dylib
             ${{env.SSCDIR}}/build/ssc/ssc.dylib 
+            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv 
 
     - name: Upload Artifacts
       if: ${{ matrix.os != 'macos-latest' }}
@@ -171,6 +177,7 @@ jobs:
           path: |
             ${{env.SSCDIR}}/build/ssc/libssc.dylib
             ${{env.SSCDIR}}/build/ssc/ssc.dylib 
+            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv 
 
   build-on-windows:
     runs-on: windows-2019
@@ -236,7 +243,9 @@ jobs:
       # Turn off fast fail for when the landbosse tests write to cerr
       run: |
         cd ${SSCDIR}/build/test/Release
-        ./Test.exe
+        ./Test.exe > ${SSCDIR}/build/test/gtest.log
+        pip install pandas
+        python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
   
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
@@ -244,3 +253,4 @@ jobs:
           name: SSC Windows Shared Libraries
           path: |
             ${{env.SSCDIR}}\build\ssc\Release\ssc.dll
+            ${{env.SSCDIR}}\build\ssc\test\gtest_elapsed_times.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
       with:
           name: SSC Windows Test Time Elapsed
           path: |
-            ${{env.SSCDIR}}\build\ssc\test\gtest_elapsed_times.csv
+            ${{env.SSCDIR}}\build\test\gtest_elapsed_times.csv
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,17 +76,23 @@ jobs:
       run: |
         set -e
         ${SSCDIR}/build/test/Test > ${SSCDIR}/build/test/gtest.log
-        pip install pandas
+        pip install pandas requests
         python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
     
-    - name: Upload Artifacts
+    - name: Upload Test Times CSV
+      uses: actions/upload-artifact@v4
+      with:
+          name: SSC Linux Test Time Elapsed
+          path: |
+            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv
+
+    - name: Upload Shared Libraries
       uses: actions/upload-artifact@v4
       with:
           name: SSC Linux Shared Libraries
           path: |
             ${{env.SSCDIR}}/build/ssc/libssc.so
             ${{env.SSCDIR}}/build/ssc/ssc.so
-            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv
       
   build-on-mac:
     runs-on: ${{ matrix.os }}
@@ -155,11 +161,27 @@ jobs:
       run: |
         set -e
         ${SSCDIR}/build/test/Test > ${SSCDIR}/build/test/gtest.log
-        pip install pandas
+        pip install pandas requests
         python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
       shell: bash      
-    
-    - name: Upload Artifacts
+
+    - name: Upload Test Times CSV
+      if: ${{ matrix.os == 'macos-latest' }}
+      uses: actions/upload-artifact@v4
+      with:
+          name: SSC Mac Arm Test Time Elapsed
+          path: |
+            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv 
+
+    - name: Upload Test Times CSV
+      if: ${{ matrix.os != 'macos-latest' }}
+      uses: actions/upload-artifact@v4
+      with:
+          name: SSC Mac Intel Test Time Elapsed
+          path: |
+            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv 
+
+    - name: Upload Shared Libraries
       if: ${{ matrix.os == 'macos-latest' }}
       uses: actions/upload-artifact@v4
       with:
@@ -167,9 +189,8 @@ jobs:
           path: |
             ${{env.SSCDIR}}/build/ssc/libssc.dylib
             ${{env.SSCDIR}}/build/ssc/ssc.dylib 
-            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv 
 
-    - name: Upload Artifacts
+    - name: Upload Shared Libraries
       if: ${{ matrix.os != 'macos-latest' }}
       uses: actions/upload-artifact@v4
       with:
@@ -177,7 +198,6 @@ jobs:
           path: |
             ${{env.SSCDIR}}/build/ssc/libssc.dylib
             ${{env.SSCDIR}}/build/ssc/ssc.dylib 
-            ${{env.SSCDIR}}/build/test/gtest_elapsed_times.csv 
 
   build-on-windows:
     runs-on: windows-2019
@@ -244,13 +264,19 @@ jobs:
       run: |
         cd ${SSCDIR}/build/test/Release
         ./Test.exe > ${SSCDIR}/build/test/gtest.log
-        pip install pandas
+        pip install pandas requests
         python ${SSCDIR}/test/compare_elapsed_time.py gtest_log ${SSCDIR}/build/test/gtest.log
   
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+          name: SSC Windows Test Times CSV
+          path: |
+            ${{env.SSCDIR}}\build\ssc\test\gtest_elapsed_times.csv
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
           name: SSC Windows Shared Libraries
           path: |
             ${{env.SSCDIR}}\build\ssc\Release\ssc.dll
-            ${{env.SSCDIR}}\build\ssc\test\gtest_elapsed_times.csv

--- a/test/compare_elapsed_time.py
+++ b/test/compare_elapsed_time.py
@@ -1,0 +1,111 @@
+import pandas as pd
+from pathlib import Path
+import requests
+import sys
+import platform
+
+help_info = """
+Command Line Options to run this script in order to generate CSVs of time elapsed for tests and to compare them
+
+'python compare_elapsed_time.py gtest_log <path to gtest log file>' 
+    Creates the csv in the directory of the log
+
+'python compare_elapsed_time.py compare <path to csv or gtest log> <branch to compare>' 
+    Compares the results from a previous run of Github actions by downloading the artifact csv of the given branch
+"""
+
+def convert_log_to_csv(gtest_log_path):
+    test_groups = []
+    test_names = []
+    test_times = []
+    with open(gtest_log_path, 'r') as f:
+        for i in range(4):
+            next(f)
+        for line in f:
+            if line[0] != '[':
+                continue
+            if 'OK' in line or 'FAIL' in line:
+                test_arr = line.split('] ')[1].split("(")
+                test_name = test_arr[0].strip()
+                test_name = test_name.split('.')
+                test_group = test_name[0]
+                test_name = test_name[-1]
+                test_time = float(test_arr[1].split(" ms")[0])
+            elif 'test suites' in line:
+                test_group = "Total"
+                test_name = "Total"
+                test_time = float(line.split("(")[1].split(" ms")[0])
+            elif 'total' in line:
+                test_arr = line.split('from ')[1].split("(")
+                test_group = test_arr[0].split()[0]
+                test_name = "Total"
+                test_time = float(test_arr[1].split(" ms")[0])
+            else:
+                continue
+            test_groups.append(test_group)
+            test_names.append(test_name)
+            test_times.append(test_time)
+
+    test_df = pd.DataFrame({"Test Group": test_groups, "Test Name": test_names, "Test Times [ms]": test_times})
+    out_path = gtest_log_path.parent / "elapsed_times.csv"
+    test_df.to_csv(out_path)
+    print(f"Output csv: {out_path}")
+    return test_df
+
+def get_workflow_artifact_branch(base_branch):
+    base_branch = 'patch'
+
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': 'Bearer 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',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+
+    response = requests.get('https://api.github.com/repos/NREL/ssc/actions/artifacts', headers=headers)
+
+    print(response)
+
+    artifacts = response.json()['artifacts']
+
+    artifacts = [a for a in artifacts if a['workflow_run']['head_branch'] == base_branch]
+
+    if sys.platform == 'linux':
+        platform = "Linux"
+    elif sys.platform == 'win32':
+        platform = "Windows"
+    elif sys.platform == 'darwin':
+        platform = "Mac"
+    else:
+        raise RuntimeError(f"Unrecognized platform {sys.platform}")
+    
+
+if __name__ == "__main__":
+
+    gtest_log_path = Path("/Users/dguittet/Projects/SAM/ssc/test/gtest.log")
+    convert_log_to_csv(gtest_log_path)
+
+    if len(sys.argv) == 1:
+        raise RuntimeError("Options are 'gtest_log' or 'compare'. Use 'help' to see details")
+
+    if sys.argv[1] == "help":
+        print(help_info)
+        exit()
+    elif sys.argv[1] == "gtest_log":
+        if len(sys.argv) < 3:
+            raise RuntimeError("Provide path to gtest log file")
+        gtest_log_path = Path(sys.argv[2])
+        convert_log_to_csv(gtest_log_path)
+    elif sys.argv[1] == "compare":
+        if len(sys.argv) < 4:
+            raise RuntimeError("Provide path to csv or gtest log file, and the name of the branch for comparison")
+        filename = Path(sys.argv[2])
+        base_branch = sys.argv[3]
+        if Path(filename).suffix != ".csv":
+            test_df = convert_log_to_csv(filename)
+            base_test_df = get_workflow_artifact_branch(base_branch)
+            #compare
+    else:
+        raise RuntimeError("Options are 'gtest_log' or 'compare'. Use 'help' to see details")
+ 
+        
+

--- a/test/compare_elapsed_time.py
+++ b/test/compare_elapsed_time.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pathlib import Path
 import requests
 import sys
+import os
 import platform
 
 help_info = """
@@ -47,17 +48,18 @@ def convert_log_to_csv(gtest_log_path):
             test_times.append(test_time)
 
     test_df = pd.DataFrame({"Test Group": test_groups, "Test Name": test_names, "Test Times [ms]": test_times})
-    out_path = gtest_log_path.parent / "elapsed_times.csv"
+    out_path = gtest_log_path.parent / "gtest_elapsed_times.csv"
     test_df.to_csv(out_path)
     print(f"Output csv: {out_path}")
     return test_df
 
 def get_workflow_artifact_branch(base_branch):
     base_branch = 'patch'
+    access_token = os.getenv("GITHUB_TOKEN")
 
     headers = {
         'Accept': 'application/vnd.github+json',
-        'Authorization': 'Bearer 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',
+        'Authorization': f'Bearer {access_token}',
         'X-GitHub-Api-Version': '2022-11-28',
     }
 
@@ -80,9 +82,6 @@ def get_workflow_artifact_branch(base_branch):
     
 
 if __name__ == "__main__":
-
-    gtest_log_path = Path("/Users/dguittet/Projects/SAM/ssc/test/gtest.log")
-    convert_log_to_csv(gtest_log_path)
 
     if len(sys.argv) == 1:
         raise RuntimeError("Options are 'gtest_log' or 'compare'. Use 'help' to see details")


### PR DESCRIPTION
Add step in existing GitHub workflow to upload an artifact containing CSVs of elapsed test times

In a future branch, will add a new Workflow to compare CSVs across branches. Need to merge this one first so other branches upload the artifacts