### PR TITLE
Fix overflow in Detailed PV Heat Transfer Method when using array dimensions

### DIFF
--- a/shared/lib_cec6par.cpp
+++ b/shared/lib_cec6par.cpp
@@ -103,7 +103,7 @@ cec6par_module_t::cec6par_module_t( )
 	Area = Vmp = Imp = Voc = Isc = alpha_isc = beta_voc 
 		= a = Il = Io = Rs = Rsh = Adj = std::numeric_limits<double>::quiet_NaN();
 }
-double air_mass_modifier( double Zenith_deg, double Elev_m, double a[5] )
+double air_mass_modifier( double Zenith_deg, double Elev_m, double const a[5] )
 {
 	// !Calculation of Air Mass Modifier
 	double air_mass = 1/(cos( Zenith_deg*M_PI/180 )+0.5057*pow(96.080-Zenith_deg, -1.634));
@@ -112,7 +112,7 @@ double air_mass_modifier( double Zenith_deg, double Elev_m, double a[5] )
 	return f1 > 0.0 ? f1 : 0.0;
 }
 
-bool cec6par_module_t::operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &out )
+bool cec6par_module_t::operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &out ) const
 {
 	double muIsc = alpha_isc * (1-Adj/100);
 	//double muVoc = beta_voc * (1+Adj/100);
@@ -216,7 +216,7 @@ bool cec6par_module_t::operator() ( pvinput_t &input, double TcellC, double opvo
  *********************************************************************************************
  *********************************************************************************************/
 
-bool noct_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &module, double , double &Tcell ) const
+bool noct_celltemp_t::operator() ( pvinput_t const &  input, pvmodule_t const &  module, double , double &Tcell ) const
 {
 	double G_total, Geff_total;
 	double tau_al = std::abs(TauAlpha);
@@ -362,7 +362,7 @@ static double channel_free_194( double W_gap, double SLOPE, double TA, double T_
 	return  Nu*k_air/W_gap;
 }
 
-bool mcsp_celltemp_t::operator() ( pvinput_t  &input, pvmodule_t &module, double opvoltage, double &Tcell ) const
+bool mcsp_celltemp_t::operator() ( pvinput_t const &input, pvmodule_t const &module, double opvoltage, double &Tcell ) const
 {	
     m_err = "Populating a default error message";
 	if ( input.Ibeam + input.Idiff + input.Ignd < 1 )

--- a/shared/lib_cec6par.h
+++ b/shared/lib_cec6par.h
@@ -62,13 +62,13 @@ public:
 
 	cec6par_module_t();
 
-	virtual double AreaRef() { return Area; }
-	virtual double VmpRef() { return Vmp; }
-	virtual double ImpRef() { return Imp; }
-	virtual double VocRef() { return Voc; }
-	virtual double IscRef() { return Isc; }
+	virtual double AreaRef() const { return Area; }
+	virtual double VmpRef() const { return Vmp; }
+	virtual double ImpRef() const { return Imp; }
+	virtual double VocRef() const { return Voc; }
+	virtual double IscRef() const { return Isc; }
 
-	virtual bool operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &output );
+	virtual bool operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &output ) const;
 
 	virtual ~cec6par_module_t() {};
 };
@@ -81,7 +81,7 @@ public:
 	double ffv_wind;
 	double Tnoct;
 
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const;
+	virtual bool operator() ( pvinput_t const &input, pvmodule_t const &module, double opvoltage, double &Tcell ) const;
 
 	virtual ~noct_celltemp_t(){}
 };
@@ -105,7 +105,7 @@ public:
     double ground_clearance_height; //Ground clearance height used in Calaf heat transfer coefficient h fit
     int lacunarity_enable;
     double GCR;
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const;
+	virtual bool operator() ( pvinput_t const &input, pvmodule_t const &module, double opvoltage, double &Tcell ) const;
 
 	virtual ~mcsp_celltemp_t() {};
 };

--- a/shared/lib_cec6par.h
+++ b/shared/lib_cec6par.h
@@ -81,7 +81,7 @@ public:
 	double ffv_wind;
 	double Tnoct;
 
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell );
+	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const;
 
 	virtual ~noct_celltemp_t(){}
 };
