### PR TITLE
Fix build on GCC 15.1.1

### DIFF
--- a/shared/lib_battery_dispatch.cpp
+++ b/shared/lib_battery_dispatch.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <math.h>
 #include <algorithm>
+#include <cstdint>
 
 /*
 Dispatch base class


### PR DESCRIPTION
Include missing `<cstdint>` for `SIZE_MAX`.

Fixes #1336 

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone
