### PR TITLE
Enforce saving lifetime variables in PV-Battery simulations

### DIFF
--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1278,9 +1278,9 @@ void cm_pvsamv1::exec()
     bool en_batt = as_boolean("en_batt");
     int batt_topology = 0;
     if (en_batt && !save_full_lifetime_variables) {
-        if (nyears != 1) {
-            throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved when multiple years are simulated.");
-        }
+        //if (nyears != 1) {
+        //    throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved when multiple years are simulated.");
+        //}
     }
     if (en_batt) {
 

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1278,9 +1278,9 @@ void cm_pvsamv1::exec()
     bool en_batt = as_boolean("en_batt");
     int batt_topology = 0;
     if (en_batt && !save_full_lifetime_variables) {
-        //if (nyears != 1) {
-        //    throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved when multiple years are simulated.");
-        //}
+        if (nyears != 1) {
+            throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved when multiple years are simulated.");
+        }
     }
     if (en_batt) {
 

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1278,7 +1278,9 @@ void cm_pvsamv1::exec()
     bool en_batt = as_boolean("en_batt");
     int batt_topology = 0;
     if (en_batt && !save_full_lifetime_variables) {
-        throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved.");
+        if (nyears != 1) {
+            throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved when multiple years are simulated.");
+        }
     }
     if (en_batt) {
 

--- a/ssc/cmod_pvsamv1.cpp
+++ b/ssc/cmod_pvsamv1.cpp
@@ -1277,6 +1277,9 @@ void cm_pvsamv1::exec()
     std::shared_ptr<battstor> batt = nullptr;
     bool en_batt = as_boolean("en_batt");
     int batt_topology = 0;
+    if (en_batt && !save_full_lifetime_variables) {
+        throw exec_error("pvsamv1", "The PV Battery configuration requires full lifetime variables to be saved.");
+    }
     if (en_batt) {
 
         // Single timestep or non-annual simulations are not enabled with batteries


### PR DESCRIPTION
### Description

[SAM#2008](https://github.com/NREL/SAM/issues/2008) describes a bug in which deselecting the option to save lifetime variables in a PV-Battery simulation leads SAM to crash. The underlying cause of the crash is described more thoroughly in the SAM issue, but briefly, it is a heap corruption bug caused by the smaller, non-lifetime allocations being too small to compute figures for the battery in cmod_pvsamv1.cpp. 

This PR partially resolves this issue by disallowing the option to not save lifetime variables in cases where more than one year is simulated for a PV-Battery system. 

A separate PR in the SAM repository disables the corresponding checkbox in the UI for this option and additionally adds a warning message explaining why this option is disabled. 

To review, see @brtietz's instructions in the SAM issue:

> To Reproduce
> 
> Steps to reproduce the behavior:
> 
>     Set up a behind the meter, detailed PV + battery simulation (tested with host developer)
>     On the "DC degradation" page, uncheck the "save all output variables over analysis period" box
>     Set up a grid outage (tested with 100% crit load and an outage in every timestep
>     Run the simulation
>     SAM crashes


Fixes https://github.com/NREL/sam/issues/2008

### Corresponding branches and PRs:

https://github.com/NREL/SAM/pull/2087

### Unit Test Impact:

No changes expected for tests. 

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone


