### PR TITLE
ssc test speed up

### DIFF
--- a/test/input_cases/battwatts_cases.h
+++ b/test/input_cases/battwatts_cases.h
@@ -51,8 +51,7 @@ int v1 = sprintf(ac_power_path, "%s/test/input_cases/battwatts_data/ac_power.csv
 void pvwatts_pv_defaults(ssc_data_t& data) {
 	ssc_data_set_string(data, "solar_resource_file", solar_resource_path);
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-    //ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2); 
     ssc_data_set_number(data, "system_capacity", 4.6928700000000001);
 	ssc_data_set_number(data, "module_type", 0);
 	ssc_data_set_number(data, "dc_ac_ratio", 1.2);

--- a/test/input_cases/battwatts_cases.h
+++ b/test/input_cases/battwatts_cases.h
@@ -51,8 +51,9 @@ int v1 = sprintf(ac_power_path, "%s/test/input_cases/battwatts_data/ac_power.csv
 void pvwatts_pv_defaults(ssc_data_t& data) {
 	ssc_data_set_string(data, "solar_resource_file", solar_resource_path);
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	ssc_data_set_number(data, "analysis_period", 25);
-	ssc_data_set_number(data, "system_capacity", 4.6928700000000001);
+    //ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "system_capacity", 4.6928700000000001);
 	ssc_data_set_number(data, "module_type", 0);
 	ssc_data_set_number(data, "dc_ac_ratio", 1.2);
 	ssc_data_set_number(data, "array_type", 0);

--- a/test/input_cases/biomass_common.h
+++ b/test/input_cases/biomass_common.h
@@ -149,7 +149,9 @@ void biomass_commondata(ssc_data_t &data) {
 
     ssc_data_set_number(data, "adjust_constant", 0.0);
 
-	ssc_data_set_number(data, "analysis_period", 25);
+	//ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
 	ssc_number_t p_federal_tax_rate[1] = { 21 };
 	ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);
 	ssc_number_t p_state_tax_rate[1] = { 7 };

--- a/test/input_cases/biomass_common.h
+++ b/test/input_cases/biomass_common.h
@@ -149,8 +149,7 @@ void biomass_commondata(ssc_data_t &data) {
 
     ssc_data_set_number(data, "adjust_constant", 0.0);
 
-	//ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2);
 
 	ssc_number_t p_federal_tax_rate[1] = { 21 };
 	ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);

--- a/test/input_cases/csp_financial_defaults.cpp
+++ b/test/input_cases/csp_financial_defaults.cpp
@@ -7,8 +7,7 @@ ssc_data_t singleowner_defaults()
 {
     ssc_data_t data = ssc_data_create();
 
-    //ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2);
 
     ssc_number_t p_federal_tax_rate[1] = { 21 };
     ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);

--- a/test/input_cases/csp_financial_defaults.cpp
+++ b/test/input_cases/csp_financial_defaults.cpp
@@ -7,7 +7,9 @@ ssc_data_t singleowner_defaults()
 {
     ssc_data_t data = ssc_data_create();
 
-    ssc_data_set_number(data, "analysis_period", 25);
+    //ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
     ssc_number_t p_federal_tax_rate[1] = { 21 };
     ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);
     ssc_number_t p_state_tax_rate[1] = { 7 };

--- a/test/input_cases/custom_generation_common_data.h
+++ b/test/input_cases/custom_generation_common_data.h
@@ -442,7 +442,9 @@ void custom_generation_commerical_battery_60min(ssc_data_t &data)
 	ssc_data_set_number(data, "conv_eff", 34.118049621582031);
 	set_array(data, "energy_output_array", customgenerationtest::gen_path_60min, 8760);
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	ssc_data_set_number(data, "analysis_period", 25);
+	//ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
 	ssc_number_t p_generic_degradation[1] = { 0 };
 	ssc_data_set_array(data, "generic_degradation", p_generic_degradation, 1);
 

--- a/test/input_cases/custom_generation_common_data.h
+++ b/test/input_cases/custom_generation_common_data.h
@@ -442,8 +442,7 @@ void custom_generation_commerical_battery_60min(ssc_data_t &data)
 	ssc_data_set_number(data, "conv_eff", 34.118049621582031);
 	set_array(data, "energy_output_array", customgenerationtest::gen_path_60min, 8760);
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	//ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2);
 
 	ssc_number_t p_generic_degradation[1] = { 0 };
 	ssc_data_set_array(data, "generic_degradation", p_generic_degradation, 1);

--- a/test/input_cases/geothermal_common_data.h
+++ b/test/input_cases/geothermal_common_data.h
@@ -58,7 +58,7 @@ static void geothermal_singleowner_default(ssc_data_t &data)
 	ssc_data_set_number(data, "resource_temp", 200);
 	ssc_data_set_number(data, "resource_depth", 2000);
     ssc_data_set_number(data, "geotherm.cost.inj_prod_well_ratio", 50);
-	ssc_data_set_number(data, "geothermal_analysis_period", 25);
+	ssc_data_set_number(data, "geothermal_analysis_period", 2);
 	ssc_data_set_number(data, "model_choice", 0);
 	ssc_data_set_number(data, "specified_pump_work_amount", 0);
 	ssc_data_set_number(data, "nameplate", 30000);
@@ -145,7 +145,7 @@ static void geothermal_singleowner_default(ssc_data_t &data)
 	set_array(data, "grid_curtailment", geothermal_curtailment_path, 8760);
 	ssc_data_set_number(data, "grid_interconnection_limit_kwac", 100000);
 	
-	ssc_data_set_number(data, "analysis_period", 25);
+	ssc_data_set_number(data, "analysis_period", 2);
 
 	ssc_number_t p_federal_tax_rate[1] = { 21 };
 	ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);

--- a/test/input_cases/geothermal_common_data.h
+++ b/test/input_cases/geothermal_common_data.h
@@ -145,8 +145,7 @@ static void geothermal_singleowner_default(ssc_data_t &data)
 	set_array(data, "grid_curtailment", geothermal_curtailment_path, 8760);
 	ssc_data_set_number(data, "grid_interconnection_limit_kwac", 100000);
 	
-//	ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+	ssc_data_set_number(data, "analysis_period", 25);
 
 	ssc_number_t p_federal_tax_rate[1] = { 21 };
 	ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);

--- a/test/input_cases/geothermal_common_data.h
+++ b/test/input_cases/geothermal_common_data.h
@@ -145,7 +145,9 @@ static void geothermal_singleowner_default(ssc_data_t &data)
 	set_array(data, "grid_curtailment", geothermal_curtailment_path, 8760);
 	ssc_data_set_number(data, "grid_interconnection_limit_kwac", 100000);
 	
-	ssc_data_set_number(data, "analysis_period", 25);
+//	ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
 	ssc_number_t p_federal_tax_rate[1] = { 21 };
 	ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);
 	ssc_number_t p_state_tax_rate[1] = { 7 };

--- a/test/input_cases/pvsamv1_battery_common_data.h
+++ b/test/input_cases/pvsamv1_battery_common_data.h
@@ -825,7 +825,9 @@ void commercial_multiarray_default(ssc_data_t& data) {
 	ssc_data_set_number(data, "transformer_load_loss", 0);
 	ssc_data_set_number(data, "system_use_lifetime_output", 1);
 	ssc_data_set_number(data, "save_full_lifetime_variables", 1);
-	ssc_data_set_number(data, "analysis_period", 25);
+//    ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales
+
     ssc_number_t p_federal_tax_rate[1] = { 21 };
     ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);
     ssc_number_t p_state_tax_rate[1] = { 7 };

--- a/test/input_cases/pvsamv1_battery_common_data.h
+++ b/test/input_cases/pvsamv1_battery_common_data.h
@@ -79,7 +79,7 @@ void pvsamv1_pv_defaults(ssc_data_t& data) {
 	ssc_data_set_number(data, "transformer_load_loss", 0);
 	ssc_data_set_number(data, "system_use_lifetime_output", 1);
 	ssc_data_set_number(data, "save_full_lifetime_variables", 1);
-    ssc_data_set_number(data, "analysis_period", 2); // speedy_gonzales 25);
+    ssc_data_set_number(data, "analysis_period", 2); 
     ssc_number_t p_dc_degradation[1] = { 0.5 };
 	ssc_data_set_array(data, "dc_degradation", p_dc_degradation, 1);
 	ssc_data_set_number(data, "en_dc_lifetime_losses", 0);
@@ -825,8 +825,7 @@ void commercial_multiarray_default(ssc_data_t& data) {
 	ssc_data_set_number(data, "transformer_load_loss", 0);
 	ssc_data_set_number(data, "system_use_lifetime_output", 1);
 	ssc_data_set_number(data, "save_full_lifetime_variables", 1);
-//    ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales
+    ssc_data_set_number(data, "analysis_period", 2); 
 
     ssc_number_t p_federal_tax_rate[1] = { 21 };
     ssc_data_set_array(data, "federal_tax_rate", p_federal_tax_rate, 1);

--- a/test/input_cases/pvsamv1_battery_common_data.h
+++ b/test/input_cases/pvsamv1_battery_common_data.h
@@ -79,8 +79,8 @@ void pvsamv1_pv_defaults(ssc_data_t& data) {
 	ssc_data_set_number(data, "transformer_load_loss", 0);
 	ssc_data_set_number(data, "system_use_lifetime_output", 1);
 	ssc_data_set_number(data, "save_full_lifetime_variables", 1);
-	ssc_data_set_number(data, "analysis_period", 25);
-	ssc_number_t p_dc_degradation[1] = { 0.5 };
+    ssc_data_set_number(data, "analysis_period", 2); // speedy_gonzales 25);
+    ssc_number_t p_dc_degradation[1] = { 0.5 };
 	ssc_data_set_array(data, "dc_degradation", p_dc_degradation, 1);
 	ssc_data_set_number(data, "en_dc_lifetime_losses", 0);
 	ssc_number_t p_dc_lifetime_losses[1] = { 0 };

--- a/test/input_cases/pvsamv1_common_data.cpp
+++ b/test/input_cases/pvsamv1_common_data.cpp
@@ -553,7 +553,9 @@ void pvsamv1_with_residential_default(ssc_data_t& data)
     ssc_data_set_number(data, "transformer_no_load_loss", 0);
     ssc_data_set_number(data, "transformer_load_loss", 0);
     ssc_data_set_number(data, "system_use_lifetime_output", 0);
-    ssc_data_set_number(data, "analysis_period", 25);
+//    ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
     ssc_number_t p_dc_degradation[1] = { 0.5 };
     ssc_data_set_array(data, "dc_degradation", p_dc_degradation, 1);
     ssc_data_set_number(data, "en_dc_lifetime_losses", 0);

--- a/test/input_cases/pvsamv1_common_data.cpp
+++ b/test/input_cases/pvsamv1_common_data.cpp
@@ -553,8 +553,7 @@ void pvsamv1_with_residential_default(ssc_data_t& data)
     ssc_data_set_number(data, "transformer_no_load_loss", 0);
     ssc_data_set_number(data, "transformer_load_loss", 0);
     ssc_data_set_number(data, "system_use_lifetime_output", 0);
-//    ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2);
 
     ssc_number_t p_dc_degradation[1] = { 0.5 };
     ssc_data_set_array(data, "dc_degradation", p_dc_degradation, 1);

--- a/test/input_cases/pvsamv1_common_data.cpp
+++ b/test/input_cases/pvsamv1_common_data.cpp
@@ -944,8 +944,10 @@ void cashloan_default(ssc_data_t& data)
     ssc_data_set_array(data, "om_fuel_cost", p_om_fuel_cost, 1);
     ssc_data_set_number(data, "om_fuel_cost_escal", 0);
     ssc_number_t itc_amount[1] = { 0 };
-    ssc_number_t itc_fed_percent[1] = { 30 };
-    ssc_number_t itc_sta_percent[1] = { 25 };
+//    ssc_number_t itc_fed_percent[1] = { 30 };
+//    ssc_number_t itc_sta_percent[1] = { 25 };
+    ssc_number_t itc_fed_percent[1] = { 0 };
+    ssc_number_t itc_sta_percent[1] = { 0 };
     ssc_number_t itc_amount_max[1] = { 1e+38 };
     ssc_data_set_array(data, "itc_fed_amount", itc_amount, 1);
     ssc_data_set_array(data, "itc_sta_amount", itc_amount, 1);

--- a/test/input_cases/pvwatts_cases.h
+++ b/test/input_cases/pvwatts_cases.h
@@ -65,7 +65,9 @@ static int pvwatts_nofinancial_testfile(ssc_data_t &data)
 
 	//set the variables for the PVWatts default case
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	ssc_data_set_number(data, "analysis_period", 25);
+	//ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
 	ssc_data_set_string(data, "solar_resource_file", hourly); //file set above
 	ssc_data_set_number(data, "system_capacity", 4);
 	ssc_data_set_number(data, "module_type", 0);

--- a/test/input_cases/pvwatts_cases.h
+++ b/test/input_cases/pvwatts_cases.h
@@ -65,8 +65,7 @@ static int pvwatts_nofinancial_testfile(ssc_data_t &data)
 
 	//set the variables for the PVWatts default case
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
-	//ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2);
 
 	ssc_data_set_string(data, "solar_resource_file", hourly); //file set above
 	ssc_data_set_number(data, "system_capacity", 4);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -61,7 +61,8 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
-    ::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
+    //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
+    ::testing::GTEST_FLAG(filter) = "CmodLeveragedPartnershipFlipTest*:CmodAllEquityPartnershipFlipTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
     //::testing::GTEST_FLAG(filter) = "etes_ptes_test*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -56,7 +56,7 @@ GTEST_API_ int main(int argc, char **argv) {
     //    ::testing::GTEST_FLAG(filter) = "CmodPVWatts*:CMPvwatts*";
     //::testing::GTEST_FLAG(filter) = "CmodHybridTest*";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1BatteryIntegration_cmod_pvsamv1.ResidentialDCBatteryModelPriceSignalDispatchGridExport";
-
+    //::testing::GTEST_FLAG(filter) = "CMPvsamv1BatteryIntegration_cmod_pvsamv1.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
 
     //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -61,8 +61,8 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
-    //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
-    ::testing::GTEST_FLAG(filter) = "CmodLeveragedPartnershipFlipTest*:CmodAllEquityPartnershipFlipTest*";
+    ::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
+    //::testing::GTEST_FLAG(filter) = "CmodLeveragedPartnershipFlipTest*:CmodAllEquityPartnershipFlipTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
     //::testing::GTEST_FLAG(filter) = "etes_ptes_test*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -61,7 +61,7 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
-    //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
+    ::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
     //::testing::GTEST_FLAG(filter) = "etes_ptes_test*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -61,7 +61,8 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
-    ::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
+    //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
+    ::testing::GTEST_FLAG(filter) = "CmodSaleLeasebackTest*:CmodThirdPartyOwnershipTest*:CmodHostDeveloperTest*:CmodMerchantPlantTest*:CmodLCOEFCRTest*";
     //::testing::GTEST_FLAG(filter) = "CmodLeveragedPartnershipFlipTest*:CmodAllEquityPartnershipFlipTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
     //::testing::GTEST_FLAG(filter) = "etes_ptes_test*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -63,7 +63,7 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
     //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
-
+    //::testing::GTEST_FLAG(filter) = "etes_ptes_test*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod*";
     //::testing::GTEST_FLAG(filter) = "CmodFresnelPhysicalTest.MSLFDefault";
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -62,7 +62,7 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
     //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
-    ::testing::GTEST_FLAG(filter) = "CmodSaleLeasebackTest*:CmodThirdPartyOwnershipTest*:CmodHostDeveloperTest*:CmodMerchantPlantTest*:CmodLCOEFCRTest*";
+    //::testing::GTEST_FLAG(filter) = "CmodSaleLeasebackTest*:CmodThirdPartyOwnershipTest*:CmodHostDeveloperTest*:CmodMerchantPlantTest*:CmodLCOEFCRTest*";
     //::testing::GTEST_FLAG(filter) = "CmodLeveragedPartnershipFlipTest*:CmodAllEquityPartnershipFlipTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
     //::testing::GTEST_FLAG(filter) = "etes_ptes_test*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -57,6 +57,8 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CmodHybridTest*";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1BatteryIntegration_cmod_pvsamv1.ResidentialDCBatteryModelPriceSignalDispatchGridExport";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1BatteryIntegration_cmod_pvsamv1.*";
+    //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.*";
+    //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
 
     //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -59,6 +59,7 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1BatteryIntegration_cmod_pvsamv1.*";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.*";
     //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
+    //::testing::GTEST_FLAG(filter) = "save_as_JSON_test_run.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
     //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -60,7 +60,7 @@ GTEST_API_ int main(int argc, char **argv) {
     //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.*";
     //::testing::GTEST_FLAG(filter) = "CMGeothermal.*";
     //::testing::GTEST_FLAG(filter) = "csp_tower.PowerTowerCmod.Default_NoFinancial";
-
+    //::testing::GTEST_FLAG(filter) = "CMPvsamv1PowerIntegration_cmod_pvsamv1.NoFinancialModelSystemDesign";
     //::testing::GTEST_FLAG(filter) = "CmodCashLoanTest*:CmodSingleOwnerTest*";
     //::testing::GTEST_FLAG(filter) = "Solesca*";
 

--- a/test/shared_test/lib_battery_dispatch_pvsmoothing_fom_test.cpp
+++ b/test/shared_test/lib_battery_dispatch_pvsmoothing_fom_test.cpp
@@ -123,7 +123,7 @@ TEST_F(PVSmoothing_lib_battery_dispatch, Generic_w_PV_input_all_on) {
     ssc_data_free(dat);
     dat = nullptr;
 }
-
+/*
 TEST_F(PVSmoothing_lib_battery_dispatch, FuelCell_PV_Phoenix_all_on) {
 
     char file_path[256];
@@ -167,4 +167,4 @@ TEST_F(PVSmoothing_lib_battery_dispatch, FuelCell_PV_Phoenix_all_on) {
     ssc_data_free(dat);
     dat = nullptr;
 }
-
+*/

--- a/test/ssc_test/cmod_battery_eqns_test.cpp
+++ b/test/ssc_test/cmod_battery_eqns_test.cpp
@@ -69,7 +69,9 @@ TEST_F(CMBatteryEqns_cmod_battery_eqns, reopt_sizing) {
 
     ssc_number_t gen[8760] = { 0 };
     ssc_data_set_array(data, "gen", gen, 8760);
-    ssc_data_set_number(data, "analysis_period", 25);
+//    ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
     ssc_data_set_number(data, "system_capacity", 5);
     set_array(data, "load", load_profile_path, 8760); // Load is required for peak shaving controllers
 

--- a/test/ssc_test/cmod_battery_eqns_test.cpp
+++ b/test/ssc_test/cmod_battery_eqns_test.cpp
@@ -69,8 +69,7 @@ TEST_F(CMBatteryEqns_cmod_battery_eqns, reopt_sizing) {
 
     ssc_number_t gen[8760] = { 0 };
     ssc_data_set_array(data, "gen", gen, 8760);
-//    ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2); 
 
     ssc_data_set_number(data, "system_capacity", 5);
     set_array(data, "load", load_profile_path, 8760); // Load is required for peak shaving controllers

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -474,7 +474,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_cashloan)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-    EXPECT_NEAR(lcos_real, 583.83, 0.1);
+//    EXPECT_NEAR(lcos_real, 583.83, 0.1);
+    EXPECT_NEAR(lcos_real, 3795.85, 0.1); // change analysis period from 25 to 2 for speedy_gonzales
 }
 
 /// Test PVSAMv1 with all defaults and battery enabled with 3 automatic dispatch methods

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -440,8 +440,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_singleowner)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-//    EXPECT_NEAR(lcos_real, 23.41, 0.1);
-    EXPECT_NEAR(lcos_real, 53.38, 0.1); // change analysis period from 25 to 2 for speedy_gonzales
+    EXPECT_NEAR(lcos_real, 53.38, 0.1);
 
 }
 
@@ -457,8 +456,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_levpartflip)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-    //EXPECT_NEAR(lcos_real, 23.43, 0.1);
-    EXPECT_NEAR(lcos_real, 53.56, 0.1);  // change analysis period from 25 to 2 for speedy_gonzales
+    EXPECT_NEAR(lcos_real, 53.56, 0.1); 
 }
 
 TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_cashloan)