@@ -105,7 +105,7 @@ public:
     double ground_clearance_height; //Ground clearance height used in Calaf heat transfer coefficient h fit
     int lacunarity_enable;
     double GCR;
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell );
+	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const;
 
 	virtual ~mcsp_celltemp_t() {};
 };

--- a/shared/lib_iec61853.cpp
+++ b/shared/lib_iec61853.cpp
@@ -864,7 +864,7 @@ bool iec61853_module_t::calculate( util::matrix_t<double> &input, int nseries, i
 	return true;
 }
 
-bool iec61853_module_t::operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &out )
+bool iec61853_module_t::operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &out ) const
 {
 	/* initialize output first */
 	out.Power = out.Voltage = out.Current = out.Efficiency = out.Voc_oper = out.Isc_oper = 0.0;

--- a/shared/lib_iec61853.h
+++ b/shared/lib_iec61853.h
@@ -94,12 +94,12 @@ public:
 	bool tcoeff( util::matrix_t<double> &input, size_t icol, double irr, 
 		double *tempc, bool verbose );
 
-	virtual double AreaRef() { return Area; }
-	virtual double VmpRef() { return Vmp0; }
-	virtual double ImpRef() { return Imp0; }
-	virtual double VocRef() { return Voc0; }
-	virtual double IscRef() { return Isc0; }
-	virtual bool operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &output );
+	virtual double AreaRef() const { return Area; }
+	virtual double VmpRef() const { return Vmp0; }
+	virtual double ImpRef() const { return Imp0; }
+	virtual double VocRef() const { return Voc0; }
+	virtual double IscRef() const { return Isc0; }
+	virtual bool operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &output ) const;
 };
 
 

--- a/shared/lib_mlmodel.cpp
+++ b/shared/lib_mlmodel.cpp
@@ -92,7 +92,7 @@ double IAMvalue_ASHRAE(double b0, double theta)
 {
 	return (1 - b0 * (1 / cos(theta) - 1));
 }
-double IAMvalue_SANDIA(double coeff[], double theta)
+double IAMvalue_SANDIA(double const coeff[], double const theta)
 {
 	return coeff[0] + coeff[1] * theta + coeff[2] * pow(theta, 2) + coeff[3] * pow(theta, 3) + coeff[4] * pow(theta, 4) + coeff[5] * pow(theta, 5);
 }
@@ -141,7 +141,7 @@ void mlmodel_module_t::initializeManual()
 }
 
 // Main module model
