### PR TITLE
Copy values to a new vector that should solve snow model re-initaliza…

### DIFF
--- a/test/ssc_test/cmod_pvsamv1_test.cpp
+++ b/test/ssc_test/cmod_pvsamv1_test.cpp
@@ -1081,7 +1081,11 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, UserArraySnowModel)
     // pull the wf snow data and put it into an array
     int l = 8760;
     ssc_number_t* snowdepth = ssc_data_get_array(data, "snowdepth", &l);
-    ssc_data_set_array(data, "snow_array", snowdepth, 8760);
+    // Copy into a local vector immediately: the raw pointer points into var_table
+    // internal storage and becomes dangling after the next simulation reallocates
+    // the "snowdepth" output array.
+    std::vector<ssc_number_t> snowdepth_vec(snowdepth, snowdepth + l);
+    ssc_data_set_array(data, "snow_array", snowdepth_vec.data(), 8760);
     // Use the snow data from the snow depth array
     pairs["use_snow_weather_file"] = 0;
     pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
@@ -1094,8 +1098,8 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, UserArraySnowModel)
     std::vector<ssc_number_t> upsampled;
     upsampled.reserve(8760 * 2);
     for (size_t i = 0; i < 8760; i++) {
-        upsampled.push_back(snowdepth[i]);
-        upsampled.push_back(snowdepth[i]);
+        upsampled.push_back(snowdepth_vec[i]);
+        upsampled.push_back(snowdepth_vec[i]);
     }
     ssc_data_set_array(data, "snow_array", upsampled.data(), 8760*2);
     pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
@@ -1108,7 +1112,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, UserArraySnowModel)
     std::vector<ssc_number_t> downsampled;
     downsampled.reserve(8760 / 2);
     for (size_t i = 0; i < 8760/2; i++) {
-        downsampled.push_back(snowdepth[2*i]);
+        downsampled.push_back(snowdepth_vec[2*i]);
     }
     ssc_data_set_array(data, "snow_array", downsampled.data(), 8760 / 2);
     pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
@@ -1158,7 +1162,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, SubhourlyClippingCorrectionModel)
         0.95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     };
-    
+
     ssc_data_set_matrix(data, "subhourly_clipping_matrix", Subhourly_Clipping_Matrix, 21, 21);
     //pairs["subhourly_clipping_matrix"] = sub_clipping_matrix;
     pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
@@ -1173,7 +1177,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, SubhourlyClippingCorrectionModel)
         for (int j = 0; j < 17; j++) {
             Subhourly_Clipping_Matrix_Short[i * 17 + j] = Subhourly_Clipping_Matrix[i * 21 + j];
         }
-    }
+        }
     ssc_data_set_matrix(data, "subhourly_clipping_matrix", Subhourly_Clipping_Matrix_Short, 16, 17);
     pvsam_errors = modify_ssc_data_and_run_module(data, "pvsamv1", pairs);
     EXPECT_FALSE(pvsam_errors);
@@ -1184,7 +1188,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, SubhourlyClippingCorrectionModel)
     EXPECT_NEAR(subhourly_clipping_loss_short, 24.746267, m_error_tolerance_lo);
     ssc_data_get_number(data, "annual_subhourly_clipping_loss_percent", &subhourly_clipping_loss_percent);
     EXPECT_NEAR(subhourly_clipping_loss_percent, 0.271086, m_error_tolerance_lo);
-}
+    }
 
 TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, useCustomCellTemp) {
 
@@ -1210,7 +1214,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, useCustomCellTemp) {
 
 
 
-}
+    }
 
 TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, UseCustomAngles) {
 
@@ -1456,7 +1460,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NonAnnual)
 
     //run the tests
     EXPECT_FALSE(run_module(data, "pvsamv1"));
-
+    
     ssc_number_t dc_net, gen;
     dc_net = ssc_data_get_array(data, "dc_net", nullptr)[12];
     EXPECT_NEAR(dc_net, 3.213, 0.01) << "DC Net Energy at noon";
@@ -1466,7 +1470,7 @@ TEST_F(CMPvsamv1PowerIntegration_cmod_pvsamv1, NonAnnual)
 
     //free the weather data
     free_weatherdata_array(weather_data);
-}
+        }
 
 
 //test non-annual run that includes Feb 29


### PR DESCRIPTION
…tion errors

## Pull Request Template

### Description

Attempt at solving https://github.com/NatLabRockies/ssc/issues/1372

Hypothesis is that keeping a pointer for the snow data array and passing that to multiple tests caused the memory to be corrupted and the results to change. Copy these values into a vector so the underlying data doesn't change run to run.

Credit to Claude Sonnet for spotting the memory re-use. Blame to Claude Sonnet for some of the annoying tab/spacing changes on the close braces.

Fixes https://github.com/NatLabRockies/ssc/issues/1372

### Corresponding branches and PRs:

Develop on all other branches

### Unit Test Impact:

Expect tests to pass consistently across OSes

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone

### Reminders- this section can be deleted
[Checking for PySAM Incompatible API Changes]
(https://github.com/NREL/SAM/wiki/PySAM-Incompatible-API-Changes-&-Regenerating-PySAM-Files).

[When do the PySAM files need to be regenerated?]
(https://github.com/NREL/SAM/wiki/PySAM-Incompatible-API-Changes-&-Regenerating-PySAM-Files#when-do-the-pysam-files-need-to-be-regenerated-via-export_config)