@@ -474,8 +472,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_cashloan)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-//    EXPECT_NEAR(lcos_real, 583.83, 0.1);
-    EXPECT_NEAR(lcos_real, 3795.85, 0.1); // change analysis period from 25 to 2 for speedy_gonzales
+    EXPECT_NEAR(lcos_real, 3795.85, 0.1); 
 }
 
 /// Test PVSAMv1 with all defaults and battery enabled with 3 automatic dispatch methods
@@ -493,8 +490,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_ACBatteryModelIntegration)
     ssc_number_t peakKwCharge[3] = { -1040.2, -1051.5, -1051.5 };
     ssc_number_t peakKwDischarge[3] = { 967.5, 969.5, 969.5 };
     ssc_number_t peakCycles[3] = { 1, 1, 1 };
-//    ssc_number_t avgCycles[3] = { 0.0039, 0.0042, 0.003 };
-    ssc_number_t avgCycles[3] = { 0.0068, 0.0110, 0.003 };// change analysis period from 25 to 2 for speedy_gonzales
+    ssc_number_t avgCycles[3] = { 0.0068, 0.0110, 0.003 };
 
     ssc_data_set_number(data, "batt_dispatch_choice", 0);
     // Test economoic dispatch look ahead, economoic dispatch look behind. Others require additional input data
@@ -599,8 +595,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
     ssc_number_t expectedBatteryDischargeEnergy = 3254.;
 
     ssc_number_t peakKwCharge = -992.86;
-    //ssc_number_t peakKwDischarge = 946.98;
-    ssc_number_t peakKwDischarge = 941.19;// change analysis period from 25 to 2 for speedy_gonzales
+    ssc_number_t peakKwDischarge = 941.19;
 
     ssc_number_t peakCycles = 1;
     ssc_number_t avgCycles = 0.0027;
@@ -653,8 +648,7 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
     ssc_number_t peakKwCharge = -841.39;
     ssc_number_t peakKwDischarge = 652.0;
     ssc_number_t peakCycles = 3;
-    //ssc_number_t avgCycles = 1.1836;
-    ssc_number_t avgCycles = 1.1849;// change analysis period from 25 to 2 for speedy_gonzales
+    ssc_number_t avgCycles = 1.1849;
 
     ssc_data_set_number(data, "batt_dispatch_choice", 2);
     ssc_data_set_number(data, "batt_ac_or_dc", 0);
@@ -908,10 +902,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
 
         auto batt_q_rel = data_vtab->as_vector_ssc_number_t("batt_capacity_percent");
         auto batt_cyc_avg = data_vtab->as_vector_ssc_number_t("batt_DOD_cycle_average");
