### PR TITLE
Add new dispatch period output for manual dispatch

### DIFF
--- a/shared/lib_battery_dispatch.h
+++ b/shared/lib_battery_dispatch.h
@@ -139,6 +139,8 @@ public:
 	virtual double cost_to_cycle() { return 0.;}
     virtual double cost_to_cycle_per_kwh() { return 0.; }
 
+    virtual size_t get_dispatch_period() { return 0; }
+
 	// control settings
 	double battery_power_to_fill();
 

--- a/shared/lib_battery_dispatch_manual.cpp
+++ b/shared/lib_battery_dispatch_manual.cpp
@@ -78,6 +78,7 @@ void dispatch_manual_t::init_with_vects(
     _can_clip_charge = can_clip_charge;
     _can_curtail_charge = can_curtail_charge;
     _priority_charge_battery = priorityChargeBattery;
+    _iprofile = 0;
 }
 
 // deep copy from dispatch to this
@@ -105,34 +106,34 @@ void dispatch_manual_t::prepareDispatch(size_t hour_of_year, size_t )
 	size_t m, h;
 	util::month_hour(hour_of_year, m, h);
 	size_t column = h - 1;
-	size_t iprofile = 0;
+	_iprofile = 0;
 
 	bool is_weekday = util::weekday(hour_of_year);
 	if (!is_weekday && _mode == MANUAL)
-		iprofile = _sched_weekend(m - 1, column);
+        _iprofile = _sched_weekend(m - 1, column);
 	else
-		iprofile = _sched(m - 1, column);  // 1-based
+        _iprofile = _sched(m - 1, column);  // 1-based
 
-	m_batteryPower->canSystemCharge = _charge_array[iprofile - 1];
-	m_batteryPower->canDischarge = _discharge_array[iprofile - 1];
-	m_batteryPower->canGridCharge = _gridcharge_array[iprofile - 1];
+	m_batteryPower->canSystemCharge = _charge_array[_iprofile - 1];
+	m_batteryPower->canDischarge = _discharge_array[_iprofile - 1];
+	m_batteryPower->canGridCharge = _gridcharge_array[_iprofile - 1];
     m_batteryPower->canClipCharge = _can_clip_charge;
     m_batteryPower->canCurtailCharge = _can_curtail_charge;
 
-	if (iprofile <= _fuelcellcharge_array.size()) {
-		m_batteryPower->canFuelCellCharge = _fuelcellcharge_array[iprofile - 1];
+	if (_iprofile <= _fuelcellcharge_array.size()) {
+		m_batteryPower->canFuelCellCharge = _fuelcellcharge_array[_iprofile - 1];
 	}
 
-    if (iprofile <= _discharge_grid_array.size()) {
-        m_batteryPower->canDischargeToGrid = _discharge_grid_array[iprofile - 1];
+    if (_iprofile <= _discharge_grid_array.size()) {
+        m_batteryPower->canDischargeToGrid = _discharge_grid_array[_iprofile - 1];
     }
 
 	_percent_discharge = 0.;
 	_percent_charge = 0.;
 
-	if (m_batteryPower->canDischarge){ _percent_discharge = _percent_discharge_array[iprofile]; }
+	if (m_batteryPower->canDischarge){ _percent_discharge = _percent_discharge_array[_iprofile]; }
 	if (m_batteryPower->canCurtailCharge || m_batteryPower->canClipCharge || m_batteryPower->canSystemCharge || m_batteryPower->canFuelCellCharge){ _percent_charge = 100.; }
-	if (m_batteryPower->canGridCharge){ _percent_charge = _percent_charge_array[iprofile]; }
+	if (m_batteryPower->canGridCharge){ _percent_charge = _percent_charge_array[_iprofile]; }
 }
 void dispatch_manual_t::dispatch(size_t year,
 	size_t hour_of_year,
@@ -290,4 +291,8 @@ void dispatch_manual_t::SOC_controller()
         else
             _charging = _prev_charging;
     }
+}
+
+size_t dispatch_manual_t::get_dispatch_period() {
+    return _iprofile;
 }

--- a/shared/lib_battery_dispatch_manual.h
+++ b/shared/lib_battery_dispatch_manual.h
@@ -85,6 +85,8 @@ public:
 		size_t hour_of_year,
 		size_t step) override;
 
+    size_t get_dispatch_period() override;
+
 protected:
 
 	/// Helper function to internally set up the dispatch model
@@ -118,6 +120,8 @@ protected:
     bool _can_clip_charge;
     bool _can_curtail_charge;
     bool _priority_charge_battery;
+
+    size_t _iprofile;
 
 	double _percent_discharge;
 	double _percent_charge;

--- a/ssc/cmod_battery.cpp
+++ b/ssc/cmod_battery.cpp
@@ -273,6 +273,8 @@ var_info vtab_battery_outputs[] = {
     { SSC_OUTPUT,        SSC_ARRAY,      "crit_load_unmet",                            "Critical load unmet in this timestep",                  "kW","",                      "Battery",       "",                           "",                              "" },
     { SSC_OUTPUT,        SSC_ARRAY,      "crit_load",                                  "Critical load in this timestep",                        "kW","",                      "Battery",       "",                           "",                              "" },
     { SSC_OUTPUT,        SSC_ARRAY,      "outage_losses_unmet",                        "Battery and system losses unmet in this timestep",     "kW","",                      "Battery",       "",                           "",                              "" },
+    { SSC_OUTPUT,        SSC_ARRAY,      "batt_dispatch_period",                       "Battery manual dispatch period in this timestep",              "","",                      "Battery",       "",                           "",                              "" },
+
 
     // PV Smoothing
     { SSC_OUTPUT,        SSC_ARRAY,      "batt_pvs_PV_ramp_interval",                  "PV smoothing PV power sampled", "kW", "", "Battery", "", "", "" },
@@ -1019,6 +1021,9 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
             outGridPowerTarget = vt.allocate("grid_power_target", nrec * nyears);
             outBattPowerTarget = vt.allocate("batt_power_target", nrec * nyears);
         }
+        else {
+            outDispatchPeriod = vt.allocate("batt_dispatch_period", nrec * nyears);
+        }
     }
     else if (batt_vars->batt_meter_position == dispatch_t::FRONT)
     {
@@ -1038,6 +1043,9 @@ battstor::battstor(var_table& vt, bool setup_model, size_t nrec, double dt_hr, c
             outBenefitGridcharge = vt.allocate("batt_revenue_gridcharge", nrec * nyears);
             outBenefitClipcharge = vt.allocate("batt_revenue_clipcharge", nrec * nyears);
             outBenefitDischarge = vt.allocate("batt_revenue_discharge", nrec * nyears);
+        }
+        else {
+            outDispatchPeriod = vt.allocate("batt_dispatch_period", nrec * nyears);
         }
     }
     outSystemToBattAC = vt.allocate("system_to_batt", nrec * nyears);
@@ -1764,6 +1772,8 @@ battstor::battstor(const battstor& orig) {
 
     outAdjustLosses = orig.outAdjustLosses;
 
+    outDispatchPeriod = orig.outDispatchPeriod;
+
     // copy models
     if (orig.batt_vars) batt_vars = orig.batt_vars;
     battery_metrics = new battery_metrics_t(orig._dt_hour);
@@ -1955,6 +1965,9 @@ void battstor::outputs_topology_dependent()
             outGridPowerTarget[index] = (ssc_number_t)(dispatch_model->power_grid_target());
             outBattPowerTarget[index] = (ssc_number_t)(dispatch_model->power_batt_target());
         }
+        else {
+            outDispatchPeriod[index] = (ssc_number_t)(dispatch_model->get_dispatch_period());
+        }
 
         if (analyze_outage) {
             outCritLoadUnmet[index] = (ssc_number_t)(dispatch_model->power_crit_load_unmet());
@@ -1984,6 +1997,9 @@ void battstor::outputs_topology_dependent()
             outBenefitDischarge[index] = (ssc_number_t)(dispatch_fom->benefit_discharge());
             outBenefitClipcharge[index] = (ssc_number_t)(dispatch_fom->benefit_clipcharge());
             outBenefitGridcharge[index] = (ssc_number_t)(dispatch_fom->benefit_gridcharge());
+        }
+        else {
+            outDispatchPeriod[index] = (ssc_number_t)(dispatch_model->get_dispatch_period());
         }
     }
 

--- a/ssc/cmod_battery.h
+++ b/ssc/cmod_battery.h
@@ -456,7 +456,8 @@ struct battstor
         * outPVS_P_pv_ac, // testing with input pv output
         * outPVS_PV_ramp_interval, // testing with sampled input pv output
         * outPVS_forecast_pv_energy, // testing with forecast based on input pv output
-        * outAdjustLosses;
+        * outAdjustLosses,
+        * outDispatchPeriod;
 
 	double outAverageCycleEfficiency;
 	double outAverageRoundtripEfficiency;


### PR DESCRIPTION
New variable "Battery manual dispatch period in this timestep" should appear for manual dispatch (both front of meter and behind the meter) but not for other dispatch modes.

Chose to do a lifetime variable instead of year 1 since I think we're trying to move in that direction.

Fixes https://github.com/NREL/ssc/issues/1230