### PR TITLE
docs: updating old hyperlinks from using NREL to NatLabRockies in docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to SSC
-The SAM team welcomes your contribution to the project! 
+The SAM team welcomes your contribution to the project!
 
-You can contribute to SSC by letting us know about problems or suggesting new features, or by making your own changes or additions to the code. You may want to report or help us fix an [issue someone else reported](https://github.com/NREL/SSC/issues), fix an issue you discovered, or add a new feature to SAM. If you have a question about using SAM, you can ask us on the [SAM support forum](https://sam.nrel.gov/support).
+You can contribute to SSC by letting us know about problems or suggesting new features, or by making your own changes or additions to the code. You may want to report or help us fix an [issue someone else reported](https://github.com/NatLabRockies/SSC/issues), fix an issue you discovered, or add a new feature to SAM. If you have a question about using SAM, you can ask us on the [SAM support forum](https://sam.nrel.gov/support).
 
-Please see our wiki page for our contribution policy: [https://github.com/NREL/SAM/wiki/Contribution-Policy](https://github.com/NREL/SAM/wiki/Contribution-Policy).
+Please see our wiki page for our [contribution policy](https://github.com/NatLabRockies/SAM/wiki/Contribution-Policy).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SSC (SAM Simulation Core)
-![Build](https://github.com/NREL/ssc/actions/workflows/ci.yml/badge.svg)[![Coverage Status](https://coveralls.io/repos/github/NREL/ssc/badge.svg)](https://coveralls.io/github/NREL/ssc?branch=patch)
+![Build](https://github.com/NatLabRockies/ssc/actions/workflows/ci.yml/badge.svg)[![Coverage Status](https://coveralls.io/repos/github/NatLabRockies/ssc/badge.svg)](https://coveralls.io/github/NatLabRockies/ssc?branch=patch)
 
 The SSC Open Source Project repository contains the source code for the technology and financial models contained within the National Laboratory of the Rockies' System Advisor Model™ (SAM™). For more details about SAM's capabilities, see the SAM website at [https://sam.nrel.gov/](https://sam.nrel.gov).
 
@@ -13,7 +13,7 @@ SSC requires building four other open-source projects:
 - [WEX](https://github.com/nrel/wex)
 - [jsoncpp](https://github.com/open-source-parsers/jsoncpp)
 
-However, if you remove SDKtool and TCSconsole from your SSC project, you can build SSC without any other software dependencies. Please see the main [SAM project wiki](https://github.com/NREL/SAM/wiki) for complete build instructions and software dependencies.
+However, if you remove SDKtool and TCSconsole from your SSC project, you can build SSC without any other software dependencies. Please see the main [SAM project wiki](https://github.com/NatLabRockies/SAM/wiki) for complete build instructions and software dependencies.
 
 SSC directly includes source code from three other open-source projects, and builds them as part of its build process.  These projects and their respective licenses are:
 - [NLopt](https://nlopt.readthedocs.io/en/latest/) - code located [here](https://github.com/NREL/ssc/tree/develop/nlopt), [LGPL license](https://nlopt.readthedocs.io/en/latest/NLopt_License_and_Copyright/)
@@ -25,7 +25,7 @@ To explore the code and understand the algorithms used in SSC, start by looking 
 
 # Contributing
 
-Please see the contribution guidelines in the main [SAM project readme](https://github.com/NREL/SAM/blob/develop/README.md).
+Please see the contribution guidelines in the main [SAM project readme](https://github.com/NatLabRockies/SAM/blob/develop/README.md).
 
 # License
 


### PR DESCRIPTION
## Pull Request Template

### Description

Docs like `README.md` and `CONTRIBUTING.md` have hyperlinks using the previous GitHub org name of NREL. This PR is updating relevant links to use NatLabRockies. 

While I confirmed that links using NREL still work, I believe this change to use current org name formalizes expectations for writing and maintaining documentation.

Fixes # (issue(s))
N/A. No open issues with this title or description.

### Corresponding branches and PRs:

[ which branches of wex, lk, and ssc should be built with this PR ]
Development.

[ link any corresponding PRs in other repos, i.e. NREL/ssc#x ]
N/A.

### Unit Test Impact:
N/A.


### Checklist
- [ ] requires help revision and I added that label
- [ ] adds, removes, modifies, or deletes variables in existing compute modules
- [ ] adds a new compute module
- [ ] changes defaults
- [ ] I've tagged this PR to a milestone

N/A (?) this is just a docs maintenance PR.
