### PR TITLE
Remove parasitics from system target

### DIFF
--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -1647,7 +1647,7 @@ void C_csp_solver::calc_timestep_plant_control_and_targets(
             // and use system-level q_dot_pc_max
             // (although dispatch estimate should have a decent q_dot_pc estimate that includes parasitic estimates)
             if( W_dot_system_target > 0.0 ) {
-                double W_dot_pc_gross_est = (W_dot_system_target - W_dot_rec_par_est - m_W_dot_fixed_design) /
+                double W_dot_pc_gross_est = (W_dot_system_target + W_dot_rec_par_est + m_W_dot_fixed_design) /
                     (1.0 - m_ratio_cycle_dep_par_design);
                 q_dot_pc_target = std::min(W_dot_pc_gross_est / pc_eta_est, q_dot_pc_max);
                 q_dot_elec_to_PAR_HTR = 0.0;

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -1629,8 +1629,8 @@ void C_csp_solver::calc_timestep_plant_control_and_targets(
         double q_dot_elec_to_PAR_HTR_disp = mc_dispatch.dispatch_outputs.q_eh_target;
 
         // Add fixed parasitics to the system target and max
-        double W_dot_system_target_disp = mc_dispatch.dispatch_outputs.w_dot_target - m_W_dot_fixed_design;
-        double W_dot_system_max_disp = (mc_dispatch.dispatch_outputs.w_dot_target - m_W_dot_fixed_design) * 1.2;  // Not used?
+        double W_dot_system_target_disp = mc_dispatch.dispatch_outputs.w_dot_target;
+        double W_dot_system_max_disp = mc_dispatch.dispatch_outputs.w_dot_target * 1.2;  // Not used?
         
         q_dot_pc_max = m_cycle_max_frac * m_cycle_q_dot_des;		        //[MWt]
         


### PR DESCRIPTION
Fixed parasitic power was double accounted. Once in dispatch model and once after the target net power is set (by the dispatch). This removes the latter.