-        //EXPECT_NEAR(batt_q_rel.back(), 85.875, 2e-2);
-        EXPECT_NEAR(batt_q_rel.back(), 95.926, 2e-2); // change analysis period from 25 to 2 for speedy_gonzales
-        //EXPECT_NEAR(batt_cyc_avg.back(), 21.81, m_error_tolerance_lo);
-        EXPECT_NEAR(batt_cyc_avg.back(), 20.56, m_error_tolerance_lo);// change analysis period from 25 to 2 for speedy_gonzales
+        EXPECT_NEAR(batt_q_rel.back(), 95.926, 2e-2); 
+        EXPECT_NEAR(batt_cyc_avg.back(), 20.56, m_error_tolerance_lo);
     }
 
 }

--- a/test/ssc_test/cmod_battery_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_battery_pvsamv1_test.cpp
@@ -440,7 +440,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_singleowner)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-    EXPECT_NEAR(lcos_real, 23.41, 0.1);
+//    EXPECT_NEAR(lcos_real, 23.41, 0.1);
+    EXPECT_NEAR(lcos_real, 53.38, 0.1); // change analysis period from 25 to 2 for speedy_gonzales
 
 }
 
@@ -456,7 +457,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_levpartflip)
 
     ssc_number_t lcos_real;
     ssc_data_get_number(data, "lcos_real", &lcos_real);
-    EXPECT_NEAR(lcos_real, 23.43, 0.1);
+    //EXPECT_NEAR(lcos_real, 23.43, 0.1);
+    EXPECT_NEAR(lcos_real, 53.56, 0.1);  // change analysis period from 25 to 2 for speedy_gonzales
 }
 
 TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, LCOS_test_cashloan)
@@ -490,7 +492,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_ACBatteryModelIntegration)
     ssc_number_t peakKwCharge[3] = { -1040.2, -1051.5, -1051.5 };
     ssc_number_t peakKwDischarge[3] = { 967.5, 969.5, 969.5 };
     ssc_number_t peakCycles[3] = { 1, 1, 1 };
-    ssc_number_t avgCycles[3] = { 0.0039, 0.0042, 0.003 };
+//    ssc_number_t avgCycles[3] = { 0.0039, 0.0042, 0.003 };
+    ssc_number_t avgCycles[3] = { 0.0068, 0.0110, 0.003 };// change analysis period from 25 to 2 for speedy_gonzales
 
     ssc_data_set_number(data, "batt_dispatch_choice", 0);
     // Test economoic dispatch look ahead, economoic dispatch look behind. Others require additional input data
@@ -595,7 +598,9 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
     ssc_number_t expectedBatteryDischargeEnergy = 3254.;
 
     ssc_number_t peakKwCharge = -992.86;
-    ssc_number_t peakKwDischarge = 946.98;
+    //ssc_number_t peakKwDischarge = 946.98;
+    ssc_number_t peakKwDischarge = 941.19;// change analysis period from 25 to 2 for speedy_gonzales
+
     ssc_number_t peakCycles = 1;
     ssc_number_t avgCycles = 0.0027;
 
@@ -647,7 +652,8 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
     ssc_number_t peakKwCharge = -841.39;
     ssc_number_t peakKwDischarge = 652.0;
     ssc_number_t peakCycles = 3;
-    ssc_number_t avgCycles = 1.1836;
+    //ssc_number_t avgCycles = 1.1836;
+    ssc_number_t avgCycles = 1.1849;// change analysis period from 25 to 2 for speedy_gonzales
 
     ssc_data_set_number(data, "batt_dispatch_choice", 2);
     ssc_data_set_number(data, "batt_ac_or_dc", 0);
@@ -901,8 +907,10 @@ TEST_F(CMPvsamv1BatteryIntegration_cmod_pvsamv1, PPA_CustomDispatchBatteryModelD
 
         auto batt_q_rel = data_vtab->as_vector_ssc_number_t("batt_capacity_percent");
         auto batt_cyc_avg = data_vtab->as_vector_ssc_number_t("batt_DOD_cycle_average");
-        EXPECT_NEAR(batt_q_rel.back(), 85.875, 2e-2);
-        EXPECT_NEAR(batt_cyc_avg.back(), 21.81, m_error_tolerance_lo);
+        //EXPECT_NEAR(batt_q_rel.back(), 85.875, 2e-2);
+        EXPECT_NEAR(batt_q_rel.back(), 95.926, 2e-2); // change analysis period from 25 to 2 for speedy_gonzales
+        //EXPECT_NEAR(batt_cyc_avg.back(), 21.81, m_error_tolerance_lo);
+        EXPECT_NEAR(batt_cyc_avg.back(), 20.56, m_error_tolerance_lo);// change analysis period from 25 to 2 for speedy_gonzales
     }
 
 }

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -231,7 +231,7 @@ TEST_F(CmodCashLoanTest, EmpiricalTroughCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodCashLoanTest, FuelCellCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Fuel_Cell_Commercial_cmod_cashloan.json";
@@ -242,7 +242,7 @@ TEST_F(CmodCashLoanTest, FuelCellCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, GenericCSPCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_CSP_System_Commercial_cmod_cashloan.json";

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -76,7 +76,7 @@ TEST_F(CmodCashLoanTest, DiscountedPayback) {
 }
 
 
-/*
+
 TEST_F(CmodCashLoanTest, PVWattsResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Residential_cmod_cashloan.json";
@@ -109,7 +109,7 @@ TEST_F(CmodCashLoanTest, PVWattsBatteryResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, PVWattsBatteryCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Battery_Commercial_cmod_cashloan.json";
@@ -187,7 +187,7 @@ TEST_F(CmodCashLoanTest, CustomGenerationCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+
 TEST_F(CmodCashLoanTest, CustomGenerationBatteryResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_Battery_Residential_cmod_cashloan.json";
@@ -198,7 +198,7 @@ TEST_F(CmodCashLoanTest, CustomGenerationBatteryResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, CustomGenerationBatteryCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_Battery_Commercial_cmod_cashloan.json";
@@ -330,4 +330,5 @@ TEST_F(CmodCashLoanTest, WindCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
+
 */

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -131,7 +131,7 @@ TEST_F(CmodCashLoanTest, PVResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodCashLoanTest, PVCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Flat_Plate_PV_Commercial_cmod_cashloan.json";
@@ -142,7 +142,7 @@ TEST_F(CmodCashLoanTest, PVCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+
 
 TEST_F(CmodCashLoanTest, PVBatteryResidential) {
     std::string file_inputs = SSCDIR;

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -76,7 +76,7 @@ TEST_F(CmodCashLoanTest, DiscountedPayback) {
 }
 
 
-
+/*
 TEST_F(CmodCashLoanTest, PVWattsResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Residential_cmod_cashloan.json";
@@ -87,7 +87,7 @@ TEST_F(CmodCashLoanTest, PVWattsResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodCashLoanTest, PVWattsCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Commercial_cmod_cashloan.json";

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -121,6 +121,7 @@ TEST_F(CmodCashLoanTest, PVWattsBatteryCommercial) {
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
+/*
 TEST_F(CmodCashLoanTest, PVResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Flat_Plate_PV_Residential_cmod_cashloan.json";
@@ -330,4 +331,4 @@ TEST_F(CmodCashLoanTest, WindCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -76,7 +76,7 @@ TEST_F(CmodCashLoanTest, DiscountedPayback) {
 }
 
 
-
+/*
 TEST_F(CmodCashLoanTest, PVWattsResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Residential_cmod_cashloan.json";
@@ -121,7 +121,6 @@ TEST_F(CmodCashLoanTest, PVWattsBatteryCommercial) {
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
 TEST_F(CmodCashLoanTest, PVResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Flat_Plate_PV_Residential_cmod_cashloan.json";
@@ -143,7 +142,7 @@ TEST_F(CmodCashLoanTest, PVCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 
 TEST_F(CmodCashLoanTest, PVBatteryResidential) {
     std::string file_inputs = SSCDIR;
@@ -166,7 +165,7 @@ TEST_F(CmodCashLoanTest, PVBatteryCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, CustomGenerationResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_System_Residential_cmod_cashloan.json";

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -154,7 +154,7 @@ TEST_F(CmodCashLoanTest, PVBatteryResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, PVBatteryCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PV_Battery_Commercial_cmod_cashloan.json";
@@ -165,7 +165,7 @@ TEST_F(CmodCashLoanTest, PVBatteryCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+
 TEST_F(CmodCashLoanTest, CustomGenerationResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_System_Residential_cmod_cashloan.json";
@@ -176,7 +176,7 @@ TEST_F(CmodCashLoanTest, CustomGenerationResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodCashLoanTest, CustomGenerationCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_System_Commercial_cmod_cashloan.json";
@@ -187,7 +187,7 @@ TEST_F(CmodCashLoanTest, CustomGenerationCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, CustomGenerationBatteryResidential) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_Battery_Residential_cmod_cashloan.json";
@@ -242,7 +242,7 @@ TEST_F(CmodCashLoanTest, FuelCellCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+
 TEST_F(CmodCashLoanTest, GenericCSPCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_CSP_System_Commercial_cmod_cashloan.json";
@@ -253,7 +253,7 @@ TEST_F(CmodCashLoanTest, GenericCSPCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodCashLoanTest, MSLFCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_MSLF_Commercial_cmod_cashloan.json";

--- a/test/ssc_test/cmod_cashloan_test.cpp
+++ b/test/ssc_test/cmod_cashloan_test.cpp
@@ -76,18 +76,6 @@ TEST_F(CmodCashLoanTest, DiscountedPayback) {
 }
 
 
-/*
-TEST_F(CmodCashLoanTest, PVWattsResidential) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Residential_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Residential_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodCashLoanTest, PVWattsCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Commercial_cmod_cashloan.json";
@@ -109,29 +97,6 @@ TEST_F(CmodCashLoanTest, PVWattsBatteryResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodCashLoanTest, PVWattsBatteryCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Battery_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PVWatts_Battery_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, PVResidential) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Flat_Plate_PV_Residential_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Flat_Plate_PV_Residential_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodCashLoanTest, PVCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Flat_Plate_PV_Commercial_cmod_cashloan.json";
@@ -154,29 +119,6 @@ TEST_F(CmodCashLoanTest, PVBatteryResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodCashLoanTest, PVBatteryCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PV_Battery_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_PV_Battery_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, CustomGenerationResidential) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_System_Residential_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_System_Residential_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodCashLoanTest, CustomGenerationCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_System_Commercial_cmod_cashloan.json";
@@ -198,40 +140,6 @@ TEST_F(CmodCashLoanTest, CustomGenerationBatteryResidential) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodCashLoanTest, CustomGenerationBatteryCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_Battery_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Generic_Battery_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, DSLFCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_DSLF_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_DSLF_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, EmpiricalTroughCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Empirical_Trough_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Empirical_Trough_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodCashLoanTest, FuelCellCommercial) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Fuel_Cell_Commercial_cmod_cashloan.json";
@@ -253,82 +161,4 @@ TEST_F(CmodCashLoanTest, GenericCSPCommercial) {
 
     Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodCashLoanTest, MSLFCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_MSLF_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_MSLF_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
 
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, SWHResidential) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Solar_Water_Heating_Residential_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Solar_Water_Heating_Residential_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, SWHCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Solar_Water_Heating_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Solar_Water_Heating_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, StandaloneBatteryResidential) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Standalone_Battery_Residential_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Standalone_Battery_Residential_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, StandaloneBatteryCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Standalone_Battery_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Standalone_Battery_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, WindResidential) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Wind_Power_Residential_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Wind_Power_Residential_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodCashLoanTest, WindCommercial) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Wind_Power_Commercial_cmod_cashloan.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/cashloan/2022.08.08_develop_branch_Wind_Power_Commercial_cmod_cashloan_outputs.json";
-    std::vector<std::string> compare_number_variables = { "lcoe_nom", "npv", "payback" };
-    std::vector<std::string> compare_array_variables = { "cf_after_tax_cash_flow", "cf_value_added", "cf_after_tax_net_equity_cost_flow", "cf_parasitic_cost", "cf_util_escal_rate" };
-
-    Test("cashloan", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gtest/gtest.h"
 
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, Biopower) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Biopower_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -172,7 +172,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PhysicalTrough) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodAllEquityPartnershipFlipTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PV_Battery_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -184,7 +184,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PVBattery) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PVWatts_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -195,7 +195,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PVWatts) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodAllEquityPartnershipFlipTest, StandaloneBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Standalone_Battery_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -207,7 +207,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, StandaloneBattery) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, Wind) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Wind_Power_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -219,4 +219,4 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Wind) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -68,7 +68,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, EmpiricalTrough) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 
 TEST_F(CmodAllEquityPartnershipFlipTest, PV) {
     std::string file_inputs = SSCDIR;
@@ -80,7 +80,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PV) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+/*
 
 TEST_F(CmodAllEquityPartnershipFlipTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
@@ -92,7 +92,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, CustomGenerationBattery) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+*/
 TEST_F(CmodAllEquityPartnershipFlipTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Generic_CSP_System_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -115,7 +115,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, CustomGeneration) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-*/
+
 TEST_F(CmodAllEquityPartnershipFlipTest, Geotherrmal) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Geothermal_Power_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -150,7 +150,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, MSLF) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-*/
+
 TEST_F(CmodAllEquityPartnershipFlipTest, MSPT) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_MSPT_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -161,7 +161,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, MSPT) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+
 TEST_F(CmodAllEquityPartnershipFlipTest, PhysicalTrough) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Physical_Trough_All_Equity_Partnership_Flip_cmod_equpartflip.json";

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -150,6 +150,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, MSLF) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
+*/
 TEST_F(CmodAllEquityPartnershipFlipTest, MSPT) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_MSPT_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -160,7 +161,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, MSPT) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, PhysicalTrough) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Physical_Trough_All_Equity_Partnership_Flip_cmod_equpartflip.json";

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -207,7 +207,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, StandaloneBattery) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
+
 TEST_F(CmodAllEquityPartnershipFlipTest, Wind) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Wind_Power_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -219,4 +219,4 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Wind) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-*/
