### PR TITLE
Ssc 1300 wind lifetime mode

### DIFF
--- a/shared/lib_battery.cpp
+++ b/shared/lib_battery.cpp
@@ -537,6 +537,8 @@ double battery_t::calculate_max_charge_kw(double *max_current_A) {
         thermal->updateTemperature(current, state->last_idx + 1);
         qmax = capacity->qmax() * thermal->capacity_percent() * 0.01 * SOC_ratio;
     }
+    current = std::min(0.0, current);
+    power_W = std::min(0.0, power_W);
     if (max_current_A)
         *max_current_A = current;
     *thermal->state = thermal_initial;
@@ -556,6 +558,8 @@ double battery_t::calculate_max_discharge_kw(double *max_current_A) {
         thermal->updateTemperature(current, state->last_idx + 1);
         qmax = capacity->qmax() * thermal->capacity_percent()  * 0.01;
     }
+    current = std::max(0.0, current);
+    power_W = std::max(0.0, power_W);
     if (max_current_A)
         *max_current_A = current;
     *thermal->state = thermal_initial;

--- a/shared/lib_pv_io_manager.cpp
+++ b/shared/lib_pv_io_manager.cpp
@@ -140,7 +140,7 @@ Irradiance_IO::Irradiance_IO(compute_module* cm, std::string cmName)
         if (weatherDataProvider->has_message()) cm->log(weatherDataProvider->message(), SSC_WARNING);
     }
     else {
-        throw exec_error(cmName, "No weather data supplied");
+        throw exec_error(cmName, "No weather data supplied.");
     }
 
     // assumes instantaneous values, unless hourly file with no minute column specified
@@ -166,7 +166,7 @@ Irradiance_IO::Irradiance_IO(compute_module* cm, std::string cmName)
         tsShiftHours = 0.5;
     }
     else
-        throw exec_error(cmName, "subhourly and non-annual weather files must specify the minute for each record");
+        throw exec_error(cmName, "Subhourly and non-annual weather files must specify the minute for each record.");
 
     weatherDataProvider->header(&weatherHeader);
 
@@ -182,7 +182,7 @@ Irradiance_IO::Irradiance_IO(compute_module* cm, std::string cmName)
     }
 
     if (weatherDataProvider->annualSimulation() && numberOfWeatherFileRecords % 8760 != 0)
-        throw exec_error(cmName, util::format("invalid number of data records (%zu): must be an integer multiple of 8760", numberOfWeatherFileRecords));
+        throw exec_error(cmName, util::format("Invalid number of data records (%zu): must be an integer multiple of 8760.", numberOfWeatherFileRecords));
     if (weatherDataProvider->annualSimulation() && (stepsPerHour < 1 || stepsPerHour > 60))
         throw exec_error(cmName, util::format("%d timesteps per hour found. Weather data should be single year.", stepsPerHour));
 
@@ -251,36 +251,36 @@ void Irradiance_IO::checkWeatherFile(compute_module* cm, std::string cmName)
     for (size_t idx = 0; idx < numberOfWeatherFileRecords; idx++)
     {
         if (!weatherDataProvider->read(&weatherRecord))
-            throw exec_error(cmName, "could not read data line " + util::to_string((int)(idx + 1)) + " in weather file");
+            throw exec_error(cmName, "Could not read data line " + util::to_string((int)(idx + 1)) + " in weather file.");
 
         // Check for missing data
         if ((weatherRecord.gh != weatherRecord.gh) && (radiationMode == irrad::DN_GH || radiationMode == irrad::GH_DF)) {
-            cm->log(util::format("missing global irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting",
+            cm->log(util::format("Missing global irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting.",
                 weatherRecord.gh, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_ERROR, (float)idx);
             return;
         }
         if ((weatherRecord.dn != weatherRecord.dn) && (radiationMode == irrad::DN_DF || radiationMode == irrad::DN_GH)) {
-            cm->log(util::format("missing beam irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting",
+            cm->log(util::format("Missing beam irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting.",
                 weatherRecord.dn, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_ERROR, (float)idx);
             return;
         }
         if ((weatherRecord.df != weatherRecord.df) && (radiationMode == irrad::DN_DF || radiationMode == irrad::GH_DF)) {
-            cm->log(util::format("missing diffuse irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting",
+            cm->log(util::format("Missing diffuse irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting.",
                 weatherRecord.df, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_ERROR, (float)idx);
             return;
         }
         if ((weatherRecord.poa != weatherRecord.poa) && (radiationMode == irrad::POA_R || radiationMode == irrad::POA_P)) {
-            cm->log(util::format("missing POA irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting",
+            cm->log(util::format("Missing POA irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting.",
                 weatherRecord.poa, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_ERROR, (float)idx);
             return;
         }
         if (weatherRecord.tdry != weatherRecord.tdry) {
-            cm->log(util::format("missing temperature %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting",
+            cm->log(util::format("Missing temperature %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting.",
                 weatherRecord.tdry, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_ERROR, (float)idx);
             return;
         }
         if (weatherRecord.wspd != weatherRecord.wspd) {
-            cm->log(util::format("missing wind speed %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting",
+            cm->log(util::format("Missing wind speed %lg W/m2 at time [y:%d m:%d d:%d h:%d, minute:%lg], exiting.",
                 weatherRecord.wspd, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_ERROR, (float)idx);
             return;
         }
@@ -288,36 +288,41 @@ void Irradiance_IO::checkWeatherFile(compute_module* cm, std::string cmName)
         // Check for bad data
         if ((weatherRecord.gh < 0 || weatherRecord.gh >  irrad::irradiationMax) && (radiationMode == irrad::DN_GH || radiationMode == irrad::GH_DF))
         {
-            cm->log(util::format("Out of range global irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero",
+            cm->log(util::format("Out of range global irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
                 weatherRecord.gh, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_WARNING, (float)idx);
             weatherRecord.gh = 0;
         }
         if ((weatherRecord.dn < 0 || weatherRecord.dn >  irrad::irradiationMax) && (radiationMode == irrad::DN_DF || radiationMode == irrad::DN_GH))
         {
-            cm->log(util::format("Out of range beam irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero",
+            cm->log(util::format("Out of range beam irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
                 weatherRecord.dn, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_WARNING, (float)idx);
             weatherRecord.dn = 0;
         }
         if ((weatherRecord.df < 0 || weatherRecord.df >  irrad::irradiationMax) && (radiationMode == irrad::DN_DF || radiationMode == irrad::GH_DF))
         {
-            cm->log(util::format("Out of range diffuse irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero",
+            cm->log(util::format("Out of range diffuse irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
                 weatherRecord.df, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_WARNING, (float)idx);
             weatherRecord.df = 0;
         }
         if ((weatherRecord.poa < 0 || weatherRecord.poa >  irrad::irradiationMax) && (radiationMode == irrad::POA_R || radiationMode == irrad::POA_P))
         {
-            cm->log(util::format("Out of range POA irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero",
+            cm->log(util::format("Out of range POA irradiance %lg W/m2 at time [y:%d m:%d d:%d h:%d minute:%lg], set to zero.",
                 weatherRecord.poa, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_WARNING, (float)idx);
             weatherRecord.poa = 0;
         }
         if (useWeatherFileAlbedo && (weatherRecord.alb <= 0 || weatherRecord.alb >= 1))
         {
+            if (num_alb_errors < 5)
+            {
+                cm->log(util::format("Out of range albedo %lg at time [y:%d m:%d d:%d h:%d minute:%lg]. This warning only appears for the first five instances of this error.",
+                    weatherRecord.alb, weatherRecord.year, weatherRecord.month, weatherRecord.day, weatherRecord.hour, weatherRecord.minute), SSC_WARNING, (float)idx);
+            }
             num_alb_errors++;
             weatherRecord.alb = 0;
         }
     }
     if (num_alb_errors > 0)
-        cm->log(util::format("Weather file albedo has %d invalid values, using monthly value", (int)num_alb_errors), SSC_WARNING);
+        cm->log(util::format("Weather file albedo has %d invalid values, using user-defined or default values for these time steps. See albedo output variable.", (int)num_alb_errors), SSC_WARNING);
 
     weatherDataProvider->rewind();
 }
@@ -381,7 +386,7 @@ Subarray_IO::Subarray_IO(compute_module* cm, const std::string& cmName, size_t s
     {
         int n = cm->as_integer(prefix + "nstrings");
         if (n < 0) {
-            throw exec_error(cmName, "invalid string allocation between subarrays.  all subarrays must have zero or positive number of strings.");
+            throw exec_error(cmName, "Invalid string allocation between subarrays. All subarrays must have zero or positive number of strings.");
         }
 
         nStrings = n;
@@ -486,11 +491,11 @@ Subarray_IO::Subarray_IO(compute_module* cm, const std::string& cmName, size_t s
             (1 - nameplateLossPercent));
 
         if (groundCoverageRatio < 0.01)
-            throw exec_error(cmName, "array ground coverage ratio must obey 0.01 < gcr");
+            throw exec_error(cmName, "Array ground coverage ratio must obey 0.01 < gcr.");
 
 
         monthlySoiling = cm->as_vector_double(prefix + "soiling");
-        if (monthlySoiling.size() != 12) throw exec_error(cmName, "soiling loss array must have 12 values: subarray " + util::to_string((int)(subarrayNumber)));
+        if (monthlySoiling.size() != 12) throw exec_error(cmName, "Soiling loss array must have 12 values: subarray " + util::to_string((int)(subarrayNumber)) + ".");
 
         //convert from % to derate
         for (size_t m = 0; m < monthlySoiling.size(); m++)
@@ -603,7 +608,7 @@ void PVSystem_IO::SetupPOAInput()
             for (size_t ii = 0; ii < Irradiance->numberOfWeatherFileRecords; ii++) {
 
                 if (!wdprov->read(&wf)) {
-                    throw exec_error("pvsamv1", "could not read data line " + util::to_string((int)(ii + 1)) + " in weather file while loading POA data");
+                    throw exec_error("pvsamv1", "Could not read data line " + util::to_string((int)(ii + 1)) + " in weather file while loading POA data.");
                 }
                 int month_idx = wf.month - 1;
 
@@ -807,20 +812,20 @@ PVSystem_IO::PVSystem_IO(compute_module* cm, std::string cmName, Simulation_IO* 
         if (enableDCLifetimeLosses)
         {
             if (!Simulation->annualSimulation)
-                throw exec_error(cmName, "Lifetime daily losses cannot be entered with non-annual weather data");
+                throw exec_error(cmName, "Lifetime daily losses cannot be entered with non-annual weather data.");
 
             dcLifetimeLosses = cm->as_vector_double("dc_lifetime_losses");
             if (dcLifetimeLosses.size() != Simulation->numberOfYears * 365)
-                throw exec_error(cmName, "Length of the lifetime daily DC losses array must be equal to the analysis period * 365 days/year");
+                throw exec_error(cmName, "Length of the lifetime daily DC losses array must be equal to the analysis period * 365 days/year.");
         }
         if (enableACLifetimeLosses)
         {
             if (!Simulation->annualSimulation)
-                throw exec_error(cmName, "Lifetime daily losses cannot be entered with non-annual weather data");
+                throw exec_error(cmName, "Lifetime daily losses cannot be entered with non-annual weather data.");
 
             acLifetimeLosses = cm->as_vector_double("ac_lifetime_losses");
             if (acLifetimeLosses.size() != Simulation->numberOfYears * 365)
-                throw exec_error(cmName, "Length of the lifetime daily AC losses array must be equal to the analysis period * 365 days/year");
+                throw exec_error(cmName, "Length of the lifetime daily AC losses array must be equal to the analysis period * 365 days/year.");
         }
     }
 
@@ -1052,7 +1057,7 @@ Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)
             simpleEfficiencyModel.Rad[i] = cm->as_double(util::format("spe_rad%d", i));
             simpleEfficiencyModel.Eff[i] = 0.01 * cm->as_double(util::format("spe_eff%d", i));
             if (i > 0 && simpleEfficiencyModel.Rad[i] <= simpleEfficiencyModel.Rad[i - 1])
-                throw exec_error(cmName, "simpleEfficiencyModel model radiation levels must increase monotonically");
+                throw exec_error(cmName, "Simple Efficiency Model model radiation levels must increase monotonically.");
         }
 
         simpleEfficiencyModel.Gamma = cm->as_double("spe_temp_coeff");
@@ -1091,7 +1096,7 @@ Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)
             sandiaCellTemp.DT0 = cm->as_double("spe_dT");
             break;
         default:
-            throw exec_error(cmName, "invalid simpleEfficiencyModel module structure and mounting");
+            throw exec_error(cmName, "Invalid Simple Efficiency Model module structure and mounting.");
         }
 
         simpleEfficiencyModel.fd = cm->as_double("spe_fd");
@@ -1479,7 +1484,7 @@ Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)
             cellTempModel = &mockCellTemp;
         }
         else {
-            throw exec_error(cmName, "invalid temperature model type");
+            throw exec_error(cmName, "Invalid temperature model type.");
         }
 
         mlModuleModel.initializeManual();
@@ -1495,7 +1500,7 @@ Module_IO::Module_IO(compute_module* cm, std::string cmName, double dcLoss)
     }
     else
     {
-        throw exec_error(cmName, "invalid pv module model type");
+        throw exec_error(cmName, "Invalid pv module model type.");
     }
 
     // TODO: reimplement, but fix issues that this causes with some tests
@@ -1669,7 +1674,7 @@ Inverter_IO::Inverter_IO(compute_module* cm, std::string cmName)
     }
     else
     {
-        throw exec_error("pvsamv1", "invalid inverter model type");
+        throw exec_error("pvsamv1", "Invalid inverter model type.");
     }
 }
 

--- a/shared/lib_windfile.cpp
+++ b/shared/lib_windfile.cpp
@@ -309,35 +309,30 @@ bool winddata_provider::read( double requested_height,
 
 }
 
+void winddata_provider::rewind() {
+    // Empty but defined
+}
+
 windfile::windfile()
-	: winddata_provider()
+	: winddata_provider(), m_nrec(0), m_index(0)
 {
-	m_nrec = 0;
 	close();
 }
 
 windfile::windfile( const std::string &file )
-	: winddata_provider()
+	: winddata_provider(), m_nrec(0), m_index(0)
 {
-	m_nrec = 0;
 	close();
 	open( file );
 }
 
-windfile::~windfile()
+bool windfile::ok() const
 {
-  	m_ifs.close();
-}
-
-bool windfile::ok()
-{
-    if (!m_ifs.good())
-        m_errorMsg = "file stream error reading file";
-  	return m_ifs.good();
+    return m_nrec > 0 && m_cache.size() == m_nrec;
 }
 
 
-std::string windfile::filename()
+std::string windfile::filename() const
 {
 	return m_file;
 }
@@ -347,14 +342,15 @@ bool windfile::open( const std::string &file )
 	close();
 	if (file.empty()) return false;
 	
-	m_ifs.open(file);
-	if (!m_ifs.good())
+    std::ifstream ifs(file);
+	if (!ifs.good())
 	{
 		m_errorMsg = "could not open file for reading: " + file;
 		return false;
 	}
 
     // store number of header rows: legacy srw should be 5, csv 2
+    std::string buf;
     size_t nhdrs = 0;
 
     // *** Legacy SRW format: Header with 5 lines *** //
@@ -371,15 +367,15 @@ bool windfile::open( const std::string &file )
         /* read header rows */
 
         // read line 1 header info
-        getline(m_ifs, m_buf);
+        getline(ifs, buf);
         nhdrs++;
         std::vector<std::string> cols;
-        int ncols = locate2(m_buf, cols, ',');
+        int ncols = locate2(buf, cols, ',');
 
         if (ncols < 8)
         {
             m_errorMsg = util::format("error reading header (line 1).  At least 8 columns required, %d found.", ncols);
-            m_ifs.close();
+            ifs.close();
             return false;
         }
 
@@ -398,18 +394,18 @@ bool windfile::open( const std::string &file )
         catch (const std::invalid_argument&) {/* nothing to do */ };
 
         // read line 2, description
-        getline(m_ifs, desc);
+        getline(ifs, desc);
         nhdrs++;
         trim(desc);
 
         // read line 3, column names (must be pressure, temperature, speed, direction)
-        getline(m_ifs, m_buf);
+        getline(ifs, buf);
         nhdrs++;
-        ncols = locate2(m_buf, cols, ',');
+        ncols = locate2(buf, cols, ',');
         if (ncols < 4)
         {
             m_errorMsg = util::format("header line 3 contains %d data types. requires at least 4: temperature, speed, direction, and atmospheric pressure.", ncols);
-            m_ifs.close();
+            ifs.close();
             return false;
         }
 
@@ -439,7 +435,7 @@ bool windfile::open( const std::string &file )
             else if (ctype.length() > 0)
             {
                 m_errorMsg = util::format("error reading data column type specifier in col %d of %d: '%s' len: %d", i + 1, ncols, ctype.c_str(), ctype.length());
-                m_ifs.close();
+                ifs.close();
                 return false;
             }
         }
@@ -447,17 +443,17 @@ bool windfile::open( const std::string &file )
         m_heights.resize(m_dataid.size(), -1);
 
         // read line 4, units for each column (ignore this for now)
-        getline(m_ifs, m_buf);
+        getline(ifs, buf);
         nhdrs++;
 
         // read line 5, height in meters for each data column
-        getline(m_ifs, m_buf);
+        getline(ifs, buf);
         nhdrs++;
-        ncols = locate2(m_buf, cols, ',');
+        ncols = locate2(buf, cols, ',');
         if (ncols != (int)m_heights.size())
         {
             m_errorMsg = util::format("number of columns in header line 5 must match line 3: %d required but %d found", (int)m_heights.size(), ncols);
-            m_ifs.close();
+            ifs.close();
             return false;
         }
 
@@ -474,10 +470,10 @@ bool windfile::open( const std::string &file )
         std::string tz_site, tz_data, hdr_item;
 
         // line 1 site information
-        getline(m_ifs, m_buf);
+        getline(ifs, buf);
         nhdrs++;
         std::vector<std::string> hdr;
-        int ncols = locate2(m_buf, hdr, ',');
+        int ncols = locate2(buf, hdr, ',');
 
         lat = std::numeric_limits<float>::quiet_NaN();
         lon = std::numeric_limits<float>::quiet_NaN();
@@ -527,10 +523,10 @@ bool windfile::open( const std::string &file )
             return false;
         }
         // line 2 data column headings
-        getline(m_ifs, m_buf);
+        getline(ifs, buf);
         nhdrs++;
         std::vector<std::string> cols;
-        ncols = locate2(m_buf, cols, ',');
+        ncols = locate2(buf, cols, ',');
 
         // get data column positions
         // this approach ignores columns that may contain other data that is not used by wind model
@@ -568,31 +564,56 @@ bool windfile::open( const std::string &file )
         }
     }
 
-	// read all lines to determine the number of records in the file
-	while (getline(m_ifs, m_buf))
-		m_nrec++;
+    std::string row_buf;
+    while (getline(ifs, row_buf))
+    {
+        std::vector<std::string> cols;
+        int ncols = locate2(row_buf, cols, ',');
 
-    // rewind the file and reposition right after header lines
-    m_ifs.clear();
-    m_ifs.seekg(0);
-    for (size_t i = 0; i < nhdrs; i++) // csv
-		getline(m_ifs, m_buf);
+        std::vector<double> row;
+        row.reserve(m_colid.size());
 
-    // number of data records (without headers)
-    //m_nrec = m_nrec - nhdrs;
+        for (int i = 0; i < ncols; i++)
+        {
+            if (std::find(m_colid.begin(), m_colid.end(), i) != m_colid.end())
+            {
+                if (util::lower_case(cols[i]) == "n/a")
+                    row.push_back(std::numeric_limits<double>::quiet_NaN());
+                else if (cols[i].empty())
+                {
+                    m_errorMsg = util::format("data is missing from column %d", i + 1);
+                    return false;
+                }
+                else
+                    row.push_back(std::stof(cols[i]));
+            }
+        }
 
-    // weather file name
+        if (row.size() != m_colid.size())
+        {
+            m_errorMsg = util::format("line contains %d columns, should contain %d", ncols, (int)m_colid.size());
+            return false;
+        }
+
+        m_cache.push_back(std::move(row));
+    }
+
+    if (m_cache.empty())
+    {
+        m_errorMsg = "no data records found in wind resource file: " + file;
+        return false;
+    }
+
+    ifs.close();
+    m_nrec = m_cache.size();
     m_file = file;
-
-	// ready to read line-by-line
-    // columns should correspond to data types in m_dataid and measurement heights in m_heights
-	return true;
+    m_index = 0;
+    return true;
 }
 
 void windfile::close()
 {
-  	m_ifs.close();
-
+    m_cache.clear();
 	m_file.clear();
 	city.clear();
 	state.clear();
@@ -602,6 +623,7 @@ void windfile::close()
 	year = 1900;
 	lat = lon = elev = 0.0;
 	m_nrec = 0;
+    m_index = 0;
 }
 
 size_t windfile::nrecords()
@@ -612,37 +634,11 @@ size_t windfile::nrecords()
 // read temperature, pressure, speed, direction data at different heights from line
 bool windfile::read_line( std::vector<double> &values )
 {
-	if ( !ok() ) return false;
-
-	std::vector<std::string> cols; // columns from file
-    getline(m_ifs, m_buf);
-	int ncols = locate2(m_buf, cols, ',');
-
-    // read only columns that are in m_colid (list of columns numbers that contain data)
-    for (size_t i = 0; i < ncols; i++)
+    if (m_index >= m_nrec)
     {
-        if (std::find(m_colid.begin(), m_colid.end(), i) != m_colid.end())
-        {
-            // WIND Toolkit API returns "N/A" in data columns for requested heights that are not available
-            // this can happen when requesting data for all available heights by not including any attributes
-            // in the API call
-            if (util::lower_case(cols[i]) == "n/a")
-                values.push_back(std::numeric_limits<double>::quiet_NaN());
-            else if (cols[i] == "") // missing data
-            {
-                m_errorMsg = util::format("data is missing from column %d", i+1);
-                return false;
-            }
-            else
-                values.push_back(std::stof(cols[i]));
-        }
-    }
-
-    if (values.size() != m_colid.size())
-    {
-        m_errorMsg = util::format("line contains %d columns, should contain %d", ncols, m_colid.size());
+        m_errorMsg = "windfile: read past end of cached records";
         return false;
     }
-
+    values = m_cache[m_index++];
     return true;
 }

--- a/shared/lib_windfile.h
+++ b/shared/lib_windfile.h
@@ -77,6 +77,8 @@ public:
 	virtual bool read_line( std::vector<double> &values ) = 0;
 	virtual size_t nrecords() = 0;
 
+    virtual void rewind();
+
 	
 	std::string error() { return m_errorMsg; }
 
@@ -97,24 +99,30 @@ protected:
 class windfile : public winddata_provider
 {
 private:
-  	std::ifstream m_ifs;
-	std::string m_buf;
-	std::string m_file;
-	size_t m_nrec;
+    std::string m_file;
+    size_t      m_nrec;
+    size_t      m_index;
+
+    // All data rows loaded into memory during open() so that rewind()
+    // can replay the same year for multi-year (lifetime) simulations
+    // without re-reading the file, analogous to the weatherfile class.
+    std::vector<std::vector<double>> m_cache;
 
 public:
-	windfile();
-	explicit windfile( const std::string &file );
-	~windfile() override;
+    windfile();
+    explicit windfile(const std::string& file);
+    ~windfile() override = default;
 
-	bool ok();
-	std::string filename();
-	void close();
-	bool open( const std::string &file );
-	
-	bool read_line(std::vector<double> &values) override;
-	size_t nrecords() override;
-	
+    bool ok() const;
+    std::string filename() const;
+    void close();
+    bool open(const std::string& file);
+
+    /// Reset the read cursor to the first data record.
+    void rewind() override { m_index = 0; }
+
+    bool   read_line(std::vector<double>& values) override;
+    size_t nrecords() override;
 };
 
 #endif

--- a/ssc/cmod_custom_generation.cpp
+++ b/ssc/cmod_custom_generation.cpp
@@ -52,7 +52,7 @@ static var_info _cm_vtab_custom_generation[] = {
 	// optional for lifetime analysis
 	{ SSC_INPUT,        SSC_NUMBER,      "system_use_lifetime_output",                  "Custom generation profile lifetime simulation",                               "0/1",      "",                              "Lifetime",             "?=0",                        "INTEGER,MIN=0,MAX=1",          "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "analysis_period",                             "Lifetime analysis period",                             "years",    "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
-	{ SSC_INPUT,        SSC_ARRAY,       "generic_degradation",                              "Annual AC degradation",                            "%/year",   "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
+	{ SSC_INPUT,        SSC_ARRAY,       "ac_degradation",                              "Annual AC degradation",                            "%/year",   "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
 
 
 //    OUTPUTS ----------------------------------------------------------------------------								      														   
@@ -130,7 +130,7 @@ public:
 			// setup system degradation
 			size_t i, count_degrad = 0;
 			ssc_number_t *degrad = 0;
-			degrad = as_array("generic_degradation", &count_degrad);
+			degrad = as_array("ac_degradation", &count_degrad);
 
 			if (count_degrad == 1)
 			{

--- a/ssc/cmod_generic_system.cpp
+++ b/ssc/cmod_generic_system.cpp
@@ -63,7 +63,7 @@ static var_info _cm_vtab_generic_system[] = {
 	// optional for lifetime analysis
 	{ SSC_INPUT,        SSC_NUMBER,      "system_use_lifetime_output",                  "Generic lifetime simulation",                               "0/1",      "",                              "Lifetime",             "?=0",                        "INTEGER,MIN=0,MAX=1",          "" },
 	{ SSC_INPUT,        SSC_NUMBER,      "analysis_period",                             "Lifetime analysis period",                             "years",    "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
-	{ SSC_INPUT,        SSC_ARRAY,       "generic_degradation",                              "Annual AC degradation",                            "%/year",   "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
+	{ SSC_INPUT,        SSC_ARRAY,       "ac_degradation",                              "Annual AC degradation",                            "%/year",   "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
 
 
 //    OUTPUTS ----------------------------------------------------------------------------								      														   
@@ -142,7 +142,7 @@ public:
 			// setup system degradation
 			size_t i, count_degrad = 0;
 			ssc_number_t *degrad = 0;
-			degrad = as_array("generic_degradation", &count_degrad);
+			degrad = as_array("ac_degradation", &count_degrad);
 
 			if (count_degrad == 1)
 			{

--- a/ssc/cmod_hybrid.cpp
+++ b/ssc/cmod_hybrid.cpp
@@ -220,7 +220,7 @@ public:
                     size_t count_degrad = 0;
                     ssc_number_t* degrad = input.as_array("degradation", &count_degrad);
                     if (compute_module == "custom_generation")
-                        input.assign("generic_degradation", *input.lookup("degradation"));
+                        input.assign("ac_degradation", *input.lookup("degradation"));
                     if (count_degrad == 1) {
                         for (int i = 1; i <= analysisPeriod; i++)
                             pDegradation[i] = pow((1.0 - degrad[0] / 100.0), i - 1);

--- a/ssc/cmod_mhk_wave.cpp
+++ b/ssc/cmod_mhk_wave.cpp
@@ -60,7 +60,7 @@ static var_info _cm_vtab_mhk_wave[] = {
 
     { SSC_INPUT,        SSC_NUMBER,      "system_use_lifetime_output",                  "Generic lifetime simulation",                               "0/1",      "",                              "Lifetime",             "?=0",                        "INTEGER,MIN=0,MAX=1",          "" },
     { SSC_INPUT,        SSC_NUMBER,      "analysis_period",                             "Lifetime analysis period",                             "years",    "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
-    { SSC_INPUT,        SSC_ARRAY,       "generic_degradation",                              "Annual AC degradation",                            "%/year",   "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
+    { SSC_INPUT,        SSC_ARRAY,       "ac_degradation",                              "Annual AC degradation",                            "%/year",   "",                              "Lifetime",             "system_use_lifetime_output=1",   "",                             "" },
 
 
     // losses
@@ -566,7 +566,7 @@ public:
                 // setup system degradation
                 size_t i, count_degrad = 0;
                 ssc_number_t* degrad = 0;
-                degrad = as_array("generic_degradation", &count_degrad);
+                degrad = as_array("ac_degradation", &count_degrad);
 
                 if (count_degrad == 1)
                 {

--- a/ssc/cmod_pvwattsv8.cpp
+++ b/ssc/cmod_pvwattsv8.cpp
@@ -861,7 +861,13 @@ public:
                     if ((std::isfinite(wf.alb) && (wf.alb > 0 && wf.alb < 1)))
                         alb = wf.alb;
                     else
+                    {
+                        if (n_alb_errs < 5) // display warning up to 5 times
+                        {
+                            log(util::format("Invalid albedo input value %f [year:%d month:%d day:%d hour:%d minute:%lg]. Using default albedo value %f (snow) or %f (no snow). This warning only appears for the first five instances of this error.", wf.alb, wf.year, wf.month, wf.day, wf.hour, wf.minute, as_double("albedo_default_snow"), as_double("albedo_default")), SSC_NOTICE);
+                        }
                         n_alb_errs++;
+                    }
                 }
                 else
                 {
@@ -884,11 +890,6 @@ public:
                         alb = as_double("albedo_default_snow");
                     else
                         alb = as_double("albedo_default");
-                    if (!use_wf_albedo && n_alb_errs < 5) // display warning up to 5 times
-                    {
-                        log(util::format("Albedo input value is not valid for time step %d. Using default albedo value of %f (snow) or %f (no snow). This warning only appears for the first five instances of this error.", idx, as_double("albedo_default_snow"), as_double("albedo_default")), SSC_NOTICE);
-                        n_alb_errs++;
-                    }
                 }
 
                 // report albedo value as output
@@ -1388,7 +1389,7 @@ public:
             }
 
             if (n_alb_errs > 0)
-                log(util::format("Weather file albedo has %d invalid values, using monthly value", (int)n_alb_errs), SSC_WARNING);
+                log(util::format("Weather file albedo has %d invalid values, using user-specified or default values for those time steps. See Albedo output variable.", (int)n_alb_errs), SSC_WARNING);
 
             wdprov->rewind();
         }

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -438,8 +438,9 @@ void cm_windpower::exec()
 		for (size_t i = 0; i < wpc.nTurbines; i++)
 			turbine_output[i] = (ssc_number_t)turbine_outkW[i];
 
-		accumulate_monthly("gen", "monthly_energy");
-		accumulate_annual("gen", "annual_energy");
+        size_t steps_per_hour = 1; // Always 1 for statistical
+        accumulate_monthly_for_year("gen", "monthly_energy", 1, 1);
+        accumulate_annual_for_year("gen", "annual_energy", 1, 1);
 
 		// metric outputs moved to technology
 		double kWhperkW = 0.0;
@@ -531,8 +532,9 @@ void cm_windpower::exec()
             }
         }
 
-        accumulate_monthly("gen", "monthly_energy");
-        accumulate_annual("gen", "annual_energy");
+        size_t steps_per_hour = 1; // Always 1 for distribution
+        accumulate_monthly_for_year("gen", "monthly_energy", 1, 1);
+        accumulate_annual_for_year("gen", "annual_energy", 1, 1);
 
         // average wind speed
         double avg_speed = 0.;

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -100,7 +100,7 @@ static var_info _cm_vtab_windpower[] = {
 
     { SSC_INOUT,   SSC_NUMBER,  "system_use_lifetime_output"         , "Run lifetime simulation",                   "0/1",     "",                                     "Lifetime",                              "?=0",                        "",                              "" },
     { SSC_INPUT,   SSC_NUMBER,  "analysis_period"                    , "Analysis period",                           "years",    "",                                    "Lifetime",                              "system_use_lifetime_output=1", "",                          "" },
-    { SSC_INPUT,   SSC_ARRAY,   "generic_degradation",                 "Annual AC degradation for lifetime simulations","%/year",  "",                                 "Lifetime",                              "system_use_lifetime_output=1", "",                          "" },
+    { SSC_INPUT,   SSC_ARRAY,   "ac_degradation",                 "Annual AC degradation for lifetime simulations","%/year",  "",                                 "Lifetime",                              "system_use_lifetime_output=1", "",                          "" },
 
 
         // OUTPUTS ----------------------------------------------------------------------------annual_energy
@@ -371,7 +371,7 @@ void cm_windpower::exec()
     std::vector<double> degradationFactor;
     if (as_boolean("system_use_lifetime_output")) {
         nyears = as_unsigned_long("analysis_period");
-        std::vector<double> ac_degradation = as_vector_double("generic_degradation");
+        std::vector<double> ac_degradation = as_vector_double("ac_degradation");
         if (ac_degradation.size() == 1) {
             degradationFactor.push_back(1.0); // assume zero degradation in year 1
             for (size_t y = 1; y < nyears; y++) {

--- a/ssc/cmod_windpower.cpp
+++ b/ssc/cmod_windpower.cpp
@@ -98,6 +98,9 @@ static var_info _cm_vtab_windpower[] = {
 	{ SSC_INPUT  , SSC_NUMBER , "turb_perf_loss"                     , "Turbine Sub-optimal performance loss"     , "%"       ,""                                    , "Losses"                               , "?=0"                                             , "MIN=0,MAX=100"                                   , "" } ,
 	{ SSC_INPUT  , SSC_NUMBER , "turb_specific_loss"                 , "Turbine Site-specific Powercurve loss"    , "%"       ,""                                    , "Losses"                               , "?=0"                                             , "MIN=0,MAX=100"                                   , "" } ,
 
+    { SSC_INOUT,   SSC_NUMBER,  "system_use_lifetime_output"         , "Run lifetime simulation",                   "0/1",     "",                                     "Lifetime",                              "?=0",                        "",                              "" },
+    { SSC_INPUT,   SSC_NUMBER,  "analysis_period"                    , "Analysis period",                           "years",    "",                                    "Lifetime",                              "system_use_lifetime_output=1", "",                          "" },
+    { SSC_INPUT,   SSC_ARRAY,   "generic_degradation",                 "Annual AC degradation for lifetime simulations","%/year",  "",                                 "Lifetime",                              "system_use_lifetime_output=1", "",                          "" },
 
 
         // OUTPUTS ----------------------------------------------------------------------------annual_energy
@@ -235,7 +238,6 @@ bool winddata::read_line(std::vector<double> &values)
 	return true;
 }
 
-
 cm_windpower::cm_windpower(){
 	add_var_info(_cm_vtab_windpower);
 	// performance adjustment factors
@@ -365,6 +367,29 @@ void cm_windpower::exec()
     double icingRHCutoffValue = icingCutoff ? as_double("icing_cutoff_rh") : -1;
     int icingPersistenceTimesteps = as_integer("icing_persistence_timesteps");
 
+    size_t nyears = 1;
+    std::vector<double> degradationFactor;
+    if (as_boolean("system_use_lifetime_output")) {
+        nyears = as_unsigned_long("analysis_period");
+        std::vector<double> ac_degradation = as_vector_double("generic_degradation");
+        if (ac_degradation.size() == 1) {
+            degradationFactor.push_back(1.0); // assume zero degradation in year 1
+            for (size_t y = 1; y < nyears; y++) {
+                degradationFactor.push_back(1.0 - (ac_degradation[0] * y) / 100.0);
+            }
+        }
+        else {
+            if (ac_degradation.size() != nyears)
+                throw exec_error("windpower", "Length of degradation array must be equal to analysis period.");
+            for (size_t y = 0; y < nyears; y++) {
+                degradationFactor.push_back(1.0 - ac_degradation[y] / 100.0);
+            }
+        }
+    }
+    else {
+        degradationFactor.push_back(1.0);
+    }
+
 	// Run Weibull Statistical model (single outputs) if selected, requires hourly simulation
 	if (as_integer("wind_resource_model_choice") == 1 ){
 		ssc_number_t *turbine_output = allocate("turbine_output_by_windspeed_bin", wt.powerCurveArrayLength);
@@ -393,16 +418,22 @@ void cm_windpower::exec()
 
 		int nstep = 8760;
         // set up adjustment loss for Weibull distribution wind resource
-        if (!haf.setup())
+        if (!haf.setup(nstep, nyears))
             throw exec_error("windpower", "failed to set up adjustment factors for Weibull distribution wind resource: " + haf.error());
 
         ssc_number_t farm_kw = (ssc_number_t)turbine_kw * wpc.nTurbines / (ssc_number_t)nstep;
-		ssc_number_t *farmpwr = allocate("gen", nstep);
-		for (int i = 0; i < nstep; i++) //nstep is always 8760 for Weibull
-		{
-			farmpwr[i] = farm_kw; // fill "gen"
-			farmpwr[i] *= haf(i); //apply adjustment factor/availability and curtailment losses
-		}
+		ssc_number_t *farmpwr = allocate("gen", nstep * nyears);
+        size_t idx_life = 0;
+        for (size_t y = 0; y < nyears; y++) {
+            for (int i = 0; i < nstep; i++) //nstep is always 8760 for Weibull
+            {
+                farmpwr[idx_life] = farm_kw; // fill "gen"
+                farmpwr[idx_life] *= haf(idx_life); //apply adjustment factor/availability and curtailment losses
+                farmpwr[idx_life] *= degradationFactor[y]; //apply degradation for lifetime simulation if applicable
+                idx_life++;
+            }
+
+        }
 
 		for (size_t i = 0; i < wpc.nTurbines; i++)
 			turbine_output[i] = (ssc_number_t)turbine_outkW[i];
@@ -481,18 +512,23 @@ void cm_windpower::exec()
             assign("annual_wake_loss_internal_percent", var_data((ssc_number_t)annual_wake_int_loss_percent));
         }
 
+        int nstep = 8760;
         // set up adjustment factors for constant wake loss option
-        if (!haf.setup())
+        if (!haf.setup(nstep, nyears))
             throw exec_error("windpower", "failed to set up adjustment factors for wind resource probability table: " + haf.error());
 
-        int nstep = 8760;
         ssc_number_t farm_kw = farmPower / (ssc_number_t)nstep;
-        ssc_number_t *farmpwr = allocate("gen", nstep);
-        for (int i = 0; i < nstep; i++)
-        {
-            farmpwr[i] = farm_kw; // fill "gen"
-            farmpwr[i] *= haf(i); //apply adjustment factor/availability and curtailment losses
-            farmpwr[i] *= lossMultiplier;
+        ssc_number_t *farmpwr = allocate("gen", nstep * nyears);
+        size_t idx_life = 0;
+        for (size_t y = 0; y < nyears; y++) {
+            for (int i = 0; i < nstep; i++)
+            {
+                farmpwr[idx_life] = farm_kw; // fill "gen"
+                farmpwr[idx_life] *= haf(idx_life); //apply adjustment factor/availability and curtailment losses
+                farmpwr[idx_life] *= lossMultiplier;
+                farmpwr[idx_life] *= degradationFactor[y]; //apply degradation for lifetime simulation if applicable
+                idx_life++;
+            }
         }
 
         accumulate_monthly("gen", "monthly_energy");
@@ -531,7 +567,7 @@ void cm_windpower::exec()
 	{
 		// read the wind data file
 		const char *file = as_string("wind_resource_filename");
-		windfile *wp = new windfile(file);
+        windfile *wp = new windfile(file);
 		nstep = wp->nrecords();
 		wdprov = smart_ptr<winddata_provider>::ptr(wp);
 		if (!wp->ok() || (nstep == 0))
@@ -573,17 +609,18 @@ void cm_windpower::exec()
 		throw exec_error("windpower", util::format("invalid number of data records (%d): must be an integer multiple of 8760", (int)nstep));
 
     // set up adjustment factors for time series simulation
-    if (!haf.setup(nstep))
+    if (!haf.setup(nstep, nyears))
         throw exec_error("windpower", "failed to set up adjustment factors for time series wind resource data: " + haf.error());
 
 	// allocate output data
-	ssc_number_t *farmpwr = allocate("gen", nstep);
-    ssc_number_t* wakeLosskW = allocate("wake_loss_internal_kW", nstep);
-    ssc_number_t* wakeLossPercent = allocate("wake_loss_internal_percent", nstep);
-	ssc_number_t *wspd = allocate("wind_speed", nstep);
-	ssc_number_t *wdir = allocate("wind_direction", nstep);
-	ssc_number_t *air_temp = allocate("temp", nstep);
-	ssc_number_t *air_pres = allocate("pressure", nstep);
+    size_t nlifetime = nstep * nyears;
+	ssc_number_t *farmpwr = allocate("gen", nlifetime);
+    ssc_number_t* wakeLosskW = allocate("wake_loss_internal_kW", nlifetime);
+    ssc_number_t* wakeLossPercent = allocate("wake_loss_internal_percent", nlifetime);
+	ssc_number_t *wspd = allocate("wind_speed", nlifetime);
+	ssc_number_t *wdir = allocate("wind_direction", nlifetime);
+	ssc_number_t *air_temp = allocate("temp", nlifetime);
+	ssc_number_t *air_pres = allocate("pressure", nlifetime);
 
 
 	std::vector<double> Power(wpc.nTurbines, 0.), Thrust(wpc.nTurbines, 0.),
@@ -600,63 +637,65 @@ void cm_windpower::exec()
     int icingPersistenceTSRemaining = 0; //a counter for icing to persist x number of timesteps based on user input
 
 	// compute power output at i-th timestep
-	int i = 0;
-	for (size_t hr = 0; hr < 8760; hr++)
-	{
-		int imonth = util::month_of((double)hr) - 1;
+	size_t idx_life = 0;
+    for (size_t y = 0; y < nyears; y++) {
+        size_t i_year = 0;
+        for (size_t hr = 0; hr < 8760; hr++)
+        {
+            int imonth = util::month_of((double)hr) - 1;
 
-		for (size_t istep = 0; istep < steps_per_hour; istep++)
-		{
-			if (i % (nstep / 20) == 0)
-				update("", 100.0f * ((float)i) / ((float)nstep), (float)i); //update percentage complete in UI
+            for (size_t istep = 0; istep < steps_per_hour; istep++)
+            {
+                if (idx_life % (nlifetime / 20) == 0)
+                    update("", 100.0f * ((float)idx_life) / ((float)nlifetime), (float)idx_life); //update percentage complete in UI
 
-			double wind, dir, temp, pres, closest_dir_meas_ht;
+                double wind, dir, temp, pres, closest_dir_meas_ht;
 
-			//skip leap day if applicable
-			if (contains_leap_day)
-			{
-				if (hr == 1416) //(31 days in Jan  + 28 days in Feb) * 24 hours a day, +1 to be the start of Feb 29, -1 because of 0 indexing
-					for (size_t j = 0; j < 24 * steps_per_hour; j++) //trash 24 hours' worth of lines in the weather file to skip the entire day of Feb 29
-					{
-						if (!wdprov->read(wt.hubHeight, &wind, &dir, &temp, &pres, &wt.measurementHeight, &closest_dir_meas_ht, true))
-							throw exec_error("windpower", util::format("error reading wind resource file leap day data at %d: ", i) + wdprov->error());
-					}
-			} //now continue with the normal process, none of the counters have been incremented so everything else should be ok
+                //skip leap day if applicable
+                if (contains_leap_day)
+                {
+                    if (hr == 1416) //(31 days in Jan  + 28 days in Feb) * 24 hours a day, +1 to be the start of Feb 29, -1 because of 0 indexing
+                        for (size_t j = 0; j < 24 * steps_per_hour; j++) //trash 24 hours' worth of lines in the weather file to skip the entire day of Feb 29
+                        {
+                            if (!wdprov->read(wt.hubHeight, &wind, &dir, &temp, &pres, &wt.measurementHeight, &closest_dir_meas_ht, true))
+                                throw exec_error("windpower", util::format("error reading wind resource file leap day data at %d: ", idx_life) + wdprov->error());
+                        }
+                } //now continue with the normal process, none of the counters have been incremented so everything else should be ok
 
-			// if wf.read is set to interpolate (last input), and it's able to do so, then it will set wpc.measurementHeight equal to hub_ht
-			// direction will not be interpolated, pressure and temperature will be if possible
-			if (!wdprov->read(wt.hubHeight, &wind, &dir, &temp, &pres, &wt.measurementHeight, &closest_dir_meas_ht, true))
-				throw exec_error("windpower", util::format("error reading wind resource file for interpolation at time step %d: ", i) + wdprov->error());
+                // if wf.read is set to interpolate (last input), and it's able to do so, then it will set wpc.measurementHeight equal to hub_ht
+                // direction will not be interpolated, pressure and temperature will be if possible
+                if (!wdprov->read(wt.hubHeight, &wind, &dir, &temp, &pres, &wt.measurementHeight, &closest_dir_meas_ht, true))
+                    throw exec_error("windpower", util::format("error reading wind resource file for interpolation at time step %d: ", idx_life) + wdprov->error());
 
-			if (std::abs(wt.measurementHeight - wt.hubHeight) > 35.0)
-				throw exec_error("windpower", util::format("the closest wind speed measurement height (%lg m) found is more than 35 m from the hub height specified (%lg m)", wt.measurementHeight, wt.hubHeight));
+                if (std::abs(wt.measurementHeight - wt.hubHeight) > 35.0)
+                    throw exec_error("windpower", util::format("the closest wind speed measurement height (%lg m) found is more than 35 m from the hub height specified (%lg m)", wt.measurementHeight, wt.hubHeight));
 
-			if (std::abs(closest_dir_meas_ht - wt.measurementHeight) > 10.0)
-			{
-				if (i > 0) // if this isn't the first hour, then it's probably because of interpolation
-				{
-					// probably interpolated wind speed, but could not interpolate wind direction because the directions were too far apart.
-					// first, verify:
-					if ((wt.measurementHeight == wt.hubHeight) && (closest_dir_meas_ht != wt.hubHeight))
-						// now, alert the user of this discrepancy
-						throw exec_error("windpower", util::format("on hour %d, SAM interpolated the wind speed to an %lgm measurement height, but could not interpolate the wind direction from the two closest measurements because the directions encountered were too disparate", i + 1, wt.measurementHeight));
-					else
-						throw exec_error("windpower", util::format("SAM encountered an error at hour %d: hub height = %lg, closest wind speed meas height = %lg, closest wind direction meas height = %lg ", i + 1, wt.hubHeight, wt.measurementHeight, closest_dir_meas_ht));
-				}
-				else
-					throw exec_error("windpower", util::format("the closest wind speed measurement height (%lg m) and direction measurement height (%lg m) were more than 10m apart", wt.measurementHeight, closest_dir_meas_ht));
-			}
+                if (std::abs(closest_dir_meas_ht - wt.measurementHeight) > 10.0)
+                {
+                    if (idx_life > 0) // if this isn't the first hour, then it's probably because of interpolation
+                    {
+                        // probably interpolated wind speed, but could not interpolate wind direction because the directions were too far apart.
+                        // first, verify:
+                        if ((wt.measurementHeight == wt.hubHeight) && (closest_dir_meas_ht != wt.hubHeight))
+                            // now, alert the user of this discrepancy
+                            throw exec_error("windpower", util::format("on hour %d, SAM interpolated the wind speed to an %lgm measurement height, but could not interpolate the wind direction from the two closest measurements because the directions encountered were too disparate", idx_life + 1, wt.measurementHeight));
+                        else
+                            throw exec_error("windpower", util::format("SAM encountered an error at hour %d: hub height = %lg, closest wind speed meas height = %lg, closest wind direction meas height = %lg ", idx_life + 1, wt.hubHeight, wt.measurementHeight, closest_dir_meas_ht));
+                    }
+                    else
+                        throw exec_error("windpower", util::format("the closest wind speed measurement height (%lg m) and direction measurement height (%lg m) were more than 10m apart", wt.measurementHeight, closest_dir_meas_ht));
+                }
 
-			// If the wind speed measurement height still differs from the turbine hub height (ie it wasn't corrected above, maybe because file only has one measurement height), use the shear to correct it.
-			if (std::abs(wt.measurementHeight - wt.hubHeight) > 1) {
-				if (wt.shearExponent > 1.0) wt.shearExponent = 1.0 / 7.0;
-				wind = wind * pow(wt.hubHeight / wt.measurementHeight, wt.shearExponent);
-				wt.measurementHeight = wt.hubHeight;
-			}
+                // If the wind speed measurement height still differs from the turbine hub height (ie it wasn't corrected above, maybe because file only has one measurement height), use the shear to correct it.
+                if (std::abs(wt.measurementHeight - wt.hubHeight) > 1) {
+                    if (wt.shearExponent > 1.0) wt.shearExponent = 1.0 / 7.0;
+                    wind = wind * pow(wt.hubHeight / wt.measurementHeight, wt.shearExponent);
+                    wt.measurementHeight = wt.hubHeight;
+                }
 
-			double farmp = 0., gross_farmp = 0.;
+                double farmp = 0., gross_farmp = 0.;
 
-			if ((int)wpc.nTurbines != wpc.windPowerUsingResource(
+                if ((int)wpc.nTurbines != wpc.windPowerUsingResource(
                     /* inputs */
                     wind,    /* m/s */
                     dir,    /* degrees */
@@ -673,57 +712,64 @@ void cm_windpower::exec()
                     &Turb[0],
                     &DistDown[0],
                     &DistCross[0]))
-				throw exec_error("windpower", util::format("error in wind calculation at time %d, details: %s", i, wpc.GetErrorDetails().c_str()));
+                    throw exec_error("windpower", util::format("error in wind calculation at time %d, details: %s", idx_life, wpc.GetErrorDetails().c_str()));
 
-            if (wakeModelChoice != CONSTANTVALUE && is_assigned("wake_loss_multiplier")) //wake loss multiplier isn't available for constant wake loss option
-            {
-                double wakeLossMultiplier = as_double("wake_loss_multiplier");
-                double wakeLossBeforeMultiplier = gross_farmp - farmp;
-                double newWakeLoss = wakeLossBeforeMultiplier * wakeLossMultiplier;
-                farmp = gross_farmp - newWakeLoss;
-            }
-
-            //wake loss calculations need to happen before other losses are applied
-            annual_gross += gross_farmp / (ssc_number_t)steps_per_hour;
-			annual_after_wake_loss += farmp / (ssc_number_t)steps_per_hour;       
-            wakeLosskW[i] = gross_farmp - farmp;          
-            if (gross_farmp == 0.0) wakeLossPercent[i] = 0.0;
-            else wakeLossPercent[i] = wakeLosskW[i] / gross_farmp * 100.0;
-
-			farmp *= lossMultiplier;
-			// apply and track cutoff losses
-            withoutCutOffLosses += farmp * haf(i) / (ssc_number_t)steps_per_hour;
-
-            if (lowTempCutoff){
-				if (temp < lowTempCutoffValue) farmp = 0.0;
-			}
-			if (icingCutoff){
-                if (temp < icingTempCutoffValue && wdprov->relativeHumidity()[i] > icingRHCutoffValue)
+                if (wakeModelChoice != CONSTANTVALUE && is_assigned("wake_loss_multiplier")) //wake loss multiplier isn't available for constant wake loss option
                 {
-                    farmp = 0.0;
-                    icingPersistenceTSRemaining = icingPersistenceTimesteps;
+                    double wakeLossMultiplier = as_double("wake_loss_multiplier");
+                    double wakeLossBeforeMultiplier = gross_farmp - farmp;
+                    double newWakeLoss = wakeLossBeforeMultiplier * wakeLossMultiplier;
+                    farmp = gross_farmp - newWakeLoss;
                 }
-                if (icingPersistenceTSRemaining > 0)
-                {
-                    farmp = 0.0;
-                    icingPersistenceTSRemaining--;
+
+                if (y == 0) {
+                    //wake loss calculations need to happen before other losses are applied
+                    annual_gross += gross_farmp / (ssc_number_t)steps_per_hour;
+                    annual_after_wake_loss += farmp / (ssc_number_t)steps_per_hour;
                 }
-			}
+                wakeLosskW[idx_life] = gross_farmp - farmp;
+                if (gross_farmp == 0.0) wakeLossPercent[idx_life] = 0.0;
+                else wakeLossPercent[idx_life] = wakeLosskW[idx_life] / gross_farmp * 100.0;
 
-            farmpwr[i] = (ssc_number_t)farmp * haf(i);
-            wspd[i] = (ssc_number_t)wind;
-			wdir[i] = (ssc_number_t)dir;
-			air_temp[i] = (ssc_number_t)temp;
-            if (pres > 1.1) pres = pres / physics::Pa_PER_Atm; // assumes that value greater than 1.1 is i Pa
-			air_pres[i] = (ssc_number_t)pres;
+                farmp *= lossMultiplier * degradationFactor[y];
+                // apply and track cutoff losses
+                withoutCutOffLosses += farmp * haf(idx_life) / (ssc_number_t)steps_per_hour;
 
-			// accumulate monthly and annual energy
-			monthly[imonth] += farmpwr[i] / (ssc_number_t)steps_per_hour;
-			annual += farmpwr[i] / (ssc_number_t)steps_per_hour;
+                if (lowTempCutoff) {
+                    if (temp < lowTempCutoffValue) farmp = 0.0;
+                }
+                if (icingCutoff) {
+                    if (temp < icingTempCutoffValue && wdprov->relativeHumidity()[i_year] > icingRHCutoffValue)
+                    {
+                        farmp = 0.0;
+                        icingPersistenceTSRemaining = icingPersistenceTimesteps;
+                    }
+                    if (icingPersistenceTSRemaining > 0)
+                    {
+                        farmp = 0.0;
+                        icingPersistenceTSRemaining--;
+                    }
+                }
 
-			i++;
-		} // end steps_per_hour loop
-	} // end 1->8760 loop
+                farmpwr[idx_life] = (ssc_number_t)farmp * haf(idx_life);
+                wspd[idx_life] = (ssc_number_t)wind;
+                wdir[idx_life] = (ssc_number_t)dir;
+                air_temp[idx_life] = (ssc_number_t)temp;
+                if (pres > 1.1) pres = pres / physics::Pa_PER_Atm; // assumes that value greater than 1.1 is i Pa
+                air_pres[idx_life] = (ssc_number_t)pres;
+
+                if (y == 0) {
+                    // accumulate monthly and annual energy
+                    monthly[imonth] += farmpwr[i_year] / (ssc_number_t)steps_per_hour;
+                    annual += farmpwr[i_year] / (ssc_number_t)steps_per_hour;
+                }
+
+                i_year++;
+                idx_life++;
+            } // end steps_per_hour loop
+        } // end 1->8760 loop
+        wdprov->rewind(); //reset to beginning of file for next year of simulation if applicable
+    }
     ssc_number_t* p_annual_energy_dist_time = gen_heatmap(this, steps_per_hour);
 	// assign outputs
 	assign("annual_energy", var_data((ssc_number_t)annual));

--- a/ssc/cmod_windpower.h
+++ b/ssc/cmod_windpower.h
@@ -62,6 +62,8 @@ public:
 	bool read_line(std::vector<double> &values) override;
 
 	std::string get_stdErrorMsg(){ return stdErrorMsg; };
+
+    void rewind() override { irecord = 0; }
 };
 
 class cm_windpower : public compute_module

--- a/test/input_cases/custom_generation_common_data.h
+++ b/test/input_cases/custom_generation_common_data.h
@@ -74,8 +74,8 @@ void custom_generation_singleowner_battery_60min(ssc_data_t &data)
 	set_array( data, "energy_output_array", customgenerationtest::gen_path_60min, 8760);
 	ssc_data_set_number( data, "system_use_lifetime_output", 0 );
 	ssc_data_set_number( data, "analysis_period", 25 );
-	ssc_number_t p_generic_degradation[1] ={ 0 };
-	ssc_data_set_array( data, "generic_degradation", p_generic_degradation, 1 );
+	ssc_number_t p_ac_degradation[1] ={ 0 };
+	ssc_data_set_array( data, "ac_degradation", p_ac_degradation, 1 );
 
     ssc_data_set_number(data, "adjust_constant", 0.0);
 
@@ -444,8 +444,8 @@ void custom_generation_commerical_battery_60min(ssc_data_t &data)
 	ssc_data_set_number(data, "system_use_lifetime_output", 0);
     ssc_data_set_number(data, "analysis_period", 2);
 
-	ssc_number_t p_generic_degradation[1] = { 0 };
-	ssc_data_set_array(data, "generic_degradation", p_generic_degradation, 1);
+	ssc_number_t p_ac_degradation[1] = { 0 };
+	ssc_data_set_array(data, "ac_degradation", p_ac_degradation, 1);
 
     ssc_data_set_number(data, "adjust_constant", 0.0);
 

--- a/test/ssc_test/cmod_windpower_test.cpp
+++ b/test/ssc_test/cmod_windpower_test.cpp
@@ -314,6 +314,62 @@ TEST_F(CMWindPowerIntegration, UsingDataArray_cmod_windpower) {
     free_winddata_array(windresourcedata);
 }
 
+// Run the data array in lifetime mode
+TEST_F(CMWindPowerIntegration, UsingDataArray_cmod_windpower_lifetime) {
+    // using hourly data
+    ssc_data_unassign(data, "wind_resource_filename");
+    var_table* vt = static_cast<var_table*>(data);
+    auto windresourcedata = create_winddata_array(1, 1);
+    ssc_data_set_table(data, "wind_resource_data", windresourcedata);
+    ssc_data_set_number(data, "system_use_lifetime_output", 1);
+    ssc_data_set_number(data, "analysis_period", 2);
+    ssc_number_t degradation[1] = { 0 };
+    ssc_data_set_array(data, "generic_degradation", degradation, 1);
+
+    compute();
+    double expectedAnnualEnergy = 4219481;
+    double relErr = expectedAnnualEnergy * .001;
+
+
+    ssc_number_t annual_energy;
+    ssc_data_get_number(data, "annual_energy", &annual_energy);
+    EXPECT_NEAR(annual_energy, expectedAnnualEnergy, relErr);
+
+    ssc_number_t monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[0];
+    EXPECT_NEAR(monthly_energy, 0, relErr / 10.);
+
+    monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[11];
+    EXPECT_NEAR(monthly_energy, 1972735, relErr / 10.);
+
+    int gen_length = 0;
+    ssc_data_get_array(data, "gen", &gen_length);
+    EXPECT_EQ(gen_length, 8760 * 2);
+
+    free_winddata_array(windresourcedata);
+
+    // 15 min data
+    ssc_data_unassign(data, "wind_resource_data");
+    windresourcedata = create_winddata_array(4, 1);
+    vt->assign("wind_resource_data", *windresourcedata);
+
+    compute();
+
+    ssc_data_get_number(data, "annual_energy", &annual_energy);
+    EXPECT_NEAR(annual_energy, expectedAnnualEnergy, relErr);
+
+    monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[0];
+    EXPECT_NEAR(monthly_energy, 0, relErr / 10.);
+
+    monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[11];
+    EXPECT_NEAR(monthly_energy, 1972735, relErr / 10.);
+
+    gen_length = 0;
+    ssc_data_get_array(data, "gen", &gen_length);
+    EXPECT_EQ(gen_length, 8760 * 4 * 2);
+
+    free_winddata_array(windresourcedata);
+}
+
 /// Using Weibull Distribution
 TEST_F(CMWindPowerIntegration, Weibull_cmod_windpower) {
     ssc_data_set_number(data, "wind_resource_model_choice", 1);
@@ -328,6 +384,30 @@ TEST_F(CMWindPowerIntegration, Weibull_cmod_windpower) {
 
     monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[11];
     EXPECT_NEAR(monthly_energy, 15326247, e);
+}
+
+// Now in lifetime mode!
+TEST_F(CMWindPowerIntegration, Weibull_cmod_windpower_lifetime) {
+    ssc_data_set_number(data, "wind_resource_model_choice", 1);
+    ssc_data_set_number(data, "system_use_lifetime_output", 1);
+    ssc_data_set_number(data, "analysis_period", 2);
+    ssc_number_t degradation[1] = { 0 };
+    ssc_data_set_array(data, "generic_degradation", degradation, 1);
+    compute();
+
+    ssc_number_t annual_energy;
+    ssc_data_get_number(data, "annual_energy", &annual_energy);
+    EXPECT_NEAR(annual_energy, 180453760, e);
+
+    ssc_number_t monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[0];
+    EXPECT_NEAR(monthly_energy, 15326247, e);
+
+    monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[11];
+    EXPECT_NEAR(monthly_energy, 15326247, e);
+
+    int gen_length = 0;
+    ssc_data_get_array(data, "gen", &gen_length);
+    EXPECT_EQ(gen_length, 8760 * 2);
 }
 
 /// Using Wind Resource 2-D Distribution
@@ -352,6 +432,38 @@ TEST_F(CMWindPowerIntegration, WindDist_cmod_windpower) {
 
     monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[11];
     EXPECT_NEAR(monthly_energy, 13573000, e);
+}
+
+// Same as above, in lifetime mode 
+TEST_F(CMWindPowerIntegration, WindDist_cmod_windpower_lifetime) {
+    ssc_data_set_number(data, "wind_resource_model_choice", 2);
+    double dist[18] = { 1.5, 180, .12583,
+                       5, 180, .3933,
+                       8, 180, .18276,
+                       10, 180, .1341,
+                       13.5, 180, .14217,
+                       19, 180, .0211 };
+
+    ssc_data_set_matrix(data, "wind_resource_distribution", dist, 6, 3);
+    ssc_data_set_number(data, "system_use_lifetime_output", 1);
+    ssc_data_set_number(data, "analysis_period", 2);
+    ssc_number_t degradation[1] = { 0 };
+    ssc_data_set_array(data, "generic_degradation", degradation, 1);
+    compute();
+
+    ssc_number_t annual_energy;
+    ssc_data_get_number(data, "annual_energy", &annual_energy);
+    EXPECT_NEAR(annual_energy, 159807000, e);
+
+    ssc_number_t monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[0];
+    EXPECT_NEAR(monthly_energy, 13573000, e);
+
+    monthly_energy = ssc_data_get_array(data, "monthly_energy", nullptr)[11];
+    EXPECT_NEAR(monthly_energy, 13573000, e);
+
+    int gen_length = 0;
+    ssc_data_get_array(data, "gen", &gen_length);
+    EXPECT_EQ(gen_length, 8760 * 2);
 }
 
 /// Using Wind Resource 2-D Distribution

--- a/test/ssc_test/cmod_windpower_test.cpp
+++ b/test/ssc_test/cmod_windpower_test.cpp
@@ -324,7 +324,7 @@ TEST_F(CMWindPowerIntegration, UsingDataArray_cmod_windpower_lifetime) {
     ssc_data_set_number(data, "system_use_lifetime_output", 1);
     ssc_data_set_number(data, "analysis_period", 2);
     ssc_number_t degradation[1] = { 0 };
-    ssc_data_set_array(data, "generic_degradation", degradation, 1);
+    ssc_data_set_array(data, "ac_degradation", degradation, 1);
 
     compute();
     double expectedAnnualEnergy = 4219481;
@@ -392,7 +392,7 @@ TEST_F(CMWindPowerIntegration, Weibull_cmod_windpower_lifetime) {
     ssc_data_set_number(data, "system_use_lifetime_output", 1);
     ssc_data_set_number(data, "analysis_period", 2);
     ssc_number_t degradation[1] = { 0 };
-    ssc_data_set_array(data, "generic_degradation", degradation, 1);
+    ssc_data_set_array(data, "ac_degradation", degradation, 1);
     compute();
 
     ssc_number_t annual_energy;
@@ -448,7 +448,7 @@ TEST_F(CMWindPowerIntegration, WindDist_cmod_windpower_lifetime) {
     ssc_data_set_number(data, "system_use_lifetime_output", 1);
     ssc_data_set_number(data, "analysis_period", 2);
     ssc_number_t degradation[1] = { 0 };
-    ssc_data_set_array(data, "generic_degradation", degradation, 1);
+    ssc_data_set_array(data, "ac_degradation", degradation, 1);
     compute();
 
     ssc_number_t annual_energy;


### PR DESCRIPTION
## Pull Request Template

### Description

Adds lifetime mode to windpower. In addition to the obvious for loops, required updating the data provider with a rewind function. This reads in the file at the start of the simulation and references arrays, more similar to PV. AI disclosure: Claude Sonnet assisted with the rewind function.

Note that the weather file mode for wind is slower by a linear factor of analysis period length. Open to changing that prior to merging if we prefer a different approach to applying degradation. This would impact year 1 vs lifetime outputs.

Fixes https://github.com/NatLabRockies/ssc/issues/1300

### Corresponding branches and PRs:

SAM PR tbd. Develop of other repos.

### Unit Test Impact:

New wind lifetime tests. No other changes expected

### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [x] changes defaults
- [ ] I've tagged this PR to a milestone

### Reminders- this section can be deleted
[Checking for PySAM Incompatible API Changes]
(https://github.com/NREL/SAM/wiki/PySAM-Incompatible-API-Changes-&-Regenerating-PySAM-Files).

[When do the PySAM files need to be regenerated?]
(https://github.com/NREL/SAM/wiki/PySAM-Incompatible-API-Changes-&-Regenerating-PySAM-Files#when-do-the-pysam-files-need-to-be-regenerated-via-export_config)
