### PR TITLE
Add back work ratio to sco2 outputs.

### DIFF
--- a/ssc/csp_common.cpp
+++ b/ssc/csp_common.cpp
@@ -941,6 +941,10 @@ var_info vtab_sco2_design[] = {
     { SSC_OUTPUT, SSC_NUMBER,  "t2_D",                 "Secondary Turbine diameter",                             "m",          "Turbine 2",  "",      "cycle_config=4",     "",       "" },
     { SSC_OUTPUT, SSC_NUMBER,  "t2_cost_equipment",    "Secondary Tubine cost - equipment",                      "M$",         "Turbine 2",  "",      "cycle_config=4",     "",       "" },
     { SSC_OUTPUT, SSC_NUMBER,  "t2_cost_bare_erected", "Secondary Tubine cost - equipment plus install",         "M$",         "Turbine 2",  "",      "cycle_config=4",     "",       "" },
+        // Turbine Totals
+    { SSC_OUTPUT, SSC_NUMBER,   "t_tot_cost_equip",    "Turbine total cost",                                     "M$",         "Compressor Totals",    "",  "*",     "",       "" },
+    { SSC_OUTPUT, SSC_NUMBER,   "t_tot_W_dot",         "Turbine total summed power",                             "MWe",        "Compressor Totals",    "",  "*",     "",       "" },
+    { SSC_OUTPUT, SSC_NUMBER,   "back_work_ratio",     "Back work ratio",                                        "",           "Compressor Totals",    "",  "*",     "",       "" },
         // Recuperators																				 
 	{ SSC_OUTPUT, SSC_NUMBER,  "recup_total_UA_assigned", "Total recuperator UA assigned to design routine",     "MW/K",       "Recuperators",    "",      "*",     "",       "" },
     { SSC_OUTPUT, SSC_NUMBER,  "recup_total_UA_calculated", "Total recuperator UA calculated considering max eff and/or min temp diff parameter", "MW/K",       "Recuperators",    "",      "*",     "",       "" },
@@ -1751,7 +1755,9 @@ int sco2_design_cmod_common(compute_module *cm, C_sco2_phx_air_cooler & c_sco2_c
 	cm->assign("c_tot_cost_equip", comp_cost_equip_sum);		//[M$]
 	cm->assign("c_tot_W_dot", comp_power_sum);		//[MWe]
 	// Turbine
-	cm->assign("t_W_dot", (ssc_number_t)(c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_W_dot_t*1.E-3));	//[MWe] convert from kWe
+    double t_tot_W_dot = c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_W_dot_t * 1.E-3;    // [MWe]
+    double t_tot_cost_equip = c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.ms_t_des_solved.m_equipment_cost;    // [M$]
+    cm->assign("t_W_dot", (ssc_number_t)(c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_W_dot_t*1.E-3));	//[MWe] convert from kWe
 	cm->assign("t_m_dot_des", (ssc_number_t)c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_m_dot_t);		//[kg/s]
 	cm->assign("T_turb_in", (ssc_number_t)(c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_temp[C_sco2_cycle_core::TURB_IN] - 273.15));	//[C] Turbine inlet temp, convert from K
 	cm->assign("t_P_in_des", (ssc_number_t)(c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_pres[C_sco2_cycle_core::TURB_IN] * 1.E-3));	//[MPa] Turbine inlet pressure, convert from kPa
@@ -1787,9 +1793,17 @@ int sco2_design_cmod_common(compute_module *cm, C_sco2_phx_air_cooler & c_sco2_c
         cost_equip_sum += c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.ms_t2_des_solved.m_equipment_cost;			//[M$]
         cm->assign("t2_cost_bare_erected", (ssc_number_t)c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.ms_t2_des_solved.m_bare_erected_cost);		//[M$]
         cost_bare_erected_sum += c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.ms_t2_des_solved.m_bare_erected_cost;
-    }
-    
 
+        t_tot_W_dot += c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.m_W_dot_t2 * 1.E-3; // [MWe]
+        t_tot_cost_equip += c_sco2_cycle.get_design_solved()->ms_rc_cycle_solved.ms_t2_des_solved.m_equipment_cost; // [M$]
+    }
+
+    // Turbine Totals
+    cm->assign("t_tot_cost_equip", t_tot_cost_equip);   // [M$]
+    cm->assign("t_tot_W_dot", t_tot_W_dot); // [MWe]
+
+    // Back work ratio
+    cm->assign("back_work_ratio", comp_power_sum / t_tot_W_dot);    // []
 
         // Recuperator
     int LTR_LP_IN_enum = cycle_config == 4 ? C_sco2_cycle_core::TURB2_OUT : C_sco2_cycle_core::HTR_LP_OUT;  // Define LTR LP inlet state point

--- a/test/ssc_test/cmod_sco2_csp_system_test.cpp
+++ b/test/ssc_test/cmod_sco2_csp_system_test.cpp
@@ -246,6 +246,14 @@ NAMESPACE_TEST(sco2_design_tests, SCO2Design, recompression_default)
 
     // Check expected vs actual results
     check_result_vals(sco2, result_dict);
+
+    // Validate back work ratio calculation
+    double comp_W_dot = sco2.GetOutput("mc_W_dot") + sco2.GetOutput("rc_W_dot");
+    double t_W_dot = sco2.GetOutput("t_W_dot");
+    double back_work_ratio = comp_W_dot / t_W_dot;
+
+    double back_work_actual = sco2.GetOutput("back_work_ratio");
+    ASSERT_NEAR(back_work_ratio, back_work_actual, kTol);
 }
 
 NAMESPACE_TEST(sco2_design_tests, SCO2Design, simple_default)