+

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -46,30 +46,6 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Biopower) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodAllEquityPartnershipFlipTest, DSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_DSLF_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_DSLF_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodAllEquityPartnershipFlipTest, EmpiricalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Empirical_Trough_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Empirical_Trough_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
-
 TEST_F(CmodAllEquityPartnershipFlipTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Flat_Plate_PV_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -80,19 +56,6 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PV) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-
-TEST_F(CmodAllEquityPartnershipFlipTest, CustomGenerationBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Generic_Battery_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Generic_Battery_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodAllEquityPartnershipFlipTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Generic_CSP_System_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -126,54 +89,6 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Geotherrmal) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodAllEquityPartnershipFlipTest, CPV) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodAllEquityPartnershipFlipTest, MSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_MSLF_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_MSLF_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodAllEquityPartnershipFlipTest, MSPT) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_MSPT_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_MSPT_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodAllEquityPartnershipFlipTest, PhysicalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Physical_Trough_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Physical_Trough_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodAllEquityPartnershipFlipTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PV_Battery_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -185,39 +100,4 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PVBattery) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodAllEquityPartnershipFlipTest, PVWatts) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PVWatts_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PVWatts_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodAllEquityPartnershipFlipTest, StandaloneBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Standalone_Battery_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Standalone_Battery_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodAllEquityPartnershipFlipTest, Wind) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Wind_Power_All_Equity_Partnership_Flip_cmod_equpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Wind_Power_All_Equity_Partnership_Flip_cmod_equpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -115,7 +115,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, CustomGeneration) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodAllEquityPartnershipFlipTest, Geotherrmal) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Geothermal_Power_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -126,7 +126,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Geotherrmal) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, CPV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -184,7 +184,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PVBattery) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
+
 TEST_F(CmodAllEquityPartnershipFlipTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PVWatts_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -195,7 +195,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PVWatts) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+
 TEST_F(CmodAllEquityPartnershipFlipTest, StandaloneBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Standalone_Battery_All_Equity_Partnership_Flip_cmod_equpartflip.json";

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -80,7 +80,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PV) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 
 TEST_F(CmodAllEquityPartnershipFlipTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
@@ -92,7 +92,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, CustomGenerationBattery) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Generic_CSP_System_All_Equity_Partnership_Flip_cmod_equpartflip.json";

--- a/test/ssc_test/cmod_equpartflip_test.cpp
+++ b/test/ssc_test/cmod_equpartflip_test.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gtest/gtest.h"
 
-/*
+
 TEST_F(CmodAllEquityPartnershipFlipTest, Biopower) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_Biopower_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -46,7 +46,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Biopower) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_DSLF_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -184,7 +184,7 @@ TEST_F(CmodAllEquityPartnershipFlipTest, PVBattery) {
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodAllEquityPartnershipFlipTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/equpartflip/2023.10.27_om-expense-cash-flow_PVWatts_All_Equity_Partnership_Flip_cmod_equpartflip.json";
@@ -218,5 +218,5 @@ TEST_F(CmodAllEquityPartnershipFlipTest, Wind) {
 
     Test("equpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 

--- a/test/ssc_test/cmod_etes_etes_test.cpp
+++ b/test/ssc_test/cmod_etes_etes_test.cpp
@@ -44,6 +44,7 @@ NAMESPACE_TEST(etes_etes_test, EtesEtesCmod, Default_NoFinancial)
 {
     ssc_data_t defaults = etes_etes_defaults();
     CmodUnderTest etes_system = CmodUnderTest("etes_electric_resistance", defaults);
+    /*
     etes_system.SetInput("is_dispatch", 0);
     int errors = etes_system.RunModule();
     double ann_energy = etes_system.GetOutput("annual_energy");
@@ -51,10 +52,10 @@ NAMESPACE_TEST(etes_etes_test, EtesEtesCmod, Default_NoFinancial)
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(etes_system.GetOutput("annual_energy")), std::abs(-739728801.), kErrorToleranceHi);
     }
-
+    */
     etes_system.SetInput("is_dispatch", 1);
-    errors = etes_system.RunModule();
-    ann_energy = etes_system.GetOutput("annual_energy");
+    int errors = etes_system.RunModule();
+    double ann_energy = etes_system.GetOutput("annual_energy");
     EXPECT_FALSE(errors);
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(etes_system.GetOutput("annual_energy")), std::abs(-497554825), kErrorToleranceHi);

--- a/test/ssc_test/cmod_etes_etes_test.cpp
+++ b/test/ssc_test/cmod_etes_etes_test.cpp
@@ -44,7 +44,7 @@ NAMESPACE_TEST(etes_etes_test, EtesEtesCmod, Default_NoFinancial)
 {
     ssc_data_t defaults = etes_etes_defaults();
     CmodUnderTest etes_system = CmodUnderTest("etes_electric_resistance", defaults);
-    /*
+
     etes_system.SetInput("is_dispatch", 0);
     int errors = etes_system.RunModule();
     double ann_energy = etes_system.GetOutput("annual_energy");
@@ -52,10 +52,10 @@ NAMESPACE_TEST(etes_etes_test, EtesEtesCmod, Default_NoFinancial)
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(etes_system.GetOutput("annual_energy")), std::abs(-739728801.), kErrorToleranceHi);
     }
-    */
+
     etes_system.SetInput("is_dispatch", 1);
-    int errors = etes_system.RunModule();
-    double ann_energy = etes_system.GetOutput("annual_energy");
+    errors = etes_system.RunModule();
+    ann_energy = etes_system.GetOutput("annual_energy");
     EXPECT_FALSE(errors);
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(etes_system.GetOutput("annual_energy")), std::abs(-497554825), kErrorToleranceHi);

--- a/test/ssc_test/cmod_etes_ptes_test.cpp
+++ b/test/ssc_test/cmod_etes_ptes_test.cpp
@@ -44,6 +44,7 @@ NAMESPACE_TEST(etes_ptes_test, EtesPtesCmod, Default_NoFinancial)
 {
     ssc_data_t defaults = etes_ptes_defaults();
     CmodUnderTest ptes_system = CmodUnderTest("etes_ptes", defaults);
+    /*
     ptes_system.SetInput("is_dispatch", 0);
     int errors = ptes_system.RunModule();
     double ann_energy = ptes_system.GetOutput("annual_energy");
@@ -51,10 +52,10 @@ NAMESPACE_TEST(etes_ptes_test, EtesPtesCmod, Default_NoFinancial)
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(ptes_system.GetOutput("annual_energy")), std::abs(264339255.), kErrorToleranceHi);
     }
-
+    */
     ptes_system.SetInput("is_dispatch", 1);
-    errors = ptes_system.RunModule();
-    ann_energy = ptes_system.GetOutput("annual_energy");
+    int errors = ptes_system.RunModule();
+    double ann_energy = ptes_system.GetOutput("annual_energy");
     EXPECT_FALSE(errors);
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(ptes_system.GetOutput("annual_energy")), std::abs(202929176.), kErrorToleranceHi);

--- a/test/ssc_test/cmod_etes_ptes_test.cpp
+++ b/test/ssc_test/cmod_etes_ptes_test.cpp
@@ -44,7 +44,7 @@ NAMESPACE_TEST(etes_ptes_test, EtesPtesCmod, Default_NoFinancial)
 {
     ssc_data_t defaults = etes_ptes_defaults();
     CmodUnderTest ptes_system = CmodUnderTest("etes_ptes", defaults);
-    /*
+    
     ptes_system.SetInput("is_dispatch", 0);
     int errors = ptes_system.RunModule();
     double ann_energy = ptes_system.GetOutput("annual_energy");
@@ -52,13 +52,11 @@ NAMESPACE_TEST(etes_ptes_test, EtesPtesCmod, Default_NoFinancial)
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(ptes_system.GetOutput("annual_energy")), std::abs(264339255.), kErrorToleranceHi);
     }
-    */
     ptes_system.SetInput("is_dispatch", 1);
-    int errors = ptes_system.RunModule();
-    double ann_energy = ptes_system.GetOutput("annual_energy");
+    errors = ptes_system.RunModule();
+    ann_energy = ptes_system.GetOutput("annual_energy");
     EXPECT_FALSE(errors);
     if (!errors) {
         EXPECT_NEAR_FRAC(std::abs(ptes_system.GetOutput("annual_energy")), std::abs(202929176.), kErrorToleranceHi);
     }
-
 }

--- a/test/ssc_test/cmod_geothermal_test.cpp
+++ b/test/ssc_test/cmod_geothermal_test.cpp
@@ -47,8 +47,7 @@ TEST_F(CMGeothermal, SingleOwnerDefault_cmod_geothermal) {
 		ssc_number_t annual_energy, eff_secondlaw;
 		ssc_data_get_number(data, "annual_energy", &annual_energy);
 		ssc_data_get_number(data, "eff_secondlaw", &eff_secondlaw);
-        //EXPECT_NEAR(annual_energy, 261301614.984375, 0.1);
-        EXPECT_NEAR(annual_energy, 233130329.8425, 0.1); // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(annual_energy, 261301614.984375, 0.1);
         EXPECT_GE(eff_secondlaw, 0);
 	}
 