-bool mlmodel_module_t::operator() (pvinput_t &input, double T_C, double opvoltage, pvoutput_t &out)
+bool mlmodel_module_t::operator() (pvinput_t const &input, double T_C, double opvoltage, pvoutput_t &out) const
 {
 	// initialize output first
 	out.Power = out.Voltage = out.Current = out.Efficiency = out.Voc_oper = out.Isc_oper = 0.0;
@@ -283,7 +283,7 @@ bool mlmodel_module_t::operator() (pvinput_t &input, double T_C, double opvoltag
 
 // mockup cell temperature model
 // to be used in cases when Tcell is calculated within the module model
-bool mock_celltemp_t::operator() (pvinput_t &, pvmodule_t &, double, double &Tcell) const
+bool mock_celltemp_t::operator() (pvinput_t const &, pvmodule_t const &, double, double &Tcell) const
 {
 	Tcell = -999;
 	return true;

--- a/shared/lib_mlmodel.cpp
+++ b/shared/lib_mlmodel.cpp
@@ -283,7 +283,7 @@ bool mlmodel_module_t::operator() (pvinput_t &input, double T_C, double opvoltag
 
 // mockup cell temperature model
 // to be used in cases when Tcell is calculated within the module model
-bool mock_celltemp_t::operator() (pvinput_t &, pvmodule_t &, double, double &Tcell)
+bool mock_celltemp_t::operator() (pvinput_t &, pvmodule_t &, double, double &Tcell) const
 {
 	Tcell = -999;
 	return true;

--- a/shared/lib_mlmodel.h
+++ b/shared/lib_mlmodel.h
@@ -94,12 +94,12 @@ public:
 
 	mlmodel_module_t();
 
-	virtual double AreaRef() { return (Width * Length); }
-	virtual double VmpRef() { return V_mp_ref; }
-	virtual double ImpRef() { return I_mp_ref; }
-	virtual double VocRef() { return V_oc_ref; }
-	virtual double IscRef() { return I_sc_ref; }
-	virtual bool operator() (pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &output);
+	virtual double AreaRef() const { return (Width * Length); }
+	virtual double VmpRef() const { return V_mp_ref; }
+	virtual double ImpRef() const { return I_mp_ref; }
+	virtual double VocRef() const { return V_oc_ref; }
+	virtual double IscRef() const { return I_sc_ref; }
+	virtual bool operator() (pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &output) const;
 	virtual void initializeManual();
 
 private:
@@ -116,7 +116,7 @@ private:
 class mock_celltemp_t : public pvcelltemp_t
 {
 public:
-	virtual bool operator() (pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell) const;
+	virtual bool operator() (pvinput_t const &input, pvmodule_t const &module, double opvoltage, double &Tcell) const;
 };
 
 #endif

--- a/shared/lib_mlmodel.h
+++ b/shared/lib_mlmodel.h
@@ -116,7 +116,7 @@ private:
 class mock_celltemp_t : public pvcelltemp_t
 {
 public:
-	virtual bool operator() (pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell);
+	virtual bool operator() (pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell) const;
 };
 
 #endif

--- a/shared/lib_pvmodel.cpp
+++ b/shared/lib_pvmodel.cpp
@@ -104,7 +104,7 @@ pvoutput_t::pvoutput_t( double p, double v,
 }
 
 
-std::string pvmodule_t::error()
+std::string pvmodule_t::error() const
 {
 	return m_err;
 }
@@ -122,7 +122,7 @@ spe_module_t::spe_module_t( )
 }
 
 	
-double spe_module_t::eff_interpolate( double irrad, double rad[5], double eff[5] )
+double spe_module_t::eff_interpolate( double const irrad, double const rad[5], double const eff[5] )
 {
 	if ( irrad < rad[0] )
 		return eff[0];
@@ -139,7 +139,7 @@ double spe_module_t::eff_interpolate( double irrad, double rad[5], double eff[5]
 	return (1-wx)*eff[i1]+wx*eff[i];
 }
 
-bool spe_module_t::operator() ( pvinput_t &input, double TcellC, double , pvoutput_t &output)
+bool spe_module_t::operator() ( pvinput_t const &input, double TcellC, double , pvoutput_t &output) const
 {
 	double idiff = fd*(input.Idiff + input.Ignd);
 

--- a/shared/lib_pvmodel.h
+++ b/shared/lib_pvmodel.h
@@ -91,10 +91,10 @@ class pvmodule_t; // forward decl
 class pvcelltemp_t
 {
 protected:
-	std::string m_err;
+	mutable std::string m_err;
 public:
 	
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) = 0;
+	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const = 0;
 	std::string error();
 
 	virtual ~pvcelltemp_t() {};

--- a/shared/lib_pvmodel.h
+++ b/shared/lib_pvmodel.h
@@ -94,7 +94,7 @@ protected:
 	mutable std::string m_err;
 public:
 	
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const = 0;
+	virtual bool operator() ( pvinput_t const &input, pvmodule_t const &module, double opvoltage, double &Tcell ) const = 0;
 	std::string error();
 
 	virtual ~pvcelltemp_t() {};
@@ -103,18 +103,18 @@ public:
 class pvmodule_t
 {
 protected:
-	std::string m_err;
+	mutable std::string m_err;
 public:
 
-	virtual double AreaRef() = 0;
-	virtual double VmpRef() = 0;
-	virtual double ImpRef() = 0;
-	virtual double VocRef() = 0;
-	virtual double IscRef() = 0;
+	virtual double AreaRef() const = 0;
+	virtual double VmpRef() const = 0;
+	virtual double ImpRef() const = 0;
+	virtual double VocRef() const = 0;
+	virtual double IscRef() const = 0;
 
 
-	virtual bool operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &output ) = 0;
-	std::string error();
+	virtual bool operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &output ) const = 0;
+	std::string error() const;
 
 	virtual ~pvmodule_t() {};
 };
@@ -134,16 +134,16 @@ public:
 	double Rad[5]; // W/m2
 
 	spe_module_t( );	
-	static double eff_interpolate( double irrad, double rad[5], double eff[5] );
+	static double eff_interpolate( double const irrad, double const rad[5], double const eff[5] );
 	
-	double WattsStc() { return Eff[Reference] * Rad[Reference] * Area; }
+	double WattsStc() const { return Eff[Reference] * Rad[Reference] * Area; }
 
-	virtual double AreaRef() { return Area; }
-	virtual double VmpRef() { return VmpNominal; }
-	virtual double ImpRef() { return WattsStc()/VmpRef(); }
-	virtual double VocRef() { return VocNominal; }
-	virtual double IscRef() { return ImpRef()*1.3; }
-	virtual bool operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &output);
+	virtual double AreaRef() const { return Area; }
+	virtual double VmpRef() const { return VmpNominal; }
+	virtual double ImpRef() const { return WattsStc()/VmpRef(); }
+	virtual double VocRef() const { return VocNominal; }
+	virtual double IscRef() const { return ImpRef()*1.3; }
+	virtual bool operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &output) const;
 
 	virtual ~spe_module_t() {};
 };
@@ -157,7 +157,7 @@ double openvoltage_5par( double Voc0, double a, double IL, double IO, double Rsh
 double openvoltage_5par_rec(double Voc0, double a, double IL, double IO, double Rsh, double D2MuTau, double Vbi);
 double maxpower_5par( double Voc_ubound, double a, double Il, double Io, double Rs, double Rsh, double *Vmp=0, double *Imp=0);
 double maxpower_5par_rec(double Voc_ubound, double a, double Il, double Io, double Rs, double Rsh, double D2MuTau, double Vbi, double *__Vmp=0, double *__Imp=0);
-double air_mass_modifier( double Zenith_deg, double Elev_m, double a[5] );
+double air_mass_modifier( double Zenith_deg, double Elev_m, double const a[5] );
 
 
 

--- a/shared/lib_sandia.cpp
+++ b/shared/lib_sandia.cpp
@@ -517,7 +517,7 @@ C b   = empirical constant
 	return E * exp(a + b * Ws) + Ta;
 }
 
-bool sandia_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &, double , double &Tcell )
+bool sandia_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &, double , double &Tcell ) const
 {
 	//Sev 2015-09-14: changed to permit direct poa data
 	double Itotal;

--- a/shared/lib_sandia.cpp
+++ b/shared/lib_sandia.cpp
@@ -276,7 +276,7 @@ sandia_module_t::sandia_module_t( )
 }
 
 
