### PR TITLE
Lengthen analysis period and max loan term variables

### DIFF
--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lib_util.h"
 
 var_info vtab_standard_financial[] = {
-{ SSC_INPUT,SSC_NUMBER  , "analysis_period"                      , "Analyis period"                                                 , "years"                                  , ""                                      , "Financial Parameters" , "?=30"           , "INTEGER,MIN=0,MAX=50"  , ""},
+{ SSC_INPUT,SSC_NUMBER  , "analysis_period"                      , "Analyis period"                                                 , "years"                                  , ""                                      , "Financial Parameters" , "?=30"           , "INTEGER,MIN=0,MAX=100"  , ""},
 { SSC_INPUT, SSC_ARRAY  , "federal_tax_rate"                     , "Federal income tax rate"                                        , "%"                                      , ""                                      , "Financial Parameters" , "*"              , ""                      , ""},
 { SSC_INPUT, SSC_ARRAY  , "state_tax_rate"                       , "State income tax rate"                                          , "%"                                      , ""                                      , "Financial Parameters" , "*"              , ""                      , ""},
 
@@ -94,7 +94,7 @@ var_info vtab_fuelcell_replacement_cost[] = {
 var_info_invalid };
 
 var_info vtab_standard_loan[] = {
-{ SSC_INPUT,SSC_NUMBER  , "loan_term"                            , "Loan term"                                                      , "years"                                  , ""                                      , "Financial Parameters" , "?=0"            , "INTEGER,MIN=0,MAX=50"  , ""},
+{ SSC_INPUT,SSC_NUMBER  , "loan_term"                            , "Loan term"                                                      , "years"                                  , ""                                      , "Financial Parameters" , "?=0"            , "INTEGER,MIN=0,MAX=100"  , ""},
 { SSC_INPUT,SSC_NUMBER  , "loan_rate"                            , "Loan rate"                                                      , "%"                                      , ""                                      , "Financial Parameters" , "?=0"            , "MIN=0,MAX=100"         , ""},
 { SSC_INPUT,SSC_NUMBER  , "debt_fraction"                        , "Debt percentage"                                                , "%"                                      , ""                                      , "Financial Parameters" , "?=0"            , "MIN=0,MAX=100"         , ""},
 var_info_invalid };


### PR DESCRIPTION
## Pull Request Template

### Description

Change ssc vartable limits to allow analysis periods of up to 100 years. 

Fixes # https://github.com/NREL/SAM/issues/2140

The SAM GUI has several seconds of "not responding" when attempting to shorten a long analysis period, but this also occurs on the released version (say changing 50 to 45) so I haven't attempted to address it here.

### Corresponding branches and PRs:

Develop of wex, lk, sam-private

SAM PR https://github.com/NREL/SAM/pull/2139 resolves some related callback issues that make this easier to test, but these are technically independent.

### Unit Test Impact:

Open to suggestions on unit test impact

### Checklist
- [x] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [x] I've tagged this PR to a milestone