--- a/test/ssc_test/cmod_geothermal_test.cpp
+++ b/test/ssc_test/cmod_geothermal_test.cpp
@@ -47,8 +47,9 @@ TEST_F(CMGeothermal, SingleOwnerDefault_cmod_geothermal) {
 		ssc_number_t annual_energy, eff_secondlaw;
 		ssc_data_get_number(data, "annual_energy", &annual_energy);
 		ssc_data_get_number(data, "eff_secondlaw", &eff_secondlaw);
-		EXPECT_NEAR(annual_energy, 261301614.984375, 0.1);
-		EXPECT_GE(eff_secondlaw, 0);
+        //EXPECT_NEAR(annual_energy, 261301614.984375, 0.1);
+        EXPECT_NEAR(annual_energy, 233130329.8425, 0.1); // Speedy Gonzales 25yr to 2yr
+        EXPECT_GE(eff_secondlaw, 0);
 	}
 
 }

--- a/test/ssc_test/cmod_host_developer_test.cpp
+++ b/test/ssc_test/cmod_host_developer_test.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cmod_host_developer_test.h"
 
-
+/*
 TEST_F(CmodHostDeveloperTest, ssc_1047) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/host_developer/Default_HD_10_IBI_PVWatts_Host_Developer_cmod_host_developer.json";
@@ -46,7 +46,7 @@ TEST_F(CmodHostDeveloperTest, ssc_1047) {
 
     Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodHostDeveloperTest, sam_1477) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/host_developer/Default_HD_10_IBI_no_tax_reduce_basis_PVWatts_Host_Developer_cmod_host_developer.json";
@@ -101,6 +101,7 @@ TEST_F(CmodHostDeveloperTest, sam_1477_cbi_no_tax_reduce_basis) {
 
     Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
+
 
 TEST_F(CmodHostDeveloperTest, PVWatts) {
     std::string file_inputs = SSCDIR;
@@ -158,7 +159,7 @@ TEST_F(CmodHostDeveloperTest, CustomGeneration) {
 
     Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 
 TEST_F(CmodHostDeveloperTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
@@ -184,3 +185,4 @@ TEST_F(CmodHostDeveloperTest, StandaloneBattery) {
     Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
+*/

--- a/test/ssc_test/cmod_host_developer_test.cpp
+++ b/test/ssc_test/cmod_host_developer_test.cpp
@@ -35,18 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cmod_host_developer_test.h"
 
-/*
-TEST_F(CmodHostDeveloperTest, ssc_1047) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/host_developer/Default_HD_10_IBI_PVWatts_Host_Developer_cmod_host_developer.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/host_developer/Default_HD_10_IBI_PVWatts_Host_Developer_cmod_host_developer_outputs.json";
-    std::vector<std::string> compare_number_variables = { "project_return_aftertax_npv", "npv", "lnte_nom", "pre_depr_alloc_basis", "pre_itc_qual_basis"};
-    std::vector<std::string> compare_array_variables = { "CF_ppa_price" };
-
-    Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodHostDeveloperTest, sam_1477) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/host_developer/Default_HD_10_IBI_no_tax_reduce_basis_PVWatts_Host_Developer_cmod_host_developer.json";
@@ -159,30 +147,3 @@ TEST_F(CmodHostDeveloperTest, CustomGeneration) {
 
     Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-
-TEST_F(CmodHostDeveloperTest, CustomGenerationBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/host_developer/2023.10.27_om-expense-cash-flow_Generic_Battery_Host_Developer_cmod_host_developer.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/host_developer/2023.10.27_om-expense-cash-flow_Generic_Battery_Host_Developer_cmod_host_developer_outputs.json";
-    std::vector<std::string> compare_number_variables = { "project_return_aftertax_npv", "npv", "lnte_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_project_return_aftertax_npv" };
-
-    Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-
-TEST_F(CmodHostDeveloperTest, StandaloneBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/host_developer/2023.10.27_om-expense-cash-flow_Standalone_Battery_Host_Developer_cmod_host_developer.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/host_developer/2023.10.27_om-expense-cash-flow_Standalone_Battery_Host_Developer_cmod_host_developer_outputs.json";
-    std::vector<std::string> compare_number_variables = { "project_return_aftertax_npv", "npv", "lnte_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_project_return_aftertax_npv" };
-
-    Test("host_developer", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/

--- a/test/ssc_test/cmod_lcoefcr_test.cpp
+++ b/test/ssc_test/cmod_lcoefcr_test.cpp
@@ -46,7 +46,7 @@ TEST_F(CmodLCOEFCRTest, Biopower) {
     
     Test("lcoefcr", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodLCOEFCRTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/lcoefcr/2022.08.08_develop_branch_DSLF_LCOE_Calculator_cmod_lcoefcr.json";
@@ -68,7 +68,7 @@ TEST_F(CmodLCOEFCRTest, EmpiricalTrough) {
 
     Test("lcoefcr", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodLCOEFCRTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/lcoefcr/2022.08.08_develop_branch_Flat_Plate_PV_LCOE_Calculator_cmod_lcoefcr.json";
@@ -114,7 +114,7 @@ TEST_F(CmodLCOEFCRTest, Geotherrmal) {
 
     Test("lcoefcr", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodLCOEFCRTest, CPV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/lcoefcr/2022.08.08_develop_branch_High-X_Concentrating_PV_LCOE_Calculator_cmod_lcoefcr.json";
@@ -217,7 +217,7 @@ TEST_F(CmodLCOEFCRTest, DSGL_IPH_LCOH) {
     Test("lcoefcr", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodLCOEFCRTest, PhysicalTrough_IPH_LCOH) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/lcoefcr/2022.08.08_develop_branch_Physical_Trough_IPH_LCOH_Calculator_cmod_lcoefcr.json";

--- a/test/ssc_test/cmod_levpartflip_test.cpp
+++ b/test/ssc_test/cmod_levpartflip_test.cpp
@@ -46,30 +46,6 @@ TEST_F(CmodLeveragedPartnershipFlipTest, Biopower) {
 
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodLeveragedPartnershipFlipTest, DSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_DSLF_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_DSLF_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodLeveragedPartnershipFlipTest, EmpiricalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Empirical_Trough_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Empirical_Trough_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodLeveragedPartnershipFlipTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Flat_Plate_PV_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -81,18 +57,6 @@ TEST_F(CmodLeveragedPartnershipFlipTest, PV) {
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodLeveragedPartnershipFlipTest, CustomGenerationBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Generic_Battery_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Generic_Battery_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodLeveragedPartnershipFlipTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Generic_CSP_System_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -126,52 +90,6 @@ TEST_F(CmodLeveragedPartnershipFlipTest, Geotherrmal) {
 
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodLeveragedPartnershipFlipTest, CPV) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodLeveragedPartnershipFlipTest, MSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_MSLF_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_MSLF_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodLeveragedPartnershipFlipTest, MSPT) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_MSPT_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_MSPT_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodLeveragedPartnershipFlipTest, PhysicalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Physical_Trough_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Physical_Trough_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 
 TEST_F(CmodLeveragedPartnershipFlipTest, PVBattery) {
     std::string file_inputs = SSCDIR;
@@ -184,39 +102,3 @@ TEST_F(CmodLeveragedPartnershipFlipTest, PVBattery) {
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodLeveragedPartnershipFlipTest, PVWatts) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_PVWatts_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_PVWatts_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodLeveragedPartnershipFlipTest, StandaloneBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Standalone_Battery_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Standalone_Battery_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodLeveragedPartnershipFlipTest, Wind) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Wind_Power_Leveraged_Partnership_Flip_cmod_levpartflip.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Wind_Power_Leveraged_Partnership_Flip_cmod_levpartflip_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/

--- a/test/ssc_test/cmod_levpartflip_test.cpp
+++ b/test/ssc_test/cmod_levpartflip_test.cpp
@@ -46,7 +46,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, Biopower) {
 
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodLeveragedPartnershipFlipTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_DSLF_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -69,7 +69,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, EmpiricalTrough) {
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodLeveragedPartnershipFlipTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Flat_Plate_PV_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -81,7 +81,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, PV) {
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodLeveragedPartnershipFlipTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Generic_Battery_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -92,7 +92,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, CustomGenerationBattery) {
 
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodLeveragedPartnershipFlipTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_Generic_CSP_System_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -126,7 +126,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, Geotherrmal) {
 
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodLeveragedPartnershipFlipTest, CPV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -171,7 +171,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, PhysicalTrough) {
 
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 
 TEST_F(CmodLeveragedPartnershipFlipTest, PVBattery) {
     std::string file_inputs = SSCDIR;
@@ -184,7 +184,7 @@ TEST_F(CmodLeveragedPartnershipFlipTest, PVBattery) {
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodLeveragedPartnershipFlipTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/levpartflip/2023.10.27_om-expense-cash-flow_PVWatts_Leveraged_Partnership_Flip_cmod_levpartflip.json";
@@ -219,4 +219,4 @@ TEST_F(CmodLeveragedPartnershipFlipTest, Wind) {
     Test("levpartflip", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/

--- a/test/ssc_test/cmod_merchantplant_test.cpp
+++ b/test/ssc_test/cmod_merchantplant_test.cpp
@@ -46,30 +46,6 @@ TEST_F(CmodMerchantPlantTest, Biopower) {
 
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodMerchantPlantTest, DSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_DSLF_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_DSLF_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodMerchantPlantTest, EmpiricalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Empirical_Trough_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Empirical_Trough_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodMerchantPlantTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Flat_Plate_PV_Merchant_Plant_cmod_merchantplant.json";
@@ -81,18 +57,6 @@ TEST_F(CmodMerchantPlantTest, PV) {
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodMerchantPlantTest, CustomGenerationBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Generic_Battery_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Generic_Battery_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodMerchantPlantTest, CustomGenerationBattery_LCOS) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.10.21_develop_branch_Generic_Battery_Merchant_Plant_cmod_merchantplant.json";
@@ -137,53 +101,6 @@ TEST_F(CmodMerchantPlantTest, Geotherrmal) {
 
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodMerchantPlantTest, CPV) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_High-X_Concentrating_PV_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_High-X_Concentrating_PV_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodMerchantPlantTest, MSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_MSLF_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_MSLF_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodMerchantPlantTest, MSPT) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_MSPT_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_MSPT_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodMerchantPlantTest, PhysicalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Physical_Trough_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Physical_Trough_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodMerchantPlantTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_PV_Battery_Merchant_Plant_cmod_merchantplant.json";
@@ -195,40 +112,3 @@ TEST_F(CmodMerchantPlantTest, PVBattery) {
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodMerchantPlantTest, PVWatts) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_PVWatts_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_PVWatts_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodMerchantPlantTest, StandaloneBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Standalone_Battery_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Standalone_Battery_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodMerchantPlantTest, Wind) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Wind_Power_Merchant_Plant_cmod_merchantplant.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Wind_Power_Merchant_Plant_cmod_merchantplant_outputs.json";
-    std::vector<std::string> compare_number_variables = { "npv_curtailment_revenue", "npv_capacity_revenue", "npv_energy_market_revenue", "npv_ancillary_services_1_revenue", "npv_ancillary_services_2_revenue", "npv_ancillary_services_3_revenue", "npv_ancillary_services_4_revenue"};
-    std::vector<std::string> compare_array_variables = {"mp_energy_market_generated_revenue", "mp_ancillary_services1_generated_revenue", "mp_ancillary_services2_generated_revenue", "mp_ancillary_services3_generated_revenue", "mp_ancillary_services4_generated_revenue"};
-
-    Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-*/

--- a/test/ssc_test/cmod_merchantplant_test.cpp
+++ b/test/ssc_test/cmod_merchantplant_test.cpp
@@ -46,7 +46,7 @@ TEST_F(CmodMerchantPlantTest, Biopower) {
 
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodMerchantPlantTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_DSLF_Merchant_Plant_cmod_merchantplant.json";
@@ -69,7 +69,7 @@ TEST_F(CmodMerchantPlantTest, EmpiricalTrough) {
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodMerchantPlantTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Flat_Plate_PV_Merchant_Plant_cmod_merchantplant.json";
@@ -81,7 +81,7 @@ TEST_F(CmodMerchantPlantTest, PV) {
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodMerchantPlantTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_Generic_Battery_Merchant_Plant_cmod_merchantplant.json";
@@ -92,7 +92,7 @@ TEST_F(CmodMerchantPlantTest, CustomGenerationBattery) {
 
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodMerchantPlantTest, CustomGenerationBattery_LCOS) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.10.21_develop_branch_Generic_Battery_Merchant_Plant_cmod_merchantplant.json";
@@ -137,7 +137,7 @@ TEST_F(CmodMerchantPlantTest, Geotherrmal) {
 
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodMerchantPlantTest, CPV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_High-X_Concentrating_PV_Merchant_Plant_cmod_merchantplant.json";
@@ -183,7 +183,7 @@ TEST_F(CmodMerchantPlantTest, PhysicalTrough) {
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodMerchantPlantTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_PV_Battery_Merchant_Plant_cmod_merchantplant.json";
@@ -195,7 +195,7 @@ TEST_F(CmodMerchantPlantTest, PVBattery) {
     Test("merchantplant", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodMerchantPlantTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/merchantplant/2022.08.08_develop_branch_PVWatts_Merchant_Plant_cmod_merchantplant.json";
@@ -231,3 +231,4 @@ TEST_F(CmodMerchantPlantTest, Wind) {
 }
 
 
+*/

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -145,11 +145,13 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
 
         ssc_number_t lcoe_nom;
         ssc_data_get_number(data, "lcoe_nom", &lcoe_nom);
-        EXPECT_NEAR(lcoe_nom, 7.03, m_error_tolerance_lo) << "Levelized COE (nominal)";
+//        EXPECT_NEAR(lcoe_nom, 7.03, m_error_tolerance_lo) << "Levelized COE (nominal)";
+        EXPECT_NEAR(lcoe_nom, 33.48, m_error_tolerance_lo) << "Levelized COE (nominal)"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t lcoe_real;
         ssc_data_get_number(data, "lcoe_real", &lcoe_real);
-        EXPECT_NEAR(lcoe_real, 5.65, m_error_tolerance_lo) << "Levelized COE (real)";
+//        EXPECT_NEAR(lcoe_real, 5.65, m_error_tolerance_lo) << "Levelized COE (real)";
+        EXPECT_NEAR(lcoe_real, 31.15, m_error_tolerance_lo) << "Levelized COE (real)"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t utility_bill_wo_sys_year1;
         ssc_data_get_number(data, "utility_bill_wo_sys_year1", &utility_bill_wo_sys_year1);
@@ -165,11 +167,13 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
 
         ssc_number_t npv;
         ssc_data_get_number(data, "npv", &npv);
-        EXPECT_NEAR(npv, 4691.1, m_error_tolerance_hi) << "Net present value";
+//        EXPECT_NEAR(npv, 4691.1, m_error_tolerance_hi) << "Net present value";
+        EXPECT_NEAR(npv, 5685.3, m_error_tolerance_hi) << "Net present value";
 
         ssc_number_t payback;
         ssc_data_get_number(data, "payback", &payback);
-        EXPECT_NEAR(payback, 11.8, m_error_tolerance_lo) << "Payback period";
+//        EXPECT_NEAR(payback, 11.8, m_error_tolerance_lo) << "Payback period";
+        EXPECT_TRUE(std::isnan(payback)) << "Payback period"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t discounted_payback;
         ssc_data_get_number(data, "discounted_payback", &discounted_payback);

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -146,12 +146,12 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
         ssc_number_t lcoe_nom;
         ssc_data_get_number(data, "lcoe_nom", &lcoe_nom);
 //        EXPECT_NEAR(lcoe_nom, 7.03, m_error_tolerance_lo) << "Levelized COE (nominal)";
-        EXPECT_NEAR(lcoe_nom, -26.45, m_error_tolerance_lo) << "Levelized COE (nominal)"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(lcoe_nom, 12.05, m_error_tolerance_lo) << "Levelized COE (nominal)"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t lcoe_real;
         ssc_data_get_number(data, "lcoe_real", &lcoe_real);
 //        EXPECT_NEAR(lcoe_real, 5.65, m_error_tolerance_lo) << "Levelized COE (real)";
-        EXPECT_NEAR(lcoe_real, -25.50, m_error_tolerance_lo) << "Levelized COE (real)"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(lcoe_real, 11.61, m_error_tolerance_lo) << "Levelized COE (real)"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t utility_bill_wo_sys_year1;
         ssc_data_get_number(data, "utility_bill_wo_sys_year1", &utility_bill_wo_sys_year1);
@@ -168,7 +168,8 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
         ssc_number_t npv;
         ssc_data_get_number(data, "npv", &npv);
 //        EXPECT_NEAR(npv, 4691.1, m_error_tolerance_hi) << "Net present value";
-        EXPECT_NEAR(npv, 5685.3, m_error_tolerance_hi) << "Net present value";
+//        EXPECT_NEAR(npv, 5685.3, m_error_tolerance_hi) << "Net present value";
+        EXPECT_NEAR(npv, -358.2, m_error_tolerance_hi) << "Net present value";
 
         ssc_number_t payback;
         ssc_data_get_number(data, "payback", &payback);

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -670,7 +670,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NoFinancialModelSystemDesign)
                                 192329, 187710, 185732, 197565, 201021, 192329, 187710
     };
 
-    for (size_t i = 0; i < annual_energy_expected.size(); i+=15)
+    for (size_t i = 57; i < annual_energy_expected.size(); i++)
     {
         pairs["enable_mismatch_vmax_calc"] = enable_mismatch[i];
         pairs["subarray1_azimuth"] = subarray1_azimuth[i];

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -671,7 +671,8 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NoFinancialModelSystemDesign)
                                 192329, 187710, 185732, 197565, 201021, 192329, 187710
     };
 
-    for (size_t i = 57; i < annual_energy_expected.size(); i++)
+    //for (size_t i = 0; i < annual_energy_expected.size(); i++)
+    size_t i = 13;
     {
         pairs["enable_mismatch_vmax_calc"] = enable_mismatch[i];
         pairs["subarray1_azimuth"] = subarray1_azimuth[i];

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -146,12 +146,12 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
         ssc_number_t lcoe_nom;
         ssc_data_get_number(data, "lcoe_nom", &lcoe_nom);
 //        EXPECT_NEAR(lcoe_nom, 7.03, m_error_tolerance_lo) << "Levelized COE (nominal)";
-        EXPECT_NEAR(lcoe_nom, 33.48, m_error_tolerance_lo) << "Levelized COE (nominal)"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(lcoe_nom, -26.45, m_error_tolerance_lo) << "Levelized COE (nominal)"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t lcoe_real;
         ssc_data_get_number(data, "lcoe_real", &lcoe_real);
 //        EXPECT_NEAR(lcoe_real, 5.65, m_error_tolerance_lo) << "Levelized COE (real)";
-        EXPECT_NEAR(lcoe_real, 31.15, m_error_tolerance_lo) << "Levelized COE (real)"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(lcoe_real, -25.50, m_error_tolerance_lo) << "Levelized COE (real)"; // Speedy Gonzales 25yr to 2yr
 
         ssc_number_t utility_bill_wo_sys_year1;
         ssc_data_get_number(data, "utility_bill_wo_sys_year1", &utility_bill_wo_sys_year1);

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -145,13 +145,11 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
 
         ssc_number_t lcoe_nom;
         ssc_data_get_number(data, "lcoe_nom", &lcoe_nom);
-//        EXPECT_NEAR(lcoe_nom, 7.03, m_error_tolerance_lo) << "Levelized COE (nominal)";
-        EXPECT_NEAR(lcoe_nom, 12.05, m_error_tolerance_lo) << "Levelized COE (nominal)"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(lcoe_nom, 12.05, m_error_tolerance_lo) << "Levelized COE (nominal)";
 
         ssc_number_t lcoe_real;
         ssc_data_get_number(data, "lcoe_real", &lcoe_real);
-//        EXPECT_NEAR(lcoe_real, 5.65, m_error_tolerance_lo) << "Levelized COE (real)";
-        EXPECT_NEAR(lcoe_real, 11.61, m_error_tolerance_lo) << "Levelized COE (real)"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_NEAR(lcoe_real, 11.61, m_error_tolerance_lo) << "Levelized COE (real)";
 
         ssc_number_t utility_bill_wo_sys_year1;
         ssc_data_get_number(data, "utility_bill_wo_sys_year1", &utility_bill_wo_sys_year1);
@@ -167,19 +165,15 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, DefaultResidentialModel)
 
         ssc_number_t npv;
         ssc_data_get_number(data, "npv", &npv);
-//        EXPECT_NEAR(npv, 4691.1, m_error_tolerance_hi) << "Net present value";
-//        EXPECT_NEAR(npv, 5685.3, m_error_tolerance_hi) << "Net present value";
         EXPECT_NEAR(npv, -358.2, m_error_tolerance_hi) << "Net present value";
 
         ssc_number_t payback;
         ssc_data_get_number(data, "payback", &payback);
-//        EXPECT_NEAR(payback, 11.8, m_error_tolerance_lo) << "Payback period";
-        EXPECT_TRUE(std::isnan(payback)) << "Payback period"; // Speedy Gonzales 25yr to 2yr
+        EXPECT_TRUE(std::isnan(payback)) << "Payback period"; 
 
         ssc_number_t discounted_payback;
         ssc_data_get_number(data, "discounted_payback", &discounted_payback);
         EXPECT_TRUE(std::isnan(discounted_payback)); // ssc issue 616 - discounted to year 0 instead of year 1, so discounted payback is greater than the analysis period (=NaN)
-//        EXPECT_NEAR(discounted_payback, 22.9, m_error_tolerance_lo) << "Discounted payback period";
 
         ssc_number_t adjusted_installed_cost;
         ssc_data_get_number(data, "adjusted_installed_cost", &adjusted_installed_cost);
@@ -642,68 +636,58 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NoFinancialModelSystemDesign)
     pairs["subarray4_nstrings"] = 10;
 
     annual_energy_expected.clear();
-    std::vector<double> subarray1_azimuth = { 0, 90, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180 };
-    std::vector<double> subarray2_azimuth = { 180, 180, 180, 0, 90, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180 };
-    std::vector<double> subarray3_azimuth = { 180, 180, 180, 180, 180, 180, 0, 90, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180 };
-    std::vector<double> subarray4_azimuth = { 180, 180, 180, 180, 180, 180, 180, 180, 180, 0, 90, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180, 180 };
-    std::vector<double> enable_mismatch = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    std::vector<double> subarray1_gcr = { 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.1, 0.5, 0.9, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3 };
-    std::vector<double> subarray2_gcr = { 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.1, 0.5, 0.9, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3 };
-    std::vector<double> subarray3_gcr = { 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.1, 0.5, 0.9, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3 };
-    std::vector<double> subarray4_gcr = { 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.1, 0.5, 0.9, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3 };
-    std::vector<double> subarray1_tilt = { 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 0, 45, 90, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20 };
-    std::vector<double> subarray2_tilt = { 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 0, 45, 90, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20 };
-    std::vector<double> subarray3_tilt = { 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 0, 45, 90, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20 };
-    std::vector<double> subarray4_tilt = { 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 0, 45, 90, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20 };
-    std::vector<double> subarray1_rotlim = { 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45 };
-    std::vector<double> subarray2_rotlim = { 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45 };
-    std::vector<double> subarray3_rotlim = { 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45 };
-    std::vector<double> subarray4_rotlim = { 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45 };
-    std::vector<double> subarray1_track_mode = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    std::vector<double> subarray2_track_mode = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    std::vector<double> subarray3_track_mode = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0 };
-    std::vector<double> subarray4_track_mode = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4 };
-    annual_energy_expected = { 170200, 178903, 185731, 169082, 178410, 185732, 174671, 180870, 185732, 174671, 180870,
-                                185732, 185732, 185723, 185732, 185732, 185732, 185732, 185732, 185732, 185732, 185732,
-                                185732, 185732, 185732, 185732, 179998, 185393, 165140, 179585, 185367, 163658, 181646,
-                                185497, 171063, 181646, 185497, 171062, 185732, 185732, 185732, 185732, 185732, 200809,
-                                207121, 194966, 188497, 185732, 203475, 208645, 195625, 188694, 185732, 197566, 201020,
-                                192329, 187710, 185732, 197565, 201021, 192329, 187710
-    };
+    double subarray1_azimuth = 180;
+    double subarray2_azimuth = 180;
+    double subarray3_azimuth = 180;
+    double subarray4_azimuth = 180;
+    double enable_mismatch = 1;
+    double subarray1_gcr = 0.3;
+    double subarray2_gcr = 0.3;
+    double subarray3_gcr = 0.3;
+    double subarray4_gcr = 0.3;
+    double subarray1_tilt = 20;
+    double subarray2_tilt = 20;
+    double subarray3_tilt = 20;
+    double subarray4_tilt = 20;
+    double subarray1_rotlim = 45;
+    double subarray2_rotlim = 45;
+    double subarray3_rotlim = 45;
+    double subarray4_rotlim = 45;
+    double subarray1_track_mode = 0;
+    double subarray2_track_mode = 0;
+    double subarray3_track_mode = 0;
+    double subarray4_track_mode = 0;
+    annual_energy_expected = { 185723 };
 
-    //for (size_t i = 0; i < annual_energy_expected.size(); i++)
-    size_t i = 13;
+    pairs["enable_mismatch_vmax_calc"] = enable_mismatch;
+    pairs["subarray1_azimuth"] = subarray1_azimuth;
+    pairs["subarray2_azimuth"] = subarray2_azimuth;
+    pairs["subarray3_azimuth"] = subarray3_azimuth;
+    pairs["subarray4_azimuth"] = subarray4_azimuth;
+    pairs["subarray1_gcr"] = subarray1_gcr;
+    pairs["subarray2_gcr"] = subarray2_gcr;
+    pairs["subarray3_gcr"] = subarray3_gcr;
+    pairs["subarray4_gcr"] = subarray4_gcr;
+    pairs["subarray2_tilt"] = subarray2_tilt;
+    pairs["subarray3_tilt"] = subarray3_tilt;
+    pairs["subarray1_tilt"] = subarray1_tilt;
+    pairs["subarray4_tilt"] = subarray4_tilt;
+    pairs["subarray1_rotlim"] = subarray1_rotlim;
+    pairs["subarray2_rotlim"] = subarray2_rotlim;
+    pairs["subarray3_rotlim"] = subarray3_rotlim;
+    pairs["subarray4_rotlim"] = subarray4_rotlim;
+    pairs["subarray1_track_mode"] = subarray1_track_mode;
+    pairs["subarray2_track_mode"] = subarray2_track_mode;
+    pairs["subarray3_track_mode"] = subarray3_track_mode;
+    pairs["subarray4_track_mode"] = subarray4_track_mode;
+
+    pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
+    EXPECT_FALSE(pvsam_errors);
+    if (!pvsam_errors)
     {
-        pairs["enable_mismatch_vmax_calc"] = enable_mismatch[i];
-        pairs["subarray1_azimuth"] = subarray1_azimuth[i];
-        pairs["subarray2_azimuth"] = subarray2_azimuth[i];
-        pairs["subarray3_azimuth"] = subarray3_azimuth[i];
-        pairs["subarray4_azimuth"] = subarray4_azimuth[i];
-        pairs["subarray1_gcr"] = subarray1_gcr[i];
-        pairs["subarray2_gcr"] = subarray2_gcr[i];
-        pairs["subarray3_gcr"] = subarray3_gcr[i];
-        pairs["subarray4_gcr"] = subarray4_gcr[i];
-        pairs["subarray1_tilt"] = subarray1_tilt[i];
-        pairs["subarray2_tilt"] = subarray2_tilt[i];
-        pairs["subarray3_tilt"] = subarray3_tilt[i];
-        pairs["subarray4_tilt"] = subarray4_tilt[i];
-        pairs["subarray1_rotlim"] = subarray1_rotlim[i];
-        pairs["subarray2_rotlim"] = subarray2_rotlim[i];
-        pairs["subarray3_rotlim"] = subarray3_rotlim[i];
-        pairs["subarray4_rotlim"] = subarray4_rotlim[i];
-        pairs["subarray1_track_mode"] = subarray1_track_mode[i];
-        pairs["subarray2_track_mode"] = subarray2_track_mode[i];
-        pairs["subarray3_track_mode"] = subarray3_track_mode[i];
-        pairs["subarray4_track_mode"] = subarray4_track_mode[i];
-
-        pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
-        EXPECT_FALSE(pvsam_errors);
-        if (!pvsam_errors)
-        {
-            ssc_number_t annual_energy;
-            ssc_data_get_number(data, "annual_energy", &annual_energy);
-            EXPECT_NEAR(annual_energy, annual_energy_expected[i], m_error_tolerance_hi) << "Index: " << i;
-        }
+        ssc_number_t annual_energy;
+        ssc_data_get_number(data, "annual_energy", &annual_energy);
+        EXPECT_NEAR(annual_energy, annual_energy_expected[0], m_error_tolerance_hi) << "Index: " << 0;
     }
 }
 

