### PR TITLE
Multiple revenue streams

### DIFF
--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -838,8 +838,8 @@ enum {
     CF_annual_cost_lcos,
     CF_util_escal_rate,
 
-    CF_sharable_energy_revenue,
-    CF_sharable_energy_expenses,
+    CF_energy_revenue,
+    CF_energy_expenses,
     CF_energy_revenue_ret_percent,
     CF_energy_revenue_retained,
     CF_energy_expenses_paid_percent,
@@ -1752,7 +1752,7 @@ public:
                     * pow((1 + inflation_rate + recapitalization_escalation), i - 1);
             }
 
-            cf.at(CF_sharable_energy_expenses, i) =
+            cf.at(CF_energy_expenses, i) =
                 +cf.at(CF_om_fixed_expense, i)
                 + cf.at(CF_om_production_expense, i)
                 + cf.at(CF_om_capacity_expense, i)
@@ -1774,7 +1774,7 @@ public:
                 + cf.at(CF_utility_bill, i)
                 + cf.at(CF_Recapitalization, i);
 
-            cf.at(CF_energy_expenses_paid, i) = cf.at(CF_sharable_energy_expenses, i) * cf.at(CF_energy_expenses_paid_percent, i);
+            cf.at(CF_energy_expenses_paid, i) = cf.at(CF_energy_expenses, i) * cf.at(CF_energy_expenses_paid_percent, i);
             cf.at(CF_operating_expenses, i) = cf.at(CF_energy_expenses_paid, i) + cf.at(CF_non_energy_expenses_paid, i);
         }
 
@@ -2095,12 +2095,12 @@ public:
 
 //			log(util::format("year %d : energy value =%lg", i, m_disp_calcs.tod_energy_value(i)), SSC_WARNING);
 			// total revenue
-            cf.at(CF_sharable_energy_revenue, i) = cf.at(CF_energy_value, i) +
+            cf.at(CF_energy_revenue, i) = cf.at(CF_energy_value, i) +
                 cf.at(CF_thermal_value, i) +
                 cf.at(CF_curtailment_value, i) +
                 cf.at(CF_capacity_payment, i);
 
-            cf.at(CF_energy_revenue_retained, i) = cf.at(CF_sharable_energy_revenue, i) * cf.at(CF_energy_revenue_ret_percent, i);
+            cf.at(CF_energy_revenue_retained, i) = cf.at(CF_energy_revenue, i) * cf.at(CF_energy_revenue_ret_percent, i);
 				
             cf.at(CF_total_revenue, i) =
                 cf.at(CF_energy_revenue_retained, i) +
@@ -2851,10 +2851,12 @@ public:
 
 		save_cf(CF_Recapitalization, nyears, "cf_recapitalization");
 
-        save_cf(CF_sharable_energy_revenue, nyears, "cf_sharable_energy_revenue");
-        save_cf(CF_energy_revenue_retained, nyears, "cf_sharable_energy_revenue_retained");
+        save_cf(CF_energy_revenue, nyears, "cf_energy_revenue");
+        save_cf(CF_energy_revenue_ret_percent, nyears, "cf_energy_revenue_retained_percent", 100.0);
+        save_cf(CF_energy_revenue_retained, nyears, "cf_energy_revenue_retained");
         save_cf(CF_non_energy_revenue_retained, nyears, "cf_non_energy_revenue");
-        save_cf(CF_sharable_energy_expenses, nyears, "cf_total_energy_expenses");
+        save_cf(CF_energy_expenses, nyears, "cf_total_energy_expenses");
+        save_cf(CF_energy_expenses_paid_percent, nyears, "cf_energy_expenses_paid_percent", 100.0);
         save_cf(CF_energy_expenses_paid, nyears, "cf_energy_expenses_paid");
         save_cf(CF_non_energy_expenses_paid, nyears, "cf_non_energy_expenses");
 
@@ -2914,11 +2916,11 @@ public:
 	}
 
 	// std lib
