### PR TITLE
IPH outputs during startup and on modes

### DIFF
--- a/ssc/cmod_fresnel_physical.cpp
+++ b/ssc/cmod_fresnel_physical.cpp
@@ -485,7 +485,9 @@ static var_info _cm_vtab_fresnel_physical[] = {
     { SSC_OUTPUT,       SSC_ARRAY,      "e_dot_field_int_energy",           "Field change in material/htf internal energy",                         "MWt",          "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "q_dot_htf_sf_out",                 "Field thermal power leaving in HTF",                                   "MWt",          "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "q_dot_freeze_prot",                "Field freeze protection required",                                     "MWt",          "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
-                                                                                                                                            
+
+    { SSC_OUTPUT,       SSC_ARRAY,      "rec_time_in_startup",              "Field time at startup",                                                "min",          "",         "solar_field",    "sim_type=1",                       "",                      "" },
+
     { SSC_OUTPUT,       SSC_ARRAY,      "m_dot_loop",                       "Receiver mass flow rate",                                              "kg/s",         "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "m_dot_field_recirc",               "Field total mass flow recirculated",                                   "kg/s",         "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "m_dot_field_delivered",            "Field total mass flow delivered",                                      "kg/s",         "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
@@ -796,7 +798,9 @@ public:
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_E_DOT_INTERNAL_ENERGY, allocate("e_dot_field_int_energy", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_Q_DOT_HTF_OUT, allocate("q_dot_htf_sf_out", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_Q_DOT_FREEZE_PROT, allocate("q_dot_freeze_prot", n_steps_fixed), n_steps_fixed);
-                
+
+                c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_TIME_IN_STARTUP, allocate("rec_time_in_startup", n_steps_fixed), n_steps_fixed);
+
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_M_DOT_LOOP, allocate("m_dot_loop", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_IS_RECIRCULATING, allocate("recirculating", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_M_DOT_FIELD_RECIRC, allocate("m_dot_field_recirc", n_steps_fixed), n_steps_fixed);

--- a/ssc/cmod_fresnel_physical_iph.cpp
+++ b/ssc/cmod_fresnel_physical_iph.cpp
@@ -461,7 +461,9 @@ static var_info _cm_vtab_fresnel_physical_iph[] = {
     { SSC_OUTPUT,       SSC_ARRAY,      "e_dot_field_int_energy",           "Field change in material/htf internal energy",                         "MWt",          "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "q_dot_htf_sf_out",                 "Field thermal power leaving in HTF",                                   "MWt",          "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "q_dot_freeze_prot",                "Field freeze protection required",                                     "MWt",          "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
-    
+
+    { SSC_OUTPUT,       SSC_ARRAY,      "rec_time_in_startup",              "Field time at startup",                                                "min",          "",         "solar_field",    "sim_type=1",                       "",                      "" },
+
     { SSC_OUTPUT,       SSC_ARRAY,      "m_dot_loop",                       "Receiver mass flow rate",                                              "kg/s",         "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "m_dot_field_recirc",               "Field total mass flow recirculated",                                   "kg/s",         "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
     { SSC_OUTPUT,       SSC_ARRAY,      "m_dot_field_delivered",            "Field total mass flow delivered",                                      "kg/s",         "",         "Solar_Field",    "sim_type=1",                       "",                      "" },
@@ -804,6 +806,8 @@ public:
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_E_DOT_INTERNAL_ENERGY, allocate("e_dot_field_int_energy", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_Q_DOT_HTF_OUT, allocate("q_dot_htf_sf_out", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_Q_DOT_FREEZE_PROT, allocate("q_dot_freeze_prot", n_steps_fixed), n_steps_fixed);
+
+                c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_TIME_IN_STARTUP, allocate("rec_time_in_startup", n_steps_fixed), n_steps_fixed);
 
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_M_DOT_LOOP, allocate("m_dot_loop", n_steps_fixed), n_steps_fixed);
                 c_fresnel.mc_reported_outputs.assign(C_csp_fresnel_collector_receiver::E_IS_RECIRCULATING, allocate("recirculating", n_steps_fixed), n_steps_fixed);

--- a/ssc/cmod_trough_physical.cpp
+++ b/ssc/cmod_trough_physical.cpp
@@ -604,7 +604,9 @@ static var_info _cm_vtab_trough_physical[] = {
     { SSC_OUTPUT,       SSC_ARRAY,       "e_dot_field_int_energy",    "Field change in material/htf internal energy",                                     "MWt",          "",               "solar_field",    "sim_type=1",                       "",                      "" }, 
     { SSC_OUTPUT,       SSC_ARRAY,       "q_dot_htf_sf_out",          "Field thermal power leaving in HTF",                                               "MWt",          "",               "solar_field",    "sim_type=1",                       "",                      "" },  
     { SSC_OUTPUT,       SSC_ARRAY,       "q_dot_freeze_prot",         "Field freeze protection required",                                                 "MWt",          "",               "solar_field",    "sim_type=1",                       "",                      "" },
-                                                                                                                                                                                                                                                               
+
+    { SSC_OUTPUT,       SSC_ARRAY,       "rec_time_in_startup",       "Field time at startup",                                                            "min",          "",               "solar_field",    "sim_type=1",                       "",                      "" },
+
     { SSC_OUTPUT,       SSC_ARRAY,       "m_dot_loop",                "Receiver mass flow rate",                                                          "kg/s",         "",               "solar_field",    "sim_type=1",                       "",                      "" },  
     { SSC_OUTPUT,       SSC_ARRAY,       "m_dot_field_recirc",        "Field total mass flow recirculated",                                               "kg/s",         "",               "solar_field",    "sim_type=1",                       "",                      "" },  
     { SSC_OUTPUT,       SSC_ARRAY,       "m_dot_field_delivered",     "Field total mass flow delivered",                                                  "kg/s",         "",               "solar_field",    "sim_type=1",                       "",                      "" },  
@@ -1248,8 +1250,9 @@ public:
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_Q_DOT_HTF_OUT, allocate("q_dot_htf_sf_out", n_steps_fixed), n_steps_fixed);
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_Q_DOT_FREEZE_PROT, allocate("q_dot_freeze_prot", n_steps_fixed), n_steps_fixed);
 
+                c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_TIME_IN_STARTUP, allocate("rec_time_in_startup", n_steps_fixed), n_steps_fixed);
+                
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_M_DOT_LOOP, allocate("m_dot_loop", n_steps_fixed), n_steps_fixed);
-
 
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_IS_RECIRCULATING, allocate("recirculating", n_steps_fixed), n_steps_fixed);
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_M_DOT_FIELD_RECIRC, allocate("m_dot_field_recirc", n_steps_fixed), n_steps_fixed);

--- a/ssc/cmod_trough_physical_iph.cpp
+++ b/ssc/cmod_trough_physical_iph.cpp
@@ -563,7 +563,9 @@ static var_info _cm_vtab_trough_physical_iph[] = {
     { SSC_OUTPUT,       SSC_ARRAY,       "e_dot_field_int_energy",    "Field change in material/htf internal energy",                                     "MWt",          "",               "solar_field",    "sim_type=1",                       "",                      "" }, 
     { SSC_OUTPUT,       SSC_ARRAY,       "q_dot_htf_sf_out",          "Field thermal power leaving in HTF",                                               "MWt",          "",               "solar_field",    "sim_type=1",                       "",                      "" },  
     { SSC_OUTPUT,       SSC_ARRAY,       "q_dot_freeze_prot",         "Field freeze protection required",                                                 "MWt",          "",               "solar_field",    "sim_type=1",                       "",                      "" },
-                                                                                                                                                                                                                                                               
+
+    { SSC_OUTPUT,       SSC_ARRAY,       "rec_time_in_startup",       "Field time at startup",                                                            "min",          "",               "solar_field",    "sim_type=1",                       "",                      "" },
+
     { SSC_OUTPUT,       SSC_ARRAY,       "m_dot_loop",                "Receiver mass flow rate",                                                          "kg/s",         "",               "solar_field",    "sim_type=1",                       "",                      "" },  
     { SSC_OUTPUT,       SSC_ARRAY,       "m_dot_field_recirc",        "Field total mass flow recirculated",                                               "kg/s",         "",               "solar_field",    "sim_type=1",                       "",                      "" },  
     { SSC_OUTPUT,       SSC_ARRAY,       "m_dot_field_delivered",     "Field total mass flow delivered",                                                  "kg/s",         "",               "solar_field",    "sim_type=1",                       "",                      "" },  
@@ -1155,6 +1157,8 @@ public:
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_E_DOT_INTERNAL_ENERGY, allocate("e_dot_field_int_energy", n_steps_fixed), n_steps_fixed);
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_Q_DOT_HTF_OUT, allocate("q_dot_htf_sf_out", n_steps_fixed), n_steps_fixed);
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_Q_DOT_FREEZE_PROT, allocate("q_dot_freeze_prot", n_steps_fixed), n_steps_fixed);
+
+                c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_TIME_IN_STARTUP, allocate("rec_time_in_startup", n_steps_fixed), n_steps_fixed);
 
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_M_DOT_LOOP, allocate("m_dot_loop", n_steps_fixed), n_steps_fixed);
                 c_trough.mc_reported_outputs.assign(C_csp_trough_collector_receiver::E_IS_RECIRCULATING, allocate("recirculating", n_steps_fixed), n_steps_fixed);

