### PR TITLE
Fix battery segfault from dereferencing std::max_element on an empty array

### DIFF
--- a/shared/lib_battery_dispatch_automatic_fom.cpp
+++ b/shared/lib_battery_dispatch_automatic_fom.cpp
@@ -281,7 +281,7 @@ void dispatch_automatic_front_of_meter_t::update_dispatch(size_t year, size_t ho
                 }
             }
             pv_hours_on = revenueToPVChargeForecast.size() / _steps_per_hour;
-            revenueToPVChargeMax = pv_hours_on >= t_duration ? *std::max_element(std::begin(revenueToPVChargeForecast), std::end(revenueToPVChargeForecast)): 0;
+            revenueToPVChargeMax = (!revenueToPVChargeForecast.empty() && pv_hours_on >= t_duration) ? *std::max_element(std::begin(revenueToPVChargeForecast), std::end(revenueToPVChargeForecast)): 0;
         }
 
         /*! Economic benefit of charging from clipped PV in current time step to discharge sometime in the next X hours (clipped PV is free) ($/kWh) */


### PR DESCRIPTION
### Description

Fixes https://github.com/NREL/ssc/issues/1346