### PR TITLE
Ci updates

### DIFF
--- a/.github/workflows/test_times.yml
+++ b/.github/workflows/test_times.yml
@@ -55,6 +55,12 @@ jobs:
       run: |
         echo "WORKFLOW_ID=${{ steps.workflow_id.outputs.result }}" >> $GITHUB_ENV
 
+    - name: Check Test-Running Workflows were Successfully Completed
+      shell: bash
+      run: |
+        pip install pandas requests
+        python '${{ github.workspace }}/ssc/test/compare_elapsed_time.py' check_workflow ${{env.WORKFLOW_ID}}
+
     - name: Get Artifact from Completed CI (on Feature Branch)
       uses: actions/github-script@v7
       id: get-artifact
@@ -107,7 +113,6 @@ jobs:
       run: |
         # compare the downloaded times from the feature branch to that of the default branch
         echo ${{ github.ref_name }}
-        pip install pandas requests
         outputString=$(python '${{ github.workspace }}/ssc/test/compare_elapsed_time.py' compare '${{ github.workspace }}/gtest_elapsed_times.csv' ${{ github.ref_name }})
         echo $outputString
         echo "RESULT=$outputString" >> $GITHUB_ENV

--- a/test/compare_elapsed_time.py
+++ b/test/compare_elapsed_time.py
@@ -84,17 +84,32 @@ def get_workflow_artifact_branch(base_branch):
         'X-GitHub-Api-Version': '2022-11-28',
     }
 
-    response = requests.get('https://api.github.com/repos/NREL/ssc/actions/artifacts', headers=headers)
+    params = {
+        "per_page": 100,
+        "page": 1
+    }
 
-    if response.status_code != 200:
-        print(response.json())
-        raise Exception("Failed to Get Workflow Artifacts List")
+    artifact_to_download = None
+    while artifact_to_download is None:
+        response = requests.get('https://api.github.com/repos/NREL/ssc/actions/artifacts', headers=headers, params=params)
 
-    artifacts = response.json()['artifacts']
+        if response.status_code != 200:
+            print(response.json())
+            raise Exception("Failed to Get Workflow Artifacts List")
 
-    artifacts = [a for a in artifacts if a['workflow_run']['head_branch'] == base_branch]
-    
-    artifacts = [a for a in artifacts if (platform in a['name']) and ("Test Time Elapsed" in a['name'])]
+        artifacts = response.json()['artifacts']
+
+        if len(artifacts) == 0:
+            raise Exception(f"Failed find Artifact from branch {base_branch}")
+
+        artifacts = [a for a in artifacts if a['workflow_run']['head_branch'] == base_branch]
+        
+        artifacts = [a for a in artifacts if (platform in a['name']) and ("Test Time Elapsed" in a['name'])]
+
+        if len(artifacts):
+            artifact_to_download = artifacts[0]
+
+        params['page'] += 1
 
     headers = {
     'Accept': 'application/vnd.github+json',
@@ -102,7 +117,7 @@ def get_workflow_artifact_branch(base_branch):
     'X-GitHub-Api-Version': '2022-11-28',
     }
 
-    response = requests.get(artifacts[0]['archive_download_url'], headers=headers)
+    response = requests.get(artifact_to_download['archive_download_url'], headers=headers)
 
     z = zipfile.ZipFile(io.BytesIO(response.content)) 
     file_dir = Path(__file__).parent

--- a/test/compare_elapsed_time.py
+++ b/test/compare_elapsed_time.py
@@ -54,7 +54,8 @@ def convert_log_to_csv(gtest_log_path):
                 test_name = test_name.split('.')
                 test_group = test_name[0]
                 test_name = test_name[-1]
-                test_time = float(test_arr[1].split(" ms")[0])
+                if len(test_arr) > 1:
+                    test_time = float(test_arr[1].split(" ms")[0])
             elif 'test suites' in line:
                 test_group = "Total"
                 test_name = "Total"
@@ -76,6 +77,26 @@ def convert_log_to_csv(gtest_log_path):
     print(f"Output csv: {out_path}")
     return test_df
 
+
+def check_workflow_job_status(workflow_id):
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': f'Bearer {access_token}',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+
+    response = requests.get(f'https://api.github.com/repos/NREL/ssc/actions/runs/{workflow_id}', headers=headers)
+
+    if response.status_code != 200:
+        print(response.json())
+        raise (f"Error getting data for workflow run {workflow_id}")
+    
+    conclusion = response.json()['conclusion']
+
+    if conclusion == 'failure':
+        return False
+
+    return True
 
 def get_workflow_artifact_branch(base_branch):
     headers = {
@@ -262,6 +283,12 @@ if __name__ == "__main__":
     if sys.argv[1] == "help":
         print(help_info)
         exit()
+    elif sys.argv[1] == "check_workflow":
+        if len(sys.argv) < 3:
+            raise RuntimeError("Provide workflow id to check")
+        workflow_id = sys.argv[2]
+        if not check_workflow_job_status(workflow_id):
+            raise RuntimeError(f"Workflow {workflow_id} conclusion was not successful.")
     elif sys.argv[1] == "gtest_log":
         if len(sys.argv) < 3:
             raise RuntimeError("Provide path to gtest log file")


### PR DESCRIPTION
Compare Test Time Elapsed workflow is currently failing during the `get_workflow_artifact_branch` step. The list of artifacts being returned has a limited length and if the required artifact is older then it may not show up in the list. Add a loop to step through all the pages of the artifacts from the API until one is found.

Also, Compare Test Time Elapsed can fail if the Google Test run didn't complete successfully to produce a test time log. So first check that it was successful.