-	void save_cf(int cf_line, int nyears, const std::string &name)
+	void save_cf(int cf_line, int nyears, const std::string &name, ssc_number_t scaling = 1.0)
 	{
 		ssc_number_t *arrp = allocate( name, nyears+1 );
 		for (int i=0;i<=nyears;i++)
-			arrp[i] = (ssc_number_t)cf.at(cf_line, i);
+			arrp[i] = (ssc_number_t)cf.at(cf_line, i) * scaling;
 	}
 
 	void escal_or_annual( int cf_line, int nyears, const std::string &variable,

--- a/ssc/cmod_singleowner.cpp
+++ b/ssc/cmod_singleowner.cpp
@@ -838,6 +838,17 @@ enum {
     CF_annual_cost_lcos,
     CF_util_escal_rate,
 
+    CF_sharable_energy_revenue,
+    CF_sharable_energy_expenses,
+    CF_energy_revenue_ret_percent,
+    CF_energy_revenue_retained,
+    CF_energy_expenses_paid_percent,
+    CF_energy_expenses_paid,
+    CF_non_energy_revenue,
+    CF_non_energy_revenue_retained,
+    CF_non_energy_expenses,
+    CF_non_energy_expenses_paid,
+    
 
     CF_max,
  };
@@ -877,6 +888,7 @@ public:
 		add_var_info(vtab_utility_rate_common);
         add_var_info(vtab_hybrid_fin_om);
         add_var_info(vtab_update_tech_outputs);
+        add_var_info(vtab_non_energy_cash_flow);
     }
 
 	void exec( )
@@ -1411,6 +1423,74 @@ public:
         }
         save_cf(CF_utility_bill, nyears, "cf_utility_bill");
 
+        if (is_assigned("non_energy_revenue") && is_assigned("non_energy_expenses")) {
+            // Non-energy revenues & revenue sharing
+            escal_or_annual(CF_non_energy_revenue, nyears, "non_energy_revenue", inflation_rate, 1.0, false, as_double("non_energy_revenue_escal") * 0.01);
+            escal_or_annual(CF_non_energy_expenses, nyears, "non_energy_expenses", inflation_rate, 1.0, false, as_double("non_energy_expenses_escal") * 0.01);
+
+            ssc_number_t* ne_rev_ret = as_array("non_energy_revenue_ret", &count); // Percent of non-energy revenue retained by project
+
+            if (count == 1)
+            {
+                for (int i = 0; i < nyears; i++)
+                    cf.at(CF_non_energy_revenue_retained, i + 1) = cf.at(CF_non_energy_revenue, i + 1) * ne_rev_ret[0] / 100.0;
+            }
+            else
+            {
+                for (int i = 0; i < nyears && i < (int)count; i++)
+                    cf.at(CF_non_energy_revenue_retained, i + 1) = cf.at(CF_non_energy_revenue, i + 1) * ne_rev_ret[i] / 100.0;
+            }
+
+            ssc_number_t* ne_exp_ret = as_array("non_energy_expenses_ret", &count); // Percent of non-energy expenses paid by project
+
+            if (count == 1)
+            {
+                for (int i = 0; i < nyears; i++)
+                    cf.at(CF_non_energy_expenses_paid, i + 1) = cf.at(CF_non_energy_expenses, i + 1) * ne_exp_ret[0] / 100.0;
+            }
+            else
+            {
+                for (int i = 0; i < nyears && i < (int)count; i++)
+                    cf.at(CF_non_energy_expenses_paid, i + 1) = cf.at(CF_non_energy_expenses, i + 1) * ne_exp_ret[i] / 100.0;
+            }
+        }
+        // No need for an else here - these are autofilled as zeroes.
+
+        if (is_assigned("energy_revenue_ret")) {
+            ssc_number_t* energy_rev_ret = 0;
+            energy_rev_ret = as_array("energy_revenue_ret", &count);
+
+            if (count == 1)
+            {
+                for (i = 1; i <= nyears; i++) cf.at(CF_energy_revenue_ret_percent, i) = energy_rev_ret[0] / 100.0;
+            }
+            else if (count > 0)
+            {
+                for (i = 0; i < nyears && i < (int)count; i++) cf.at(CF_energy_revenue_ret_percent, i + 1) = energy_rev_ret[i] / 100.0;
+            }
+        }
+        else {
+            for (i = 1; i <= nyears; i++) cf.at(CF_energy_revenue_ret_percent, i) = 1.0;
+        }
+
+        if (is_assigned("energy_expenses_ret")) {
+            ssc_number_t* energy_exp_ret = 0;
+            energy_exp_ret = as_array("energy_expenses_ret", &count);
+
+            if (count == 1)
+            {
+                for (i = 1; i <= nyears; i++) cf.at(CF_energy_expenses_paid_percent, i) = energy_exp_ret[0] / 100.0;
+            }
+            else if (count > 0)
+            {
+                for (i = 0; i < nyears && i < (int)count; i++) cf.at(CF_energy_expenses_paid_percent, i + 1) = energy_exp_ret[i] / 100.0;
+            }
+        }
+        else {
+            for (i = 1; i <= nyears; i++) cf.at(CF_energy_expenses_paid_percent, i) = 1.0;
+        }
+
+
 		double property_tax_assessed_value = cost_prefinancing * as_double("prop_tax_cost_assessed_percent") * 0.01;
 		double property_tax_decline_percentage = as_double("prop_tax_assessed_decline");
 		double property_tax_rate = as_double("property_tax_rate")*0.01;
