### PR TITLE
Remove refs to gtest since we no longer need to pin to that version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,6 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
-  GTEST_REF: b85864c64758dec007208e56af933fc3f52044ee
   ORTOOLS_VER: "9.14"
 
 jobs:
@@ -88,7 +87,6 @@ jobs:
       with:
         repository: google/googletest
         path: googletest
-        ref: ${{env.GTEST_REF}}
     
     - name: build Gtest
       if: steps.cachedgtest.outputs.cache-hit != 'true'


### PR DESCRIPTION
Remove the pinned version of gtest to match coveralls to the main test script.