--- a/tcs/csp_solver_fresnel_collector_receiver.cpp
+++ b/tcs/csp_solver_fresnel_collector_receiver.cpp
@@ -293,7 +293,7 @@ void C_csp_fresnel_collector_receiver::set_output_value()
         m_E_dot_xover_summed_fullts +
         m_E_dot_HR_cold_fullts +
         m_E_dot_HR_hot_fullts);			//[MWt]
-    mc_reported_outputs.value(E_Q_DOT_HTF_OUT, m_q_dot_htf_to_sink_fullts);				//[MWt]
+    mc_reported_outputs.value(E_Q_DOT_HTF_OUT, m_q_dot_thermal_reported);				//[MWt]
     mc_reported_outputs.value(E_Q_DOT_FREEZE_PROT, m_q_dot_freeze_protection);			//[MWt]
 
     mc_reported_outputs.value(E_M_DOT_LOOP, m_m_dot_htf_tot / (double)m_nLoops);		//[kg/s]
@@ -1490,6 +1490,8 @@ C_csp_fresnel_collector_receiver::C_csp_fresnel_collector_receiver()
     m_q_dot_htf_to_sink_fullts = std::numeric_limits<double>::quiet_NaN();	//[MWt]
     m_q_dot_freeze_protection = std::numeric_limits<double>::quiet_NaN();	//[MWt]
 
+    m_q_dot_thermal_reported = std::numeric_limits<double>::quiet_NaN();    //[MWt]
+
     m_dP_total = std::numeric_limits<double>::quiet_NaN();		//[bar]
     m_W_dot_pump = std::numeric_limits<double>::quiet_NaN();	//[MWe]
 
@@ -2339,7 +2341,7 @@ void C_csp_fresnel_collector_receiver::off(const C_csp_weatherreader::S_outputs&
         m_q_dot_HR_cold_loss_fullts = m_q_dot_HR_hot_loss_fullts =
         m_E_dot_sca_summed_fullts = m_E_dot_xover_summed_fullts =
         m_E_dot_HR_cold_fullts = m_E_dot_HR_hot_fullts =
-        m_q_dot_htf_to_sink_fullts = 0.0;
+        m_q_dot_htf_to_sink_fullts = m_q_dot_thermal_reported = 0.0;
 
     // Simulate through time steps
     for (int i = 0; i < n_steps_recirc; i++)
@@ -2421,7 +2423,8 @@ void C_csp_fresnel_collector_receiver::off(const C_csp_weatherreader::S_outputs&
     //cr_out_solver.m_m_dot_salt_tot = m_dot_htf_loop*3600.0*(double)m_nLoops;	//[kg/hr] Total HTF mass flow rate
     cr_out_solver.m_m_dot_salt_tot = 0.0;	//[kg/hr] Total HTF mass flow rate
 
-    cr_out_solver.m_q_thermal = 0.0;						//[MWt] No available receiver thermal output
+    m_q_dot_thermal_reported = 0.0;
+    cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;				//[MWt] No available receiver thermal output
     // 7.12.16: Return timestep-end or timestep-integrated-average?
     // If multiple recirculation steps, then need to calculate average of timestep-integrated-average
     cr_out_solver.m_T_salt_hot = m_T_sys_h_t_int_fullts - 273.15;		//[C]
@@ -2489,7 +2492,7 @@ void C_csp_fresnel_collector_receiver::startup(const C_csp_weatherreader::S_outp
         m_q_dot_HR_cold_loss_fullts = m_q_dot_HR_hot_loss_fullts =
         m_E_dot_sca_summed_fullts = m_E_dot_xover_summed_fullts =
         m_E_dot_HR_cold_fullts = m_E_dot_HR_hot_fullts =
-        m_q_dot_htf_to_sink_fullts = 0.0;
+        m_q_dot_htf_to_sink_fullts = m_q_dot_thermal_reported = 0.0;
 
     sim_info_temp.ms_ts.m_time = time_start;
 
@@ -2602,7 +2605,8 @@ void C_csp_fresnel_collector_receiver::startup(const C_csp_weatherreader::S_outp
     cr_out_solver.m_m_dot_salt_tot = 0.0;	//[kg/hr]
 
     // Should not be available thermal output if receiver is in start up, but controller doesn't use it in CR_SU (confirmed)
-    cr_out_solver.m_q_thermal = 0.0;						//[MWt] No available receiver thermal output
+    m_q_dot_thermal_reported = 0.0;
+    cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;				//[MWt] No available receiver thermal output
     // 7.12.16: Return timestep-end or timestep-integrated-average?
     // If multiple recirculation steps, then need to calculate average of timestep-integrated-average
     cr_out_solver.m_T_salt_hot = m_T_sys_h_t_int_fullts - 273.15;		//[C]
@@ -2808,7 +2812,8 @@ void C_csp_fresnel_collector_receiver::on(const C_csp_weatherreader::S_outputs& 
         // The controller also requires the receiver thermal output
         // 7.12.16 Now using the timestep-integrated-average temperature
         double c_htf_ave = m_htfProps.Cp((m_T_sys_h_t_int + T_cold_in) / 2.0);  //[kJ/kg-K]
-        cr_out_solver.m_q_thermal = (cr_out_solver.m_m_dot_salt_tot / 3600.0) * c_htf_ave * (m_T_sys_h_t_int - T_cold_in) / 1.E3;	//[MWt]
+        m_q_dot_thermal_reported = (cr_out_solver.m_m_dot_salt_tot / 3600.0) * c_htf_ave * (m_T_sys_h_t_int - T_cold_in) / 1.E3;	//[MWt]
+        cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;
 
         // Finally, the controller need the HTF outlet temperature from the field
         cr_out_solver.m_T_salt_hot = m_T_sys_h_t_int - 273.15;		//[C]
@@ -2836,12 +2841,12 @@ void C_csp_fresnel_collector_receiver::on(const C_csp_weatherreader::S_outputs& 
             m_q_dot_HR_cold_loss_fullts = m_q_dot_HR_hot_loss_fullts =
             m_E_dot_sca_summed_fullts = m_E_dot_xover_summed_fullts =
             m_E_dot_HR_cold_fullts = m_E_dot_HR_hot_fullts =
-            m_q_dot_htf_to_sink_fullts = m_q_dot_freeze_protection = 0.0;
+            m_q_dot_htf_to_sink_fullts = m_q_dot_freeze_protection = m_q_dot_thermal_reported = 0.0;
 
         cr_out_solver.m_q_startup = 0.0;			//[MWt-hr]
         cr_out_solver.m_time_required_su = 0.0;		//[s]
         cr_out_solver.m_m_dot_salt_tot = 0.0;		//[kg/hr]
-        cr_out_solver.m_q_thermal = 0.0;			//[MWt]
+        cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;			//[MWt]
         cr_out_solver.m_T_salt_hot = 0.0;			//[C]
         cr_out_solver.m_component_defocus = 1.0;	//[-]
         cr_out_solver.m_is_recirculating = false;

--- a/tcs/csp_solver_fresnel_collector_receiver.h
+++ b/tcs/csp_solver_fresnel_collector_receiver.h
@@ -132,6 +132,8 @@ public:
         E_Q_DOT_HTF_OUT,		   //[MWt]
         E_Q_DOT_FREEZE_PROT,       //[MWt]
 
+        E_TIME_IN_STARTUP,          //[min]
+
         E_M_DOT_LOOP,				//[kg/s]
         E_IS_RECIRCULATING,         //[-]
         E_M_DOT_FIELD_RECIRC,		//[kg/s]
@@ -317,6 +319,10 @@ private:
     double m_q_dot_freeze_protection;		            // [MWt] SYSTEM thermal freeze protection
 
     double m_q_dot_thermal_reported;        //[MWt] HTF thermal power reported back to controller - should be 0 for recirculating startup and off
+
+    double m_time_at_off;                   //[s]
+    double m_time_at_startup;               //[s]
+    double m_time_at_on;                    //[s]
 
     // Private Methods
 private:

--- a/tcs/csp_solver_fresnel_collector_receiver.h
+++ b/tcs/csp_solver_fresnel_collector_receiver.h
@@ -316,6 +316,7 @@ private:
     double m_q_dot_htf_to_sink_fullts;		            // [MWt] SYSTEM thermal power to sink (or artificially added to system in recirculation...)
     double m_q_dot_freeze_protection;		            // [MWt] SYSTEM thermal freeze protection
 
+    double m_q_dot_thermal_reported;        //[MWt] HTF thermal power reported back to controller - should be 0 for recirculating startup and off
 
     // Private Methods
 private:

--- a/tcs/csp_solver_mono_eq_methods.cpp
+++ b/tcs/csp_solver_mono_eq_methods.cpp
@@ -230,7 +230,7 @@ int C_csp_solver::solve_operating_mode(C_csp_collector_receiver::E_csp_cr_modes 
             }
 
             // Solve for defocus
-            double defocus_solved, tol_solved;
+            double tol_solved;
             defocus_solved = tol_solved = std::numeric_limits<double>::quiet_NaN();
             int iter_solved = -1;
 

--- a/tcs/csp_solver_trough_collector_receiver.cpp
+++ b/tcs/csp_solver_trough_collector_receiver.cpp
@@ -217,6 +217,8 @@ C_csp_trough_collector_receiver::C_csp_trough_collector_receiver()
 	m_q_dot_htf_to_sink_fullts = std::numeric_limits<double>::quiet_NaN();	//[MWt]
 	m_q_dot_freeze_protection = std::numeric_limits<double>::quiet_NaN();	//[MWt]
 
+    m_q_dot_thermal_reported = std::numeric_limits<double>::quiet_NaN();    //[MWt]
+
 	m_dP_total = std::numeric_limits<double>::quiet_NaN();		//[bar]
 	m_W_dot_pump = std::numeric_limits<double>::quiet_NaN();	//[MWe]
 
@@ -2132,7 +2134,7 @@ void C_csp_trough_collector_receiver::set_output_value()
 														m_E_dot_xover_summed_fullts +
 														m_E_dot_HR_cold_fullts +
 														m_E_dot_HR_hot_fullts);			//[MWt]
-	mc_reported_outputs.value(E_Q_DOT_HTF_OUT, m_q_dot_htf_to_sink_fullts);				//[MWt]
+	mc_reported_outputs.value(E_Q_DOT_HTF_OUT, m_q_dot_thermal_reported);				//[MWt]
 	mc_reported_outputs.value(E_Q_DOT_FREEZE_PROT, m_q_dot_freeze_protection);			//[MWt]
 
 	mc_reported_outputs.value(E_M_DOT_LOOP, m_m_dot_htf_tot/(double)m_nLoops);		//[kg/s]
@@ -2206,7 +2208,7 @@ void C_csp_trough_collector_receiver::off(const C_csp_weatherreader::S_outputs &
 		m_q_dot_HR_cold_loss_fullts = m_q_dot_HR_hot_loss_fullts = 
 		m_E_dot_sca_summed_fullts = m_E_dot_xover_summed_fullts = 
 		m_E_dot_HR_cold_fullts = m_E_dot_HR_hot_fullts = 
-		m_q_dot_htf_to_sink_fullts = 0.0;
+		m_q_dot_htf_to_sink_fullts = m_q_dot_thermal_reported = 0.0;
 
 	for(int i = 0; i < n_steps_recirc; i++)
 	{
@@ -2296,8 +2298,9 @@ void C_csp_trough_collector_receiver::off(const C_csp_weatherreader::S_outputs &
 	//              .... and not passing HTF to other components
 	//cr_out_solver.m_m_dot_salt_tot = m_dot_htf_loop*3600.0*(double)m_nLoops;	//[kg/hr] Total HTF mass flow rate
 	cr_out_solver.m_m_dot_salt_tot = 0.0;	//[kg/hr] Total HTF mass flow rate
-	
-	cr_out_solver.m_q_thermal = 0.0;						//[MWt] No available receiver thermal output
+
+    m_q_dot_thermal_reported = 0.0;
+	cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;						//[MWt] No available receiver thermal output
 		// 7.12.16: Return timestep-end or timestep-integrated-average?
 		// If multiple recirculation steps, then need to calculate average of timestep-integrated-average
 	cr_out_solver.m_T_salt_hot = m_T_sys_h_t_int_fullts - 273.15;		//[C]
@@ -2365,7 +2368,7 @@ void C_csp_trough_collector_receiver::startup(const C_csp_weatherreader::S_outpu
 		m_q_dot_HR_cold_loss_fullts = m_q_dot_HR_hot_loss_fullts =
 		m_E_dot_sca_summed_fullts = m_E_dot_xover_summed_fullts =
 		m_E_dot_HR_cold_fullts = m_E_dot_HR_hot_fullts =
-		m_q_dot_htf_to_sink_fullts = 0.0;
+		m_q_dot_htf_to_sink_fullts = m_q_dot_thermal_reported = 0.0;
 
     sim_info_temp.ms_ts.m_time = time_start;
     while(sim_info_temp.ms_ts.m_time < time_end)
@@ -2476,7 +2479,8 @@ void C_csp_trough_collector_receiver::startup(const C_csp_weatherreader::S_outpu
 	cr_out_solver.m_m_dot_salt_tot = 0.0;	//[kg/hr]
 
 	// Should not be available thermal output if receiver is in start up, but controller doesn't use it in CR_SU (confirmed)
-	cr_out_solver.m_q_thermal = 0.0;						//[MWt] No available receiver thermal output
+    m_q_dot_thermal_reported = 0.0;
+    cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;						//[MWt] No available receiver thermal output
 		// 7.12.16: Return timestep-end or timestep-integrated-average?
 		// If multiple recirculation steps, then need to calculate average of timestep-integrated-average
 	cr_out_solver.m_T_salt_hot = m_T_sys_h_t_int_fullts - 273.15;		//[C]
@@ -2735,7 +2739,8 @@ void C_csp_trough_collector_receiver::on(const C_csp_weatherreader::S_outputs &w
 			// The controller also requires the receiver thermal output
 			// 7.12.16 Now using the timestep-integrated-average temperature
 		double c_htf_ave = m_htfProps.Cp_ave(T_cold_in, m_T_sys_h_t_int);  //[kJ/kg-K]
-		cr_out_solver.m_q_thermal = (cr_out_solver.m_m_dot_salt_tot / 3600.0)*c_htf_ave*(m_T_sys_h_t_int - T_cold_in) / 1.E3;	//[MWt]
+        m_q_dot_thermal_reported = (cr_out_solver.m_m_dot_salt_tot / 3600.0) * c_htf_ave * (m_T_sys_h_t_int - T_cold_in) / 1.E3;	//[MWt]
+        cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;
 		// Finally, the controller need the HTF outlet temperature from the field
 		cr_out_solver.m_T_salt_hot = m_T_sys_h_t_int - 273.15;		//[C]
 			
@@ -2762,12 +2767,12 @@ void C_csp_trough_collector_receiver::on(const C_csp_weatherreader::S_outputs &w
 			m_q_dot_HR_cold_loss_fullts = m_q_dot_HR_hot_loss_fullts =
 			m_E_dot_sca_summed_fullts = m_E_dot_xover_summed_fullts =
 			m_E_dot_HR_cold_fullts = m_E_dot_HR_hot_fullts =
-			m_q_dot_htf_to_sink_fullts = m_q_dot_freeze_protection = 0.0;
+			m_q_dot_htf_to_sink_fullts = m_q_dot_freeze_protection = m_q_dot_thermal_reported = 0.0;
 
 		cr_out_solver.m_q_startup = 0.0;			//[MWt-hr]
 		cr_out_solver.m_time_required_su = 0.0;		//[s]
 		cr_out_solver.m_m_dot_salt_tot = 0.0;		//[kg/hr]
-		cr_out_solver.m_q_thermal = 0.0;			//[MWt]
+		cr_out_solver.m_q_thermal = m_q_dot_thermal_reported;			//[MWt]
 		cr_out_solver.m_T_salt_hot = 0.0;			//[C]
 		cr_out_solver.m_component_defocus = 1.0;	//[-]
         cr_out_solver.m_is_recirculating = false;

--- a/tcs/csp_solver_trough_collector_receiver.cpp
+++ b/tcs/csp_solver_trough_collector_receiver.cpp
@@ -60,6 +60,8 @@ static C_csp_reported_outputs::S_output_info S_output_info[] =
 	{C_csp_trough_collector_receiver::E_Q_DOT_HTF_OUT, C_csp_reported_outputs::TS_WEIGHTED_AVE},
 	{C_csp_trough_collector_receiver::E_Q_DOT_FREEZE_PROT, C_csp_reported_outputs::TS_WEIGHTED_AVE},
 
+    {C_csp_trough_collector_receiver::E_TIME_IN_STARTUP, C_csp_reported_outputs::SUMMED},
+
 	{C_csp_trough_collector_receiver::E_M_DOT_LOOP, C_csp_reported_outputs::TS_WEIGHTED_AVE},
     {C_csp_trough_collector_receiver::E_IS_RECIRCULATING, C_csp_reported_outputs::TS_WEIGHTED_AVE},
 	{C_csp_trough_collector_receiver::E_M_DOT_FIELD_RECIRC, C_csp_reported_outputs::TS_WEIGHTED_AVE},
@@ -221,6 +223,10 @@ C_csp_trough_collector_receiver::C_csp_trough_collector_receiver()
 
 	m_dP_total = std::numeric_limits<double>::quiet_NaN();		//[bar]
 	m_W_dot_pump = std::numeric_limits<double>::quiet_NaN();	//[MWe]
+
+    m_time_at_off = std::numeric_limits<double>::quiet_NaN();       //[s]
+    m_time_at_startup = std::numeric_limits<double>::quiet_NaN();   //[s]
+    m_time_at_on = std::numeric_limits<double>::quiet_NaN();        //[s]
 
 	m_is_m_dot_recirc = false;
 
@@ -2137,6 +2143,8 @@ void C_csp_trough_collector_receiver::set_output_value()
 	mc_reported_outputs.value(E_Q_DOT_HTF_OUT, m_q_dot_thermal_reported);				//[MWt]
 	mc_reported_outputs.value(E_Q_DOT_FREEZE_PROT, m_q_dot_freeze_protection);			//[MWt]
 
+    mc_reported_outputs.value(E_TIME_IN_STARTUP, m_time_at_startup / 60.0);         //[min] convert from s
+
 	mc_reported_outputs.value(E_M_DOT_LOOP, m_m_dot_htf_tot/(double)m_nLoops);		//[kg/s]
 
     mc_reported_outputs.value(E_IS_RECIRCULATING, m_is_m_dot_recirc);		    //[-]
@@ -2311,6 +2319,10 @@ void C_csp_trough_collector_receiver::off(const C_csp_weatherreader::S_outputs &
     cr_out_solver.m_q_dot_heater = m_q_dot_freeze_protection;   //[MWt]
 
 	m_operating_mode = C_csp_collector_receiver::OFF;
+
+    m_time_at_off = sim_info.ms_ts.m_step;
+    m_time_at_startup = 0.0;
+    m_time_at_on = 0.0;
 
 	set_output_value();
 
@@ -2491,6 +2503,10 @@ void C_csp_trough_collector_receiver::startup(const C_csp_weatherreader::S_outpu
     cr_out_solver.m_W_dot_elec_in_tot = m_W_dot_sca_tracking + m_W_dot_pump;    //[MWe]
         // Shouldn't need freeze protection if in startup, but may want a check on this
     cr_out_solver.m_q_dot_heater = m_q_dot_freeze_protection;    //[MWt]
+
+    m_time_at_off = 0.0;
+    m_time_at_startup = sim_info.ms_ts.m_step;
+    m_time_at_on = 0.0;
 
 	set_output_value();
 }
@@ -2783,6 +2799,10 @@ void C_csp_trough_collector_receiver::on(const C_csp_weatherreader::S_outputs &w
 
         cr_out_solver.m_q_dot_heater = m_q_dot_freeze_protection;    //[MWt]
 	}
+
+    m_time_at_off = 0.0;
+    m_time_at_startup = 0.0;
+    m_time_at_on = sim_info.ms_ts.m_step;
 
 	set_output_value();
 

--- a/tcs/csp_solver_trough_collector_receiver.h
+++ b/tcs/csp_solver_trough_collector_receiver.h
@@ -294,6 +294,8 @@ private:
 	double m_q_dot_htf_to_sink_fullts;		//[MWt] SYSTEM thermal power to sink (or artificially added to system in recirculation...)
 	double m_q_dot_freeze_protection;		//[MWt] SYSTEM thermal freeze protection
 
+    double m_q_dot_thermal_reported;        //[MWt] HTF thermal power reported back to controller - should be 0 for recirculating startup and off
+
 	double m_dP_total;						//[bar] FIELD pressure drop
 	double m_W_dot_pump;					//[MWe] FIELD pumping power
 

--- a/tcs/csp_solver_trough_collector_receiver.h
+++ b/tcs/csp_solver_trough_collector_receiver.h
@@ -73,6 +73,8 @@ public:
 		E_Q_DOT_HTF_OUT,		    //[MWt]
 		E_Q_DOT_FREEZE_PROT,        //[MWt]
 
+        E_TIME_IN_STARTUP,          //[min]
+
 		E_M_DOT_LOOP,				//[kg/s]
         E_IS_RECIRCULATING,         //[-]
 		E_M_DOT_FIELD_RECIRC,		//[kg/s]
@@ -298,6 +300,10 @@ private:
 
 	double m_dP_total;						//[bar] FIELD pressure drop
 	double m_W_dot_pump;					//[MWe] FIELD pumping power
+
+    double m_time_at_off;                   //[s]
+    double m_time_at_startup;               //[s]
+    double m_time_at_on;                    //[s]
 
 	bool m_is_m_dot_recirc;		//[-] True: trough is recirculationg HTF with interacting with other CSP components
 

--- a/test/ssc_test/cmod_trough_physical_test.cpp
+++ b/test/ssc_test/cmod_trough_physical_test.cpp
@@ -242,7 +242,7 @@ NAMESPACE_TEST(csp_trough, PowerTroughCmod, Dispatch_Targets_Default_NoFinancial
         }
         // Check Receiver operations
         if (is_rec_su_allowed_in[i] == 0.0) {
-            EXPECT_LT(rec_heat_output[i], 0.0); // receiver shutdown
+            EXPECT_LT(rec_heat_output[i], 0.0001); // receiver shutdown
         }
     }
 


### PR DESCRIPTION
During hourly timesteps where the trough or fresnel solar field was in startup for part of the timestep and on for part of the timestep, the hourly output for solar field thermal power mistakenly included weighted values from startup mode. See this thread on the SAM support forum for more details https://sam.nrel.gov/forum/forum-general/3841-differences-fileld-fraction-of-focused-sca-and-flield-optical-focus-fraction.html#14072 