@@ -1672,7 +1752,7 @@ public:
                     * pow((1 + inflation_rate + recapitalization_escalation), i - 1);
             }
 
-            cf.at(CF_operating_expenses, i) =
+            cf.at(CF_sharable_energy_expenses, i) =
                 +cf.at(CF_om_fixed_expense, i)
                 + cf.at(CF_om_production_expense, i)
                 + cf.at(CF_om_capacity_expense, i)
@@ -1693,6 +1773,9 @@ public:
                 + cf.at(CF_om_hybrid_sum, i)
                 + cf.at(CF_utility_bill, i)
                 + cf.at(CF_Recapitalization, i);
+
+            cf.at(CF_energy_expenses_paid, i) = cf.at(CF_sharable_energy_expenses, i) * cf.at(CF_energy_expenses_paid_percent, i);
+            cf.at(CF_operating_expenses, i) = cf.at(CF_energy_expenses_paid, i) + cf.at(CF_non_energy_expenses_paid, i);
         }
 
         // salvage value
@@ -2012,15 +2095,21 @@ public:
 
 //			log(util::format("year %d : energy value =%lg", i, m_disp_calcs.tod_energy_value(i)), SSC_WARNING);
 			// total revenue
-			cf.at(CF_total_revenue,i) = cf.at(CF_energy_value,i) +
-				cf.at(CF_thermal_value,i) +
-				cf.at(CF_curtailment_value, i) +
-				cf.at(CF_capacity_payment, i) +
-				pbi_fed_for_ds_frac * cf.at(CF_pbi_fed,i) +
-				pbi_sta_for_ds_frac * cf.at(CF_pbi_sta,i) +
-				pbi_uti_for_ds_frac * cf.at(CF_pbi_uti,i) +
-				pbi_oth_for_ds_frac * cf.at(CF_pbi_oth,i) +
-				cf.at(CF_net_salvage_value,i);
+            cf.at(CF_sharable_energy_revenue, i) = cf.at(CF_energy_value, i) +
+                cf.at(CF_thermal_value, i) +
+                cf.at(CF_curtailment_value, i) +
+                cf.at(CF_capacity_payment, i);
+
+            cf.at(CF_energy_revenue_retained, i) = cf.at(CF_sharable_energy_revenue, i) * cf.at(CF_energy_revenue_ret_percent, i);
+				
+            cf.at(CF_total_revenue, i) =
+                cf.at(CF_energy_revenue_retained, i) +
+                cf.at(CF_non_energy_revenue_retained, i) +
+                pbi_fed_for_ds_frac * cf.at(CF_pbi_fed, i) +
+                pbi_sta_for_ds_frac * cf.at(CF_pbi_sta, i) +
+                pbi_uti_for_ds_frac * cf.at(CF_pbi_uti, i) +
+                pbi_oth_for_ds_frac * cf.at(CF_pbi_oth, i) +
+                cf.at(CF_net_salvage_value, i);
 
 			cf.at(CF_ebitda,i) = cf.at(CF_total_revenue,i) - cf.at(CF_operating_expenses,i);
 