--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -604,7 +604,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NoFinancialModelSystemDesign)
 
     std::vector<double> annual_energy_expected = { 185732, 243325, 259072, 217960, 195177 };
 
-    for (int tracking_option = 0; tracking_option != 5; tracking_option++)
+    for (int tracking_option = 0; tracking_option < 5; tracking_option++)
     {
         // update tracking option
         pairs["subarray1_track_mode"] = (double)tracking_option;
@@ -670,7 +670,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NoFinancialModelSystemDesign)
                                 192329, 187710, 185732, 197565, 201021, 192329, 187710
     };
 
-    for (size_t i = 0; i != annual_energy_expected.size(); i++)
+    for (size_t i = 0; i < annual_energy_expected.size(); i+=15)
     {
         pairs["enable_mismatch_vmax_calc"] = enable_mismatch[i];
         pairs["subarray1_azimuth"] = subarray1_azimuth[i];

--- a/test/ssc_test/cmod_pvwattsv8_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv8_test.cpp
@@ -43,8 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_F(CMPvwattsv8Integration_cmod_pvwattsv8, DefaultSetup) {
 //    compute();
-    //ssc_data_set_number(data, "analysis_period", 25);
-    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+    ssc_data_set_number(data, "analysis_period", 2);
 
 }
 

--- a/test/ssc_test/cmod_pvwattsv8_test.cpp
+++ b/test/ssc_test/cmod_pvwattsv8_test.cpp
@@ -43,7 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_F(CMPvwattsv8Integration_cmod_pvwattsv8, DefaultSetup) {
 //    compute();
-    ssc_data_set_number(data, "analysis_period", 25);
+    //ssc_data_set_number(data, "analysis_period", 25);
+    ssc_data_set_number(data, "analysis_period", 2); // Speedy Gonzales 
+
 }
 
 ///Default PVWattsv8, but with TMY2 instead of TMY3

--- a/test/ssc_test/cmod_saleleaseback_test.cpp
+++ b/test/ssc_test/cmod_saleleaseback_test.cpp
@@ -46,30 +46,6 @@ TEST_F(CmodSaleLeasebackTest, Biopower) {
 
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodSaleLeasebackTest, DSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_DSLF_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_DSLF_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSaleLeasebackTest, EmpiricalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Empirical_Trough_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Empirical_Trough_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodSaleLeasebackTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Flat_Plate_PV_Sale_Leaseback_cmod_saleleaseback.json";
@@ -81,18 +57,6 @@ TEST_F(CmodSaleLeasebackTest, PV) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodSaleLeasebackTest, CustomGenerationBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Generic_Battery_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Generic_Battery_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodSaleLeasebackTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Generic_CSP_System_Sale_Leaseback_cmod_saleleaseback.json";
@@ -126,53 +90,6 @@ TEST_F(CmodSaleLeasebackTest, Geotherrmal) {
 
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodSaleLeasebackTest, CPV) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodSaleLeasebackTest, MSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_MSLF_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_MSLF_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSaleLeasebackTest, MSPT) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_MSPT_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_MSPT_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSaleLeasebackTest, PhysicalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Physical_Trough_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Physical_Trough_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodSaleLeasebackTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_PV_Battery_Sale_Leaseback_cmod_saleleaseback.json";
@@ -184,39 +101,3 @@ TEST_F(CmodSaleLeasebackTest, PVBattery) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodSaleLeasebackTest, PVWatts) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_PVWatts_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_PVWatts_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSaleLeasebackTest, StandaloneBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Standalone_Battery_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Standalone_Battery_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodSaleLeasebackTest, Wind) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Wind_Power_Sale_Leaseback_cmod_saleleaseback.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Wind_Power_Sale_Leaseback_cmod_saleleaseback_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "tax_investor_aftertax_npv", "sponsor_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_tax_investor_aftertax", "cf_sponsor_aftertax", "cf_annual_costs"};
-
-    Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/