@@ -274,6 +282,14 @@ NAMESPACE_TEST(sco2_design_tests, SCO2Design, simple_default)
 
     // Check expected vs actual results
     check_result_vals(sco2, result_dict);
+
+    // Validate back work ratio calculation
+    double comp_W_dot = sco2.GetOutput("mc_W_dot");
+    double t_W_dot = sco2.GetOutput("t_W_dot");
+    double back_work_ratio = comp_W_dot / t_W_dot;
+
+    double back_work_actual = sco2.GetOutput("back_work_ratio");
+    ASSERT_NEAR(back_work_ratio, back_work_actual, kTol);
 }
 
 NAMESPACE_TEST(sco2_design_tests, SCO2Design, partial_default)
@@ -302,6 +318,14 @@ NAMESPACE_TEST(sco2_design_tests, SCO2Design, partial_default)
 
     // Check expected vs actual results
     check_result_vals(sco2, result_dict);
+
+    // Validate back work ratio calculation
+    double comp_W_dot = sco2.GetOutput("mc_W_dot") + sco2.GetOutput("rc_W_dot") + sco2.GetOutput("pc_W_dot");
+    double t_W_dot = sco2.GetOutput("t_W_dot");
+    double back_work_ratio = comp_W_dot / t_W_dot;
+
+    double back_work_actual = sco2.GetOutput("back_work_ratio");
+    ASSERT_NEAR(back_work_ratio, back_work_actual, kTol);
 }
 
 NAMESPACE_TEST(sco2_design_tests, SCO2Design, htrbp_default)
@@ -336,6 +360,14 @@ NAMESPACE_TEST(sco2_design_tests, SCO2Design, htrbp_default)
 
     // Check expected vs actual results
     check_result_vals(sco2, result_dict);
+
+    // Validate back work ratio calculation
+    double comp_W_dot = sco2.GetOutput("mc_W_dot") + sco2.GetOutput("rc_W_dot");
+    double t_W_dot = sco2.GetOutput("t_W_dot");
+    double back_work_ratio = comp_W_dot / t_W_dot;
+
+    double back_work_actual = sco2.GetOutput("back_work_ratio");
+    ASSERT_NEAR(back_work_ratio, back_work_actual, kTol);
 }
 
 NAMESPACE_TEST(sco2_design_tests, SCO2Design, tsf_default)
@@ -366,6 +398,14 @@ NAMESPACE_TEST(sco2_design_tests, SCO2Design, tsf_default)
 
     // Check expected vs actual results
     check_result_vals(sco2, result_dict);
+
+    // Validate back work ratio calculation
+    double comp_W_dot = sco2.GetOutput("mc_W_dot");
+    double t_W_dot = sco2.GetOutput("t_W_dot") + sco2.GetOutput("t2_W_dot");
+    double back_work_ratio = comp_W_dot / t_W_dot;
+
+    double back_work_actual = sco2.GetOutput("back_work_ratio");
+    ASSERT_NEAR(back_work_ratio, back_work_actual, kTol);
 }
 
 // Design method 1 (hit target eta by varying total UA)
@@ -402,6 +442,14 @@ NAMESPACE_TEST(sco2_design_tests, SCO2Design, htrbp_des1)
 
     // Check expected vs actual results
     check_result_vals(sco2, result_dict);
+
+    // Validate back work ratio calculation
+    double comp_W_dot = sco2.GetOutput("mc_W_dot") + sco2.GetOutput("rc_W_dot");
+    double t_W_dot = sco2.GetOutput("t_W_dot");
+    double back_work_ratio = comp_W_dot / t_W_dot;
+
+    double back_work_actual = sco2.GetOutput("back_work_ratio");
+    ASSERT_NEAR(back_work_ratio, back_work_actual, kTol);
 }
 
 


### PR DESCRIPTION
## Pull Request Template

### Description

Add back work ratio and turbine sums to sco2 vartable outputs.

### Corresponding branches and PRs:

SAM, wex, lk: develop

### Unit Test Impact:

Modified sco2 tests to include check for back work ratio calculation.

### Checklist
- [x] adds, removes, modifies, or deletes variables in existing compute modules
