### PR TITLE
Add mac latest back into the mix after ordering issues have (hopefully) been solved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14-large]
+        os: [macos-14-large, macos-latest]
 
     steps:
     - name: Setup cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,18 @@ jobs:
         ORTOOLSDIR=$GITHUB_WORKSPACE/or-tools_x86_64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE
         echo "ORTOOLSDIR=$ORTOOLSDIR" >> $GITHUB_ENV
     
-    - name: Download OR-Tools
-      if: steps.cached-ortools-restore.outputs.cache-hit != 'true'
+    - name: Download OR-Tools x86
+      if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == macos-14-large
       shell: bash
       run: |
         curl -L https://github.com/google/or-tools/releases/download/v$ORTOOLS_VER/or-tools_x86_64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE.tar.gz -o or-tools-$ORTOOLS_VER.tar.gz
+        tar xvzf or-tools-$ORTOOLS_VER.tar.gz
+ 
+    - name: Download OR-Tools x64
+      if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == macos-latest
+      shell: bash
+      run: |
+        curl -L https://github.com/google/or-tools/releases/download/v$ORTOOLS_VER/or-tools_arm64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE.tar.gz -o or-tools-$ORTOOLS_VER.tar.gz
         tar xvzf or-tools-$ORTOOLS_VER.tar.gz
  
     - name: Get cached GTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,14 @@ jobs:
         echo "ORTOOLSDIR=$ORTOOLSDIR" >> $GITHUB_ENV
     
     - name: Download OR-Tools x86
-      if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == macos-14-large
+      if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == 'macos-14-large'
       shell: bash
       run: |
         curl -L https://github.com/google/or-tools/releases/download/v$ORTOOLS_VER/or-tools_x86_64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE.tar.gz -o or-tools-$ORTOOLS_VER.tar.gz
         tar xvzf or-tools-$ORTOOLS_VER.tar.gz
  
     - name: Download OR-Tools x64
-      if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == macos-latest
+      if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == 'macos-latest'
       shell: bash
       run: |
         curl -L https://github.com/google/or-tools/releases/download/v$ORTOOLS_VER/or-tools_arm64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE.tar.gz -o or-tools-$ORTOOLS_VER.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,6 @@ jobs:
         echo "GTEST=$GTEST" >> $GITHUB_ENV
         SSCDIR=$GITHUB_WORKSPACE/ssc
         echo "SSCDIR=$SSCDIR" >> $GITHUB_ENV
-        ORTOOLSDIR=$GITHUB_WORKSPACE/or-tools_x86_64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE
-        echo "ORTOOLSDIR=$ORTOOLSDIR" >> $GITHUB_ENV
     
     - name: Download OR-Tools x86
       if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == 'macos-14-large'
@@ -133,6 +131,8 @@ jobs:
       run: |
         curl -L https://github.com/google/or-tools/releases/download/v$ORTOOLS_VER/or-tools_x86_64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE.tar.gz -o or-tools-$ORTOOLS_VER.tar.gz
         tar xvzf or-tools-$ORTOOLS_VER.tar.gz
+        ORTOOLSDIR=$GITHUB_WORKSPACE/or-tools_x86_64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE
+        echo "ORTOOLSDIR=$ORTOOLSDIR" >> $GITHUB_ENV
  
     - name: Download OR-Tools x64
       if: steps.cached-ortools-restore.outputs.cache-hit != 'true' && matrix.os == 'macos-latest'
@@ -140,6 +140,8 @@ jobs:
       run: |
         curl -L https://github.com/google/or-tools/releases/download/v$ORTOOLS_VER/or-tools_arm64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE.tar.gz -o or-tools-$ORTOOLS_VER.tar.gz
         tar xvzf or-tools-$ORTOOLS_VER.tar.gz
+        ORTOOLSDIR=$GITHUB_WORKSPACE/or-tools_arm64_macOS-15.5_cpp_v$ORTOOLS_VER.$ORTOOLS_RELEASE
+        echo "ORTOOLSDIR=$ORTOOLSDIR" >> $GITHUB_ENV
  
     - name: Get cached GTest
       uses: actions/cache@v4


### PR DESCRIPTION
## Pull Request Template

### Description

Now that we've fixed more issues that were identified in https://github.com/NatLabRockies/ssc/pull/1354, re-enable the mac-latest runner

### Corresponding branches and PRs:

N/A

### Unit Test Impact:

Hopefully everything passes, otherwise we might have more PRs prior to getting this runner enabled

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [x] I've tagged this PR to a milestone
