### PR TITLE
Add support to run hybrids in SDKTool

### DIFF
--- a/sdktool/scripting.cpp
+++ b/sdktool/scripting.cpp
@@ -55,6 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "sscdev.h"
 #include "dataview.h"
 #include "scripting.h"
+#include "sscapi.h"
 
 void Output( const wxString &text )
 {
@@ -124,14 +125,66 @@ static bool sscvar_to_lkvar( lk::vardata_t &out, var_data *vv)
 			}
 		}
 		break;
-	}
+    case SSC_DATARR: {
+        size_t n = vv->vec.size();
+        out.empty_vector();
+        out.vec()->reserve((size_t)n);
+        for (int i = 0; i < n; i++) {
+            lk::vardata_t lk_data;
+            var_data entry = vv->vec[i];
+//            ssc_var_t entry = ssc_var_get_var_array(vd, i);
+            sscvar_to_lkvar(lk_data, &entry);
+            out.vec_append(lk_data);
+        }
+        break;
+    }
+/*
+    case SSC_DATMAT: {
+        int nr, nc;
+        ssc_var_size(vd, &nr, &nc);
+        out.empty_vector();
+        out.vec()->reserve(nr);
+        for (int i = 0; i < nr; i++) {
+            out.vec()->push_back(lk::vardata_t());
+            out.vec()->at(i).empty_vector();
+            out.vec()->at(i).vec()->reserve(nc);
+            for (int j = 0; j < nc; j++) {
+                lk::vardata_t lk_data;
+                ssc_var_t entry = ssc_var_get_var_matrix(vd, i, j);
+                sscvar_to_lkvar(entry, lk_data);
+                out.vec()->at(i).vec_append(lk_data);
+            }
+        }
+        break;
+    }
+    */
+    case SSC_INVALID:
+    default:
+        break;
+}
+
+
 
 	return true;
 }
 