-bool sandia_module_t::operator() ( pvinput_t &in, double TcellC, double opvoltage, pvoutput_t &out )
+bool sandia_module_t::operator() ( pvinput_t const &in, double TcellC, double opvoltage, pvoutput_t &out ) const
 {
 	
 	out.Power = out.Voltage = out.Current = out.Efficiency = out.Voc_oper = out.Isc_oper = 0.0;
@@ -517,7 +517,7 @@ C b   = empirical constant
 	return E * exp(a + b * Ws) + Ta;
 }
 
-bool sandia_celltemp_t::operator() ( pvinput_t &input, pvmodule_t &, double , double &Tcell ) const
+bool sandia_celltemp_t::operator() ( pvinput_t const &input, pvmodule_t const &, double , double &Tcell ) const
 {
 	//Sev 2015-09-14: changed to permit direct poa data
 	double Itotal;

--- a/shared/lib_sandia.h
+++ b/shared/lib_sandia.h
@@ -61,12 +61,12 @@ public:
 
 	sandia_module_t( );	
 	
-	virtual double AreaRef() { return Area; }
-	virtual double VmpRef() { return Vmp0; }
-	virtual double ImpRef() { return Imp0; }
-	virtual double VocRef() { return Voc0; }
-	virtual double IscRef() { return Isc0; }
-	virtual bool operator() ( pvinput_t &input, double TcellC, double opvoltage, pvoutput_t &output);
+	virtual double AreaRef() const  { return Area; }
+	virtual double VmpRef() const { return Vmp0; }
+	virtual double ImpRef() const { return Imp0; }
+	virtual double VocRef() const { return Voc0; }
+	virtual double IscRef() const { return Isc0; }
+	virtual bool operator() ( pvinput_t const &input, double TcellC, double opvoltage, pvoutput_t &output) const;
 };
 
 
