### PR TITLE
Update Windows runner version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
             ${{env.SSCDIR}}/build/ssc/ssc.dylib 
 
   build-on-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fix windows build failure from windows-latest moving to VS 2026: https://github.com/NatLabRockies/SAM/pull/2213