### PR TITLE
Throw an error if all billing demand periods are zero

### DIFF
--- a/shared/lib_utility_rate_equations.cpp
+++ b/shared/lib_utility_rate_equations.cpp
@@ -914,7 +914,7 @@ void rate_data::setup_demand_charges(ssc_number_t* dc_weekday, ssc_number_t* dc_
 	}
 }
 
-void rate_data::setup_ratcheting_demand(ssc_number_t* ratchet_percent_matrix, ssc_number_t* bd_tou_period_matrix)
+bool rate_data::setup_ratcheting_demand(ssc_number_t* ratchet_percent_matrix, ssc_number_t* bd_tou_period_matrix)
 {
     // Error checked in SSC variables
     size_t nrows = 12;
@@ -927,12 +927,21 @@ void rate_data::setup_ratcheting_demand(ssc_number_t* ratchet_percent_matrix, ss
         m_month[i].use_current_month_ratchet = ratchet_matrix.at(i, 1) == 1;
     }
 
+    // Must have at least one row at 1, otherwise indicate an error to ssc code
+    bool uses_no_tou_periods = true;
+
     nrows = m_dc_tou_periods.size();
     util::matrix_t<double> tou_matrix(nrows, ncols);
     tou_matrix.assign(bd_tou_period_matrix, nrows, ncols);
     for (size_t i = 0; i < nrows; i++) {
-        bd_tou_periods.emplace((int) tou_matrix.at(i, 0), tou_matrix.at(i, 1) == 1.0);
+        bool use_this_tou_period = tou_matrix.at(i, 1) == 1.0;
+        if (use_this_tou_period) {
+            uses_no_tou_periods = false;
+        }
+        bd_tou_periods.emplace((int) tou_matrix.at(i, 0), use_this_tou_period);
     }
+
+    return uses_no_tou_periods;
 }
 
 void rate_data::sort_energy_to_periods(int month, double energy, size_t step) {

--- a/shared/lib_utility_rate_equations.h
+++ b/shared/lib_utility_rate_equations.h
@@ -158,8 +158,8 @@ public:
 	void setup_energy_rates(ssc_number_t* ec_weekday, ssc_number_t* ec_weekend, size_t ec_tou_rows, ssc_number_t* ec_tou_in, bool sell_eq_buy);
     /* Optional function if demand charges are present */
 	void setup_demand_charges(ssc_number_t* dc_weekday, ssc_number_t* dc_weekend, size_t dc_tou_rows, ssc_number_t* dc_tou_in, size_t dc_flat_rows, ssc_number_t* dc_flat_in);
-    /* Optional function if energy charges use a ratchet for the billing demand */
-    void setup_ratcheting_demand(ssc_number_t* ratchet_percent_matrix, ssc_number_t* bd_tou_period_matrix);
+    /* Optional function if energy charges use a ratchet for the billing demand - returns error code based on data validitiy (at least one active period) */
+    bool setup_ratcheting_demand(ssc_number_t* ratchet_percent_matrix, ssc_number_t* bd_tou_period_matrix);
 
     void setup_prev_demand(ssc_number_t* prev_demand);
     /* call ur_month.update_net_and_peak before this, otherwise you'll get low values back */

--- a/ssc/cmod_utilityrate5.cpp
+++ b/ssc/cmod_utilityrate5.cpp
@@ -441,7 +441,13 @@ void rate_setup::setup(var_table* vt, int num_recs_yearly, size_t nyears, rate_d
             throw exec_error(cm_name, ss.str());
         }
 
-        rate.setup_ratcheting_demand(ratchet_matrix, bd_tou_matrix);
+        bool error = rate.setup_ratcheting_demand(ratchet_matrix, bd_tou_matrix);
+
+        if (error) {
+            std::ostringstream ss;
+            ss << "ur_dc_billing_demand_periods should have at least one period where billing demand calculations are enabled.";
+            throw exec_error(cm_name, ss.str());
+        }
     }
 
 

--- a/test/ssc_test/cmod_utilityrate5_test.cpp
+++ b/test/ssc_test/cmod_utilityrate5_test.cpp
@@ -1752,7 +1752,17 @@ TEST(cmod_utilityrate5_eqns, Test_seasonal_per_kw_charge_w_no_demand_charge) {
                                          2, 1, 200, 0, 0.028812999999999998, 0,
                                          2, 2, 9.9999999999999998e+37, 0, 0.132655, 0 };
     ssc_data_set_matrix(data, "ur_ec_tou_mat", p_ur_ec_tou_mat, 10, 6);
-    ssc_data_set_number(data, "ur_dc_enable", 0);
+    ssc_data_set_number(data, "ur_dc_enable", 1);
+
+    // Demand charge data required as of https://github.com/NREL/ssc/pull/1293 
+    ssc_number_t p_ur_dc_sched_weekday[288] = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+    ssc_data_set_matrix(data, "ur_dc_sched_weekday", p_ur_dc_sched_weekday, 12, 24);
+    ssc_number_t p_ur_dc_sched_weekend[288] = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+    ssc_data_set_matrix(data, "ur_dc_sched_weekend", p_ur_dc_sched_weekend, 12, 24);
+    ssc_number_t p_ur_dc_tou_mat[8] = { 1, 1, 9.9999999999999998e+37, 0, 2, 1, 9.9999999999999998e+37, 0 };
+    ssc_data_set_matrix(data, "ur_dc_tou_mat", p_ur_dc_tou_mat, 2, 4);
+    ssc_number_t p_ur_dc_flat_mat[48] = { 0, 1, 9.9999999999999998e+37, 0, 1, 1, 9.9999999999999998e+37, 0, 2, 1, 9.9999999999999998e+37, 0, 3, 1, 9.9999999999999998e+37, 0, 4, 1, 9.9999999999999998e+37, 0, 5, 1, 9.9999999999999998e+37, 0, 6, 1, 9.9999999999999998e+37, 0, 7, 1, 9.9999999999999998e+37, 0, 8, 1, 9.9999999999999998e+37, 0, 9, 1, 9.9999999999999998e+37, 0, 10, 1, 9.9999999999999998e+37, 0, 11, 1, 9.9999999999999998e+37, 0 };
+    ssc_data_set_matrix(data, "ur_dc_flat_mat", p_ur_dc_flat_mat, 12, 4);
 
 
     ssc_data_set_number(data, "ur_enable_billing_demand", 1);
@@ -1773,8 +1783,8 @@ TEST(cmod_utilityrate5_eqns, Test_seasonal_per_kw_charge_w_no_demand_charge) {
                                       60, 0 };
     ssc_data_set_matrix(data, "ur_billing_demand_lookback_percentages", p_ur_billing_demand_lookback_percentages, 12, 2);
 
-    ssc_number_t p_ur_billing_demand_tou_matrix[2] = { 1, 1 };
-    ssc_data_set_matrix(data, "ur_dc_billing_demand_periods", p_ur_billing_demand_tou_matrix, 1, 2);
+    ssc_number_t p_ur_billing_demand_tou_matrix[4] = { 1, 1, 2, 1 };
+    ssc_data_set_matrix(data, "ur_dc_billing_demand_periods", p_ur_billing_demand_tou_matrix, 2, 2);
 
     ssc_number_t year_zero_power[12] = { -1200,
                                         -1100,


### PR DESCRIPTION
Fixes https://github.com/NREL/SAM/issues/1985

To test:

1. Create a PVWatts commercial case
2. Enable billing demand lookback
3. Run the case - case should run successfully
4. Set all "Included in billing demand" values under "billing demand by time-of-use period for demand charges" values to zero
5. Run the case - new error message should appear.