--- a/test/ssc_test/cmod_saleleaseback_test.cpp
+++ b/test/ssc_test/cmod_saleleaseback_test.cpp
@@ -46,7 +46,7 @@ TEST_F(CmodSaleLeasebackTest, Biopower) {
 
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSaleLeasebackTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_DSLF_Sale_Leaseback_cmod_saleleaseback.json";
@@ -69,7 +69,7 @@ TEST_F(CmodSaleLeasebackTest, EmpiricalTrough) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodSaleLeasebackTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Flat_Plate_PV_Sale_Leaseback_cmod_saleleaseback.json";
@@ -81,7 +81,7 @@ TEST_F(CmodSaleLeasebackTest, PV) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodSaleLeasebackTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Generic_Battery_Sale_Leaseback_cmod_saleleaseback.json";
@@ -92,7 +92,7 @@ TEST_F(CmodSaleLeasebackTest, CustomGenerationBattery) {
 
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodSaleLeasebackTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_Generic_CSP_System_Sale_Leaseback_cmod_saleleaseback.json";
@@ -126,7 +126,7 @@ TEST_F(CmodSaleLeasebackTest, Geotherrmal) {
 
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSaleLeasebackTest, CPV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_High-X_Concentrating_PV_Sale_Leaseback_cmod_saleleaseback.json";
@@ -172,7 +172,7 @@ TEST_F(CmodSaleLeasebackTest, PhysicalTrough) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodSaleLeasebackTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_PV_Battery_Sale_Leaseback_cmod_saleleaseback.json";
@@ -184,7 +184,7 @@ TEST_F(CmodSaleLeasebackTest, PVBattery) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodSaleLeasebackTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/saleleaseback/2023.10.27_om-expense-cash-flow_PVWatts_Sale_Leaseback_cmod_saleleaseback.json";
@@ -219,4 +219,4 @@ TEST_F(CmodSaleLeasebackTest, Wind) {
     Test("saleleaseback", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -91,7 +91,7 @@ TEST_F(CmodSingleOwnerTest, EmpiricalTrough) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+
 TEST_F(CmodSingleOwnerTest, ETES) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_ETES_Single_Owner_cmod_singleowner.json";
@@ -102,7 +102,7 @@ TEST_F(CmodSingleOwnerTest, ETES) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+*/
 TEST_F(CmodSingleOwnerTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Flat_Plate_PV_Single_Owner_cmod_singleowner.json";
@@ -113,7 +113,7 @@ TEST_F(CmodSingleOwnerTest, PV) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+
 TEST_F(CmodSingleOwnerTest, FuelCell) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Fuel_Cell_Single_Owner_cmod_singleowner.json";

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -58,7 +58,7 @@ TEST_F(CmodSingleOwnerTest, ssc_1047) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodSingleOwnerTest, Biopower) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Biopower_Single_Owner_cmod_singleowner.json";
@@ -91,7 +91,7 @@ TEST_F(CmodSingleOwnerTest, EmpiricalTrough) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodSingleOwnerTest, ETES) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_ETES_Single_Owner_cmod_singleowner.json";
@@ -102,7 +102,7 @@ TEST_F(CmodSingleOwnerTest, ETES) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Flat_Plate_PV_Single_Owner_cmod_singleowner.json";
@@ -113,7 +113,7 @@ TEST_F(CmodSingleOwnerTest, PV) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodSingleOwnerTest, FuelCell) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Fuel_Cell_Single_Owner_cmod_singleowner.json";
@@ -135,7 +135,7 @@ TEST_F(CmodSingleOwnerTest, CustomGenerationBattery) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_CSP_System_Single_Owner_cmod_singleowner.json";
@@ -216,7 +216,7 @@ TEST_F(CmodSingleOwnerTest, PhysicalTrough) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodSingleOwnerTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_PV_Battery_Single_Owner_cmod_singleowner.json";
@@ -228,7 +228,7 @@ TEST_F(CmodSingleOwnerTest, PVBattery) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodSingleOwnerTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_PVWatts_Single_Owner_cmod_singleowner.json";
@@ -239,7 +239,7 @@ TEST_F(CmodSingleOwnerTest, PVWatts) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodSingleOwnerTest, StandaloneBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Standalone_Battery_Single_Owner_cmod_singleowner.json";
@@ -251,7 +251,7 @@ TEST_F(CmodSingleOwnerTest, StandaloneBattery) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodSingleOwnerTest, Wind) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Wind_Power_Single_Owner_cmod_singleowner.json";
@@ -262,5 +262,5 @@ TEST_F(CmodSingleOwnerTest, Wind) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -124,7 +124,7 @@ TEST_F(CmodSingleOwnerTest, FuelCell) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, CustomGenerationBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_Battery_Single_Owner_cmod_singleowner.json";
@@ -135,7 +135,7 @@ TEST_F(CmodSingleOwnerTest, CustomGenerationBattery) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+*/
 TEST_F(CmodSingleOwnerTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_CSP_System_Single_Owner_cmod_singleowner.json";
@@ -146,7 +146,7 @@ TEST_F(CmodSingleOwnerTest, GenericCSP) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, CustomGeneration) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_System_Single_Owner_cmod_singleowner.json";
@@ -158,7 +158,7 @@ TEST_F(CmodSingleOwnerTest, CustomGeneration) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+*/
 TEST_F(CmodSingleOwnerTest, Geotherrmal) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Geothermal_Power_Single_Owner_cmod_singleowner.json";
@@ -169,7 +169,7 @@ TEST_F(CmodSingleOwnerTest, Geotherrmal) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, CPV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_High-X_Concentrating_PV_Single_Owner_cmod_singleowner.json";
@@ -239,7 +239,7 @@ TEST_F(CmodSingleOwnerTest, PVWatts) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+
 TEST_F(CmodSingleOwnerTest, StandaloneBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Standalone_Battery_Single_Owner_cmod_singleowner.json";
@@ -251,7 +251,7 @@ TEST_F(CmodSingleOwnerTest, StandaloneBattery) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
+
 TEST_F(CmodSingleOwnerTest, Wind) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Wind_Power_Single_Owner_cmod_singleowner.json";

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -58,7 +58,7 @@ TEST_F(CmodSingleOwnerTest, ssc_1047) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
+
 TEST_F(CmodSingleOwnerTest, Biopower) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Biopower_Single_Owner_cmod_singleowner.json";
@@ -69,7 +69,7 @@ TEST_F(CmodSingleOwnerTest, Biopower) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_DSLF_Single_Owner_cmod_singleowner.json";

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -58,40 +58,6 @@ TEST_F(CmodSingleOwnerTest, ssc_1047) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
-TEST_F(CmodSingleOwnerTest, Biopower) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Biopower_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Biopower_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom"};
-    std::vector<std::string> compare_array_variables = {"cf_project_return_aftertax", "cf_annual_costs"};
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSingleOwnerTest, DSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_DSLF_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_DSLF_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSingleOwnerTest, EmpiricalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Empirical_Trough_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Empirical_Trough_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodSingleOwnerTest, ETES) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_ETES_Single_Owner_cmod_singleowner.json";
@@ -124,18 +90,6 @@ TEST_F(CmodSingleOwnerTest, FuelCell) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodSingleOwnerTest, CustomGenerationBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_Battery_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_Battery_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 TEST_F(CmodSingleOwnerTest, GenericCSP) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_CSP_System_Single_Owner_cmod_singleowner.json";
@@ -146,18 +100,6 @@ TEST_F(CmodSingleOwnerTest, GenericCSP) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodSingleOwnerTest, CustomGeneration) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_System_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Generic_System_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
 
 TEST_F(CmodSingleOwnerTest, Geotherrmal) {
     std::string file_inputs = SSCDIR;
@@ -169,54 +111,6 @@ TEST_F(CmodSingleOwnerTest, Geotherrmal) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodSingleOwnerTest, CPV) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_High-X_Concentrating_PV_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_High-X_Concentrating_PV_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodSingleOwnerTest, MSLF) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_MSLF_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_MSLF_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSingleOwnerTest, MSPT) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_MSPT_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_MSPT_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-TEST_F(CmodSingleOwnerTest, PhysicalTrough) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Physical_Trough_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Physical_Trough_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-*/
 TEST_F(CmodSingleOwnerTest, PVBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_PV_Battery_Single_Owner_cmod_singleowner.json";
@@ -239,28 +133,3 @@ TEST_F(CmodSingleOwnerTest, PVWatts) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
-TEST_F(CmodSingleOwnerTest, StandaloneBattery) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Standalone_Battery_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Standalone_Battery_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-
-
-TEST_F(CmodSingleOwnerTest, Wind) {
-    std::string file_inputs = SSCDIR;
-    file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Wind_Power_Single_Owner_cmod_singleowner.json";
-    std::string file_outputs = SSCDIR;
-    file_outputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Wind_Power_Single_Owner_cmod_singleowner_outputs.json";
-    std::vector<std::string> compare_number_variables = { "ppa", "project_return_aftertax_npv", "lcoe_real", "lppa_nom" };
-    std::vector<std::string> compare_array_variables = { "cf_project_return_aftertax", "cf_annual_costs" };
-
-    Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
-}
-*/
-

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -102,7 +102,7 @@ TEST_F(CmodSingleOwnerTest, ETES) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+
 TEST_F(CmodSingleOwnerTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Flat_Plate_PV_Single_Owner_cmod_singleowner.json";
@@ -113,7 +113,7 @@ TEST_F(CmodSingleOwnerTest, PV) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+
 TEST_F(CmodSingleOwnerTest, FuelCell) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Fuel_Cell_Single_Owner_cmod_singleowner.json";
@@ -228,7 +228,7 @@ TEST_F(CmodSingleOwnerTest, PVBattery) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-/*
+
 TEST_F(CmodSingleOwnerTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_PVWatts_Single_Owner_cmod_singleowner.json";
@@ -239,7 +239,7 @@ TEST_F(CmodSingleOwnerTest, PVWatts) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+/*
 TEST_F(CmodSingleOwnerTest, StandaloneBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Standalone_Battery_Single_Owner_cmod_singleowner.json";

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -58,7 +58,7 @@ TEST_F(CmodSingleOwnerTest, ssc_1047) {
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
-
+/*
 TEST_F(CmodSingleOwnerTest, Biopower) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Biopower_Single_Owner_cmod_singleowner.json";
@@ -69,7 +69,7 @@ TEST_F(CmodSingleOwnerTest, Biopower) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-/*
+
 TEST_F(CmodSingleOwnerTest, DSLF) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_DSLF_Single_Owner_cmod_singleowner.json";
@@ -91,7 +91,7 @@ TEST_F(CmodSingleOwnerTest, EmpiricalTrough) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodSingleOwnerTest, ETES) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_ETES_Single_Owner_cmod_singleowner.json";
@@ -102,7 +102,7 @@ TEST_F(CmodSingleOwnerTest, ETES) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-*/
+/*
 TEST_F(CmodSingleOwnerTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Flat_Plate_PV_Single_Owner_cmod_singleowner.json";
@@ -113,7 +113,7 @@ TEST_F(CmodSingleOwnerTest, PV) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodSingleOwnerTest, FuelCell) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Fuel_Cell_Single_Owner_cmod_singleowner.json";
@@ -157,8 +157,8 @@ TEST_F(CmodSingleOwnerTest, CustomGeneration) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
 */
+
 TEST_F(CmodSingleOwnerTest, Geotherrmal) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/singleowner/2022.08.08_develop_branch_Geothermal_Power_Single_Owner_cmod_singleowner.json";

--- a/test/ssc_test/cmod_thirdpartyownership_test.cpp
+++ b/test/ssc_test/cmod_thirdpartyownership_test.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cmod_thirdpartyownership_test.h"
 
-
+/*
 TEST_F(CmodThirdPartyOwnershipTest, PVWatts) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/thirdpartyownership/2022.08.08_develop_branch_PVWatts_Third_Party_cmod_thirdpartyownership.json";
@@ -57,7 +57,7 @@ TEST_F(CmodThirdPartyOwnershipTest, PVWattsBattery) {
 
     Test("thirdpartyownership", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
-
+*/
 TEST_F(CmodThirdPartyOwnershipTest, PV) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/thirdpartyownership/2022.08.08_develop_branch_Flat_Plate_PV_Third_Party_cmod_thirdpartyownership.json";
@@ -106,7 +106,7 @@ TEST_F(CmodThirdPartyOwnershipTest, CustomGenerationBattery) {
 }
 
 
-
+/*
 TEST_F(CmodThirdPartyOwnershipTest, StandaloneBattery) {
     std::string file_inputs = SSCDIR;
     file_inputs += "/test/input_json/FinancialModels/thirdpartyownership/2022.08.08_develop_branch_Standalone_Battery_Third_Party_cmod_thirdpartyownership.json";
@@ -118,3 +118,4 @@ TEST_F(CmodThirdPartyOwnershipTest, StandaloneBattery) {
     Test("thirdpartyownership", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
 
+*/


### PR DESCRIPTION
Low hanging fruit in the Google Doc completed.

The following results from running locally on Ubuntu machine with debug build for coverage results
Coverage reduced by 43 lines 63,733 to 63,690 (same percentage 54.7%)
Tests reduced from 776 to 690
Time reduced from 4,555.25s (75.92m) to 2,239.21s (37.32m)
Gory details at https://github.com/NREL/SAM-documentation/blob/main/Unit%20Testing/ssc%20test%20speedup/SSC%20Test%20speedup.docx