+
+static bool check_numeric(const lk::vardata_t& vec) {
+    bool only_numeric = true;
+    for (size_t i = 0; i < vec.length(); i++) {
+        if (vec.index(i)->type() == lk::vardata_t::VECTOR)
+            only_numeric &= check_numeric(*vec.index(i));
+        else if (vec.index(i)->type() != lk::vardata_t::NUMBER) {
+            return false;
+        }
+    }
+    return only_numeric;
+};
+
 static bool lkvar_to_sscvar( var_data *vv, lk::vardata_t &val )
 {	
 	if (!vv) return false;
+//    ssc_var_t entry = ssc_var_create();
 
 	switch (val.type())
 	{
@@ -145,6 +198,8 @@ static bool lkvar_to_sscvar( var_data *vv, lk::vardata_t &val )
 		break;
 	case lk::vardata_t::VECTOR:
 		{
+            bool only_numeric = check_numeric(val);
+
 			size_t dim1 = val.length(), dim2 = 0;
 			for (size_t i=0;i<val.length();i++)
 			{
@@ -155,10 +210,29 @@ static bool lkvar_to_sscvar( var_data *vv, lk::vardata_t &val )
 
 			if (dim2 == 0 && dim1 > 0)
 			{
+  //              ssc_var_t p_var = vv;
+                if (only_numeric) {
+                    vv->type = SSC_ARRAY;
+                    vv->num.resize(dim1);
+                    for (size_t i = 0; i < dim1; i++) {
+                        vv->num[i] = (ssc_number_t)val.index(i)->as_number();
+                    }
+                }
+                else {
+                    vv->type = SSC_DATARR;
+                    vv->vec.resize(dim1);
+                    for (size_t i = 0; i < dim1; i++) {
+                        lkvar_to_sscvar(&(vv->vec[i]), *val.index(i));
+                    }
+                }
+
+                /*
 				vv->type = SSC_ARRAY;
 				vv->num.resize( dim1 );
-				for ( size_t i=0;i<dim1;i++)
-					vv->num[i] = (ssc_number_t)val.index(i)->as_number();
+                for (size_t i = 0; i < dim1; i++) {
+                        vv->num[i] = (ssc_number_t)val.index(i)->as_number();
+                }
+                */
 			}
 			else if ( dim1 > 0 && dim2 > 0 )
 			{
@@ -195,7 +269,6 @@ static bool lkvar_to_sscvar( var_data *vv, lk::vardata_t &val )
 		}
 		break;
 	}
-
 	return true;
 }
 

--- a/sdktool/scripting.cpp
+++ b/sdktool/scripting.cpp
@@ -128,20 +128,19 @@ static bool sscvar_to_lkvar( lk::vardata_t &out, var_data *vv)
     case SSC_DATARR: {
         size_t n = vv->vec.size();
         out.empty_vector();
-        out.vec()->reserve((size_t)n);
+        out.vec()->reserve(n);
         for (int i = 0; i < n; i++) {
             lk::vardata_t lk_data;
             var_data entry = vv->vec[i];
-//            ssc_var_t entry = ssc_var_get_var_array(vd, i);
             sscvar_to_lkvar(lk_data, &entry);
             out.vec_append(lk_data);
         }
         break;
     }
-/*
     case SSC_DATMAT: {
-        int nr, nc;
-        ssc_var_size(vd, &nr, &nc);
+        size_t nr, nc;
+        nr = vv->mat.size();
+        nc = vv->mat[0].size();
         out.empty_vector();
         out.vec()->reserve(nr);
         for (int i = 0; i < nr; i++) {
@@ -150,14 +149,14 @@ static bool sscvar_to_lkvar( lk::vardata_t &out, var_data *vv)
             out.vec()->at(i).vec()->reserve(nc);
             for (int j = 0; j < nc; j++) {
                 lk::vardata_t lk_data;
-                ssc_var_t entry = ssc_var_get_var_matrix(vd, i, j);
-                sscvar_to_lkvar(entry, lk_data);
+                var_data entry = vv->mat[i][j];
+                sscvar_to_lkvar(lk_data, &entry);
                 out.vec()->at(i).vec_append(lk_data);
             }
         }
         break;
     }
-    */
+    
     case SSC_INVALID:
     default:
         break;
@@ -208,9 +207,7 @@ static bool lkvar_to_sscvar( var_data *vv, lk::vardata_t &val )
 					dim2 = row->length();
 			}
 
-			if (dim2 == 0 && dim1 > 0)
-			{
-  //              ssc_var_t p_var = vv;
+			if (dim2 == 0 && dim1 > 0)	{
                 if (only_numeric) {
                     vv->type = SSC_ARRAY;
                     vv->num.resize(dim1);
@@ -225,31 +222,36 @@ static bool lkvar_to_sscvar( var_data *vv, lk::vardata_t &val )
                         lkvar_to_sscvar(&(vv->vec[i]), *val.index(i));
                     }
                 }
-
-                /*
-				vv->type = SSC_ARRAY;
-				vv->num.resize( dim1 );
-                for (size_t i = 0; i < dim1; i++) {
-                        vv->num[i] = (ssc_number_t)val.index(i)->as_number();
-                }
-                */
 			}
-			else if ( dim1 > 0 && dim2 > 0 )
-			{
-				vv->type = SSC_MATRIX;
-				vv->num.resize( dim1, dim2 );
-				for ( size_t i=0;i<dim1;i++)
-				{
-					for ( size_t j=0;j<dim2;j++ )
-					{
-						double x = 0;
-						if ( val.index(i)->type() == lk::vardata_t::VECTOR
-							&& j < val.index(i)->length() )
-							x = (ssc_number_t)val.index(i)->index(j)->as_number();
-
-						vv->num.at(i,j) = x;
-					}
-				}
+			else if ( dim1 > 0 && dim2 > 0 ){
+                if (only_numeric) {
+                    vv->type = SSC_MATRIX;
+                    vv->num.resize(dim1, dim2);
+                    for (size_t i = 0; i < dim1; i++) {
+                        for (size_t j = 0; j < dim2; j++) {
+                            double x = 0;
+                            if (val.index(i)->type() == lk::vardata_t::VECTOR
+                                && j < val.index(i)->length())
+                                x = (ssc_number_t)val.index(i)->index(j)->as_number();
+                            vv->num.at(i, j) = x;
+                        }
+                    }
+                }
+                else {
+                    vv->type = SSC_DATMAT;
+                    vv->mat.resize(dim1);
+                    for (size_t i = 0; i < dim1; i++) {
+                        vv->mat[i].resize(dim2);
+                        for (size_t j = 0; j < dim2; j++) {
+                            if (val.index(i)->type() == lk::vardata_t::VECTOR
+                                && j < val.index(i)->length())
+                                lkvar_to_sscvar(&(vv->mat[i][j]), *val.index(i)->index(j));
+                            else {
+                                vv->mat[i][j].type = SSC_INVALID;
+                            }
+                        }
+                    }
+                }
 			}
 		}
 		break;


### PR DESCRIPTION
Updates SDKTool var function to work with hybrids.

Specifically, add support to scripting.cpp for SSC_DATARR and SSC_DATMAT types.

To test use hybrids_sdktool branch o ssc and the develop branches of other repos and clean and build SAM and SDKTool

1. In SAM, create and PVWatts Wind Battery Single Owner case
2. Use the case menu and Code generation... and select "LK for SDKTool"
3. Run the SDKTool from VS2022 or from explorer (on Windows)
4. Select the recently build ssc.dll from SDKTool Module Browser
5. Run the attached lk scripts (also has the generated json file if you want to skip steps 1 and 2)
[lk_SDKTool.zip](https://github.com/user-attachments/files/23051179/lk_SDKTool.zip)


Expected results from the PVWatts_Wind_Battery_inputs_outputs.lk using the PVWatts_Wind_Battery.json generated file
<img width="895" height="1110" alt="image" src="https://github.com/user-attachments/assets/ee5b515f-427a-4d33-8058-8dd6a967c8d1" />

Expected results from the test_datmat.lk SDKTool file
<img width="829" height="457" alt="image" src="https://github.com/user-attachments/assets/b1bfe56b-5510-4a35-ab83-4a1874669d4b" />

 