@@ -2761,6 +2850,14 @@ public:
 		save_cf( CF_reserve_interest, nyears, "cf_reserve_interest" );
 
 		save_cf(CF_Recapitalization, nyears, "cf_recapitalization");
+
+        save_cf(CF_sharable_energy_revenue, nyears, "cf_sharable_energy_revenue");
+        save_cf(CF_energy_revenue_retained, nyears, "cf_sharable_energy_revenue_retained");
+        save_cf(CF_non_energy_revenue_retained, nyears, "cf_non_energy_revenue");
+        save_cf(CF_sharable_energy_expenses, nyears, "cf_total_energy_expenses");
+        save_cf(CF_energy_expenses_paid, nyears, "cf_energy_expenses_paid");
+        save_cf(CF_non_energy_expenses_paid, nyears, "cf_non_energy_expenses");
+
 
 
 		// dispatch

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -2254,3 +2254,22 @@ void prepend_to_output(compute_module* cm, std::string var_name, size_t count, s
         }
     }
 }
+
+var_info vtab_non_energy_cash_flow[] = {
+{ SSC_INPUT,        SSC_ARRAY,		"non_energy_revenue",                     "Gross non-energy revenue",                    "$",             "", "Non-energy Revenue",       "",      "",            "" },
+{ SSC_INPUT,        SSC_NUMBER,     "non_energy_revenue_escal",                 "Non-energy revenue escalation",               "%",                 "", "Non-energy Revenue",   "?=0",   "", "" },
+{ SSC_INPUT,        SSC_ARRAY,      "non_energy_revenue_ret",                 "Non-energy revenue retained by energy owner", "%",        "", "Non-energy Revenue",         "",         "", "" },
+{ SSC_INPUT,        SSC_ARRAY,		"non_energy_expenses",                    "Gross non-energy expenses",                   "$",        "", "Non-energy Revenue",         "",         "",            "" },
+{ SSC_INPUT,        SSC_NUMBER,		"non_energy_expenses_escal",                "Non-energy expenses escalation",              "%",        "", "Non-energy Revenue",         "?=0",     "",            "" },
+{ SSC_INPUT,        SSC_ARRAY,      "non_energy_expenses_ret",	              "Non-energy expenses paid by energy owner",	 "%",	        "",	"Non-energy Revenue",	   "",         "",      			"" },
+{ SSC_INPUT,        SSC_ARRAY,      "energy_revenue_ret",		              "Energy revenue retained by energy owner",	 "%",	        "",	"Non-energy Revenue",	   "",         "",      			"" },
+{ SSC_INPUT,        SSC_ARRAY,      "energy_expenses_ret",   	              "Energy expenses paid by energy owner",		 "%",	        "",	"Non-energy Revenue",	   "",         "",      			"" },
+
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue",             "Sharable Energy Revenue",                      "$",           "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue_retained",   "Sharable Energy Revenue Retained",                   "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_revenue",                  "Share of non-energy revenue",               "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_total_energy_expenses",               "Total Energy Expenses",                     "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_expenses_paid",                "Energy Expenses Paid",                      "$",              "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_expenses",                 "Share of non-energy expenses",              "$",                   "", "Cash Flow Non-energy", "*", "", "" },
+
+var_info_invalid };

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -2265,11 +2265,13 @@ var_info vtab_non_energy_cash_flow[] = {
 { SSC_INPUT,        SSC_ARRAY,      "energy_revenue_ret",		              "Energy revenue retained by energy owner",	 "%",	        "",	"Non-energy Revenue",	   "",         "",      			"" },
 { SSC_INPUT,        SSC_ARRAY,      "energy_expenses_ret",   	              "Energy expenses paid by energy owner",		 "%",	        "",	"Non-energy Revenue",	   "",         "",      			"" },
 
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue",             "Sharable Energy Revenue",                      "$",           "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue_retained",   "Sharable Energy Revenue Retained",                   "$",               "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_revenue",                  "Share of non-energy revenue",               "$",               "", "Cash Flow Non-energy", "*", "", "" },
+
+// shareable (or maybe just Energy and non energy revenue?)
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue",             "Energy Revenue",                      "$",           "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue_retained",    "Energy Revenue Retained",                   "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_revenue",                  "Owner share of non-energy revenue",               "$",               "", "Cash Flow Non-energy", "*", "", "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_total_energy_expenses",               "Total Energy Expenses",                     "$",               "", "Cash Flow Non-energy", "*", "", "" },
 { SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_expenses_paid",                "Energy Expenses Paid",                      "$",              "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_expenses",                 "Share of non-energy expenses",              "$",                   "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_expenses",                 "Owner share of non-energy expenses",              "$",                   "", "Cash Flow Non-energy", "*", "", "" },
 
 var_info_invalid };

--- a/ssc/common.cpp
+++ b/ssc/common.cpp
@@ -2266,11 +2266,13 @@ var_info vtab_non_energy_cash_flow[] = {
 
 
 // shareable (or maybe just Energy and non energy revenue?)
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue",             "Energy Revenue",                      "$",           "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_sharable_energy_revenue_retained",    "Energy Revenue Retained",                   "$",               "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_revenue",                  "Owner share of non-energy revenue",               "$",               "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_total_energy_expenses",               "Total Energy Expenses",                     "$",               "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_expenses_paid",                "Energy Expenses Paid",                      "$",              "", "Cash Flow Non-energy", "*", "", "" },
-{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_expenses",                 "Owner share of non-energy expenses",              "$",                   "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_revenue",             "Energy revenue",                      "$",           "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_revenue_retained_percent",    "Percent of energy revenue retained",                   "%",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_revenue_retained",    "Energy revenue retained",                   "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_revenue",         "Owner share of non-energy revenue",               "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_total_energy_expenses",      "Total energy expenses",                     "$",               "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_expenses_paid_percent",       "Percent of energy expenses paid",                      "%",              "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_energy_expenses_paid",       "Energy expenses paid",                      "$",              "", "Cash Flow Non-energy", "*", "", "" },
+{ SSC_OUTPUT,       SSC_ARRAY,      "cf_non_energy_expenses",        "Owner share of non-energy expenses",              "$",                   "", "Cash Flow Non-energy", "*", "", "" },
 
 var_info_invalid };

--- a/ssc/common.h
+++ b/ssc/common.h
@@ -76,6 +76,8 @@ extern var_info vtab_hybrid_tech_inputs[];
 extern var_info vtab_hybrid_tech_om_outputs[];
 extern var_info vtab_hybrid_fin_om[];
 
+extern var_info vtab_non_energy_cash_flow[];
+
 bool calculate_p50p90(compute_module *cm);
 
 void calculate_resilience_outputs(compute_module *cm, std::unique_ptr<resilience_runner> &resilience);

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -279,4 +279,88 @@ TEST_F(CmodSingleOwnerTest, NonEnergyRevenueFixedDebt) {
     for(size_t i = 0; i < default_ebitda.size(); i++) {
         EXPECT_NEAR(pEbitdaArray[i], default_ebitda[i], 0.1) << " ebitda issue at index i=" << i;
     }
+
+    // Test 50% revenue retained
+    std::vector<double> post_share_revenue;
+    std::vector<double> post_share_costs;
+    std::vector<double> post_share_ebitda;
+
+    for (size_t i = 0; i < default_revenue.size(); i++) {
+        post_share_revenue.push_back(pRevArray[i] * 0.5);
+        post_share_costs.push_back(pCostArray[i] * 0.5);
+        post_share_ebitda.push_back(post_share_revenue[i] - post_share_costs[i]);
+    }
+
+    std::vector<double> shared_energy_revenue = { 50 };
+    std::vector<double> shared_energy_expenses = { 50 };
+
+    ssc_data_set_array(dat_inputs, "energy_revenue_ret", shared_energy_revenue.data(), (int)shared_energy_revenue.size());
+    ssc_data_set_array(dat_inputs, "energy_expenses_ret", shared_energy_expenses.data(), (int)shared_energy_expenses.size());
+
+    errors = run_module(dat_inputs, "singleowner");
+    EXPECT_FALSE(errors);
+
+    // Expect 50% reductions in values
+    pRevArray = ssc_data_get_array(dat_inputs, "cf_total_revenue", &arr_length);
+    for (size_t i = 0; i < post_share_revenue.size(); i++) {
+        EXPECT_NEAR(pRevArray[i], post_share_revenue[i], 0.1) << " revenue issue at index i=" << i;
+    }
+
+    pCostArray = ssc_data_get_array(dat_inputs, "cf_operating_expenses", &arr_length);
+    for (size_t i = 0; i < post_share_costs.size(); i++) {
+        EXPECT_NEAR(pCostArray[i], post_share_costs[i], 0.1) << " cost issue at index i=" << i;
+    }
+
+    pEbitdaArray = ssc_data_get_array(dat_inputs, "cf_ebitda", &arr_length);
+    for (size_t i = 0; i < post_share_ebitda.size(); i++) {
+        EXPECT_NEAR(pEbitdaArray[i], post_share_ebitda[i], 0.1) << " ebitda issue at index i=" << i;
+    }
+
+
+    // Test 50% revenue retained but with non-energy revenue added
+    post_share_revenue.clear();
+    post_share_costs.clear();
+    post_share_ebitda.clear();
+
+    post_share_revenue.push_back(0.0);
+    post_share_costs.push_back(0.0);
+    post_share_ebitda.push_back(0.0);
+    for (size_t i = 1; i < default_revenue.size(); i++) {
+        post_share_revenue.push_back(default_revenue[i] * 0.5 + 100000);
+        post_share_costs.push_back(default_costs[i] * 0.5 + 50000);
+        post_share_ebitda.push_back(post_share_revenue[i] - post_share_costs[i]);
+    }
+
+    std::vector<double> non_energy_revenue(25, 100000);
+    std::vector<double> non_energy_expenses(25, 50000);
+    std::vector<double> non_energy_revenue_ret = { 100 };
+    std::vector<double> non_energy_expenses_ret = { 100 };
+
+    ssc_data_set_array(dat_inputs, "non_energy_revenue", non_energy_revenue.data(), (int)non_energy_revenue.size());
+    ssc_data_set_array(dat_inputs, "non_energy_expenses", non_energy_expenses.data(), (int)non_energy_expenses.size());
+    ssc_data_set_array(dat_inputs, "non_energy_revenue_ret", non_energy_revenue_ret.data(), (int)non_energy_revenue_ret.size());
+    ssc_data_set_array(dat_inputs, "non_energy_expenses_ret", non_energy_expenses_ret.data(), (int)non_energy_expenses_ret.size());
+
+    ssc_data_set_number(dat_inputs, "non_energy_revenue_escal", -2.5);
+    ssc_data_set_number(dat_inputs, "non_energy_expenses_escal", -2.5);
+
+    errors = run_module(dat_inputs, "singleowner");
+    EXPECT_FALSE(errors);
+
+    // Expect 50% reductions in values
+    pRevArray = ssc_data_get_array(dat_inputs, "cf_total_revenue", &arr_length);
+    for (size_t i = 0; i < post_share_revenue.size(); i++) {
+        EXPECT_NEAR(pRevArray[i], post_share_revenue[i], 0.1) << " revenue issue at index i=" << i;
+    }
+
+    pCostArray = ssc_data_get_array(dat_inputs, "cf_operating_expenses", &arr_length);
+    for (size_t i = 0; i < post_share_costs.size(); i++) {
+        EXPECT_NEAR(pCostArray[i], post_share_costs[i], 0.1) << " cost issue at index i=" << i;
+    }
+
+    pEbitdaArray = ssc_data_get_array(dat_inputs, "cf_ebitda", &arr_length);
+    for (size_t i = 0; i < post_share_ebitda.size(); i++) {
+        EXPECT_NEAR(pEbitdaArray[i], post_share_ebitda[i], 0.1) << " ebitda issue at index i=" << i;
+    }
+
 }

--- a/test/ssc_test/cmod_singleowner_test.cpp
+++ b/test/ssc_test/cmod_singleowner_test.cpp
@@ -243,3 +243,40 @@ TEST_F(CmodSingleOwnerTest, IBICBI) {
 
     Test("singleowner", file_inputs, file_outputs, compare_number_variables, compare_array_variables);
 }
+
+TEST_F(CmodSingleOwnerTest, NonEnergyRevenueFixedDebt) {
+    std::string file_inputs = SSCDIR;
+    file_inputs += "/test/input_json/FinancialModels/singleowner/so-fixed-debt-fixed-price_PVWatts_Single_Owner_cmod_singleowner.json";
+
+    std::ifstream file(file_inputs);
+    std::ostringstream tmp;
+    tmp << file.rdbuf();
+    file.close();
+    ssc_data_t dat_inputs = json_to_ssc_data(tmp.str().c_str());
+
+    tmp.str("");
+    int errors = run_module(dat_inputs, "singleowner");
+
+    EXPECT_FALSE(errors);
+
+    std::vector<double> default_revenue = { 0, 8478885.956083823, 8521031.0160498116, 8563109.5073487349, 8605113.4751514699, 8647064.8985940199, 8688959.7209229749, 8730788.5669338983, 8772523.4115527496, 8814185.7912173141, 8855769.8138282895, 8897248.7138918284, 8938630.7883684468, 8979896.6277180221, 9021075.6455845423, 9062180.3135051988, 9103205.0441374388, 9144144.1064228881, 9184991.6294496525, 9225741.688526297, 9266388.2748306263, 9306925.3121825177, 9347346.5308990683, 9387645.4814586416, 9427815.7014087141, 9467850.651133962 };
+    std::vector<double> default_costs = { 0, 1900000, 1947499.9999999998, 1996187.5, 2046092.1874999993, 2097244.4921874991, 2149675.6044921861, 2203417.4946044912, 2258502.9319696035, 2314965.5052688429, 2372839.6429005638, 2432160.6339730779, 2492964.6498224046, 2555288.7660679645, 2619170.985219663, 2684650.2598501546, 2751766.5163464085, 2820560.6792550683, 2891074.6962364446, 2963351.5636423551, 3037435.3527334142, 3113371.2365517491, 3191205.517465543, 3270985.6554021812, 3352760.2967872354, 3436579.3042069157 };
+    std::vector<double> default_ebitda = { 0, 6578885.956083823, 6573531.0160498116, 6566922.0073487349, 6559021.2876514709, 6549820.4064065209, 6539284.1164307892, 6527371.0723294076, 6514020.4795831461, 6499220.2859484712, 6482930.1709277257, 6465088.0799187506, 6445666.1385460421, 6424607.8616500571, 6401904.6603648793, 6377530.0536550442, 6351438.5277910307, 6323583.4271678198, 6293916.9332132079, 6262390.1248839423, 6228952.9220972117, 6193554.0756307691, 6156141.0134335253, 6116659.8260564599, 6075055.4046214782, 6031271.3469270468 };
+
+    // Confirm arrays match default run with 0 non-energy revenue.
+    int arr_length;
+    auto pRevArray = ssc_data_get_array(dat_inputs, "cf_total_revenue", &arr_length);
+    for (size_t i = 0; i < default_revenue.size(); i++) {
+        EXPECT_NEAR(pRevArray[i], default_revenue[i], 0.1) << " revenue issue at index i=" << i;
+    }
+
+    auto pCostArray = ssc_data_get_array(dat_inputs, "cf_operating_expenses", &arr_length);
+    for(size_t i = 0; i < default_costs.size(); i++) {
+        EXPECT_NEAR(pCostArray[i], default_costs[i], 0.1) << " cost issue at index i=" << i;
+    }
+
+    auto pEbitdaArray = ssc_data_get_array(dat_inputs, "cf_ebitda", &arr_length);
+    for(size_t i = 0; i < default_ebitda.size(); i++) {
+        EXPECT_NEAR(pEbitdaArray[i], default_ebitda[i], 0.1) << " ebitda issue at index i=" << i;
+    }
+}


### PR DESCRIPTION
## Pull Request Template

### Description

Add non-energy revenue streams and energy revenue retention variables to single owner.

This makes some progress towards https://github.com/NatLabRockies/sam/issues/1601, but we would need to copy this code to community solar to close that issue.

### Corresponding branches and PRs:

multiple_revenue_streams on SAM https://github.com/NatLabRockies/SAM/pull/2190 and develop on other branches.


### Unit Test Impact:

New tests for these inputs. No changes expected to existing tests.

### Checklist
- [x] requires help revision and I added that label
- [x] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [x] changes defaults
- [x] I've tagged this PR to a milestone