@@ -75,7 +75,7 @@ class sandia_celltemp_t : public pvcelltemp_t
 {
 public:
 	double a, b, DT0, fd;	
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const;
+	virtual bool operator() ( pvinput_t const &input, pvmodule_t const &module, double opvoltage, double &Tcell ) const;
 		
 	static double sandia_tcell_from_tmodule( double Tm, double poaIrr, double fd, double DT0);
 	static double sandia_module_temperature( double poaIrr, double Ws, double Ta, double fd, double a, double b );

--- a/shared/lib_sandia.h
+++ b/shared/lib_sandia.h
@@ -75,7 +75,7 @@ class sandia_celltemp_t : public pvcelltemp_t
 {
 public:
 	double a, b, DT0, fd;	
-	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell );
+	virtual bool operator() ( pvinput_t &input, pvmodule_t &module, double opvoltage, double &Tcell ) const;
 		
 	static double sandia_tcell_from_tmodule( double Tm, double poaIrr, double fd, double DT0);
 	static double sandia_module_temperature( double poaIrr, double Ws, double Ta, double fd, double a, double b );

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1719,7 +1719,11 @@ void cm_pvsamv1::exec()
                         if (Subarrays[nn]->useCustomCellTemp == 1)
                             tcell = Subarrays[nn]->customCellTempArray[inrec];
                         else
-                            (*Subarrays[nn]->Module->cellTempModel)(in, *Subarrays[nn]->Module->moduleModel, -1.0, tcell);
+                        {
+                            if (!(*Subarrays[nn]->Module->cellTempModel)(in, *Subarrays[nn]->Module->moduleModel, -1.0, tcell)) {
+                                throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                            }
+                        }
                     }
                     double shadedb_str_vmp_stc = Subarrays[nn]->nModulesPerString * Subarrays[nn]->Module->voltageMaxPower;
                     double shadedb_mppt_lo = PVSystem->Inverter->mpptLowVoltage;
@@ -2349,8 +2353,12 @@ void cm_pvsamv1::exec()
                                 double module_voltage = avgVoltage / (double)Subarrays[nn]->nModulesPerString;
                                 if (Subarrays[nn]->useCustomCellTemp == 1)
                                     tcell = Subarrays[nn]->customCellTempArray[inrec];
-                                else
-                                    (*Subarrays[nn]->Module->cellTempModel)(in[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell);
+                                else {
+                                    if (!(*Subarrays[nn]->Module->cellTempModel)(in[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell)) {
+                                        throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                                    }
+                                }
+                                    
                                 (*Subarrays[nn]->Module->moduleModel)(in[nn], tcell, module_voltage, out[nn]);
 
                                 if (iyear == 0 || save_full_lifetime_variables == 1)	mpptVoltageClipping[nn] -= out[nn].Power; //subtract the power that remains after voltage clipping in order to get the total loss. if no power was lost, all the power will be subtracted away again.

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -2219,9 +2219,17 @@ void cm_pvsamv1::exec()
                         if (Subarrays[nn]->useCustomCellTemp == 1)
                             tcell = Subarrays[nn]->customCellTempArray[inrec];
                         else {
-                            (*Subarrays[nn]->Module->cellTempModel)(in[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell);
-                            if (std::isnan(tcell)) throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
-                            (*Subarrays[nn]->Module->cellTempModel)(in_cs[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell_cs);
+                            if (!(*Subarrays[nn]->Module->cellTempModel)(in[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell)) {
+                                throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                            }
+                            // Checking if isnan here is insufficient. The function above could have returned
+                            // without modifying tcell from the assignment of tdry into tcell earlier. 
+                            if (std::isnan(tcell)) {
+                                throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                            }
+                            if (!(*Subarrays[nn]->Module->cellTempModel)(in_cs[nn], *Subarrays[nn]->Module->moduleModel, module_voltage, tcell_cs)) {
+                                throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                            }
                         }
                         // begin Transient Thermal model
                         // steady state cell temperature - confirm modification from module model to cell temp

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -2158,7 +2158,11 @@ void cm_pvsamv1::exec()
                                 if (Subarrays[nn]->useCustomCellTemp == 1)
                                     tcell = Subarrays[nn]->customCellTempArray[inrec];
                                 else
-                                    (*Subarrays[nn]->Module->cellTempModel)(in, *Subarrays[nn]->Module->moduleModel, V, tcell);
+                                {
+                                    if (!(*Subarrays[nn]->Module->cellTempModel)(in, *Subarrays[nn]->Module->moduleModel, V, tcell)) {
+                                        throw exec_error("pvsamv1", Subarrays[nn]->Module->cellTempModel->error());
+                                    }
+                                }
                                 // calculate module power output using conversion model previously specified
                                 (*Subarrays[nn]->Module->moduleModel)(in, tcell, V, out);
                             }


### PR DESCRIPTION
### Description

This PR fixes an overflow that led to incorrect results when using the detailed PV Heat Transfer Method when using array dimensions.

The root cause of the error was that the Length and Width parameters of the mcsp_celltemp_t class were being scaled by Nrows, Ncols on each iteration. The intended behavior was to scale them a single time. 

A secondary issue was that the result of the temperature model was not checked. The temperature model takes in a temperature variable by reference and modifies it upon return. In cases where the temperature model fails (including the overflow condition above), the function fails and returns false. Because this return is not checked, and because the temperature variable is initialized to ambient temp, the error state is not detected. This results in the behavior described in [nrel/SAM #2081](https://github.com/NREL/SAM/issues/2081).

This PR should solve these issues. 

1. It removes all modifications of class variables, and instead modifies local copies. This removes the overflow.
2. It adds additional error checking in cmod_pvsamv1.cpp.
3. It adds additional error messages in the mcsp_celltemp_t operator() function. 

One additional change I made is const-qualifying the pvcelltemp_t and pvmodule_t operator() methods, and cosnt-qualifying additional methods that are downstream of these operator() methods and therefore must be const as well. This required no changes in code besides those I already made in mcsp_celltemp_t to remove the overflow. Const-qualifying these methods should prevent errors of this class from arising in the future. 

To test, follow @cpaulgilman's steps to reproduce the bug from the initial issue:

> Steps to reproduce the behavior:
> 1. Create a default Detailed PV / No Financial case.
> 2. On the Module page, choose **Heat transfer method** for the temperature correction option.
> 3. Choose **Array Dimensions** for the heat transfer dimensions option.
> 4. Run a simulation.
> 5. On the Data Tables tab of the Results page, display "Subarray 1 Cell temperature (C)" and "Weather file ambient temperature (C)". Note that starting the last daylight time step of January 16, the cell temperature and ambient temperature are the same.

**Observe that now the cell temperature does not revert to the ambient temperature on January 16**. 

![image](https://github.com/user-attachments/assets/99cef5d9-1f29-431a-81a4-bdcd584a4edc)



Fixes # (issue(s)):  [nrel/SAM #2081](https://github.com/NREL/SAM/issues/2081)

### Corresponding branches and PRs:

This PR is an SSC only PR. There are no specific branches of other repositories that this PR depends upon. 

### Unit Test Impact:

No tests were changed. If tests exist which assumed the correctness of the detailed PV heat transfer method and used array dimensions, the output of those tests may now change